### PR TITLE
feat(motion): scaffold workbench_motion ROS 2 package (phase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,6 @@ docs/superpowers/
 # schedule or the org chart.
 docs/product/
 
-# Motion internal planning —施工图，不进仓库
-robot/control/PLAN.md
-
 # Local run artifacts
 data/raw/
 data/processed/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ docs/superpowers/
 # schedule or the org chart.
 docs/product/
 
+# Motion internal planning —施工图，不进仓库
+robot/control/PLAN.md
+
 # Local run artifacts
 data/raw/
 data/processed/

--- a/docs/task_packets/motion-000-phase0-scaffold.json
+++ b/docs/task_packets/motion-000-phase0-scaffold.json
@@ -1,0 +1,42 @@
+{
+  "issue": 0,
+  "human_owner": "cyathea152-bit",
+  "objective": "Motion phase 0: scaffold the workbench_motion ROS 2 package (package.xml/setup, source dir, config/, launch/, test/), uv environment, unified logging_setup, and the evidence.py EvidenceSink interface + FakeEvidenceSink. No arm, no MoveIt, no grasp logic yet.",
+  "allowed_paths": [
+    "robot/control/**"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "docs/architecture/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "services/**",
+    "robot/description/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "colcon build --packages-select workbench_motion passes and ros2 pkg list shows the package",
+    "minimal node logs with unified format carrying run_id and uses no print",
+    "EvidenceSink interface defined with FakeEvidenceSink; unit test proves append() returns a stable unique reference and Motion holds no persistence impl",
+    "minimal launch brings up an empty-world self test without external bringup"
+  ],
+  "commands": [
+    "uv sync",
+    "colcon build --packages-select workbench_motion",
+    "uv run pytest robot/control",
+    "make task-check PACKET=docs/task_packets/motion-000-phase0-scaffold.json"
+  ],
+  "evidence": [
+    "colcon build output",
+    "ros2 pkg list output showing workbench_motion",
+    "unit test output for FakeEvidenceSink stable-reference behavior"
+  ],
+  "stop_conditions": [
+    "root-level uv.lock decision not yet approved by Linux/Integration Owner",
+    "production EvidenceSink adapter ownership (World Model side) unresolved",
+    "ROS Jazzy apt rclpy not visible inside the uv venv",
+    "any change would require touching a forbidden path or interfaces/"
+  ]
+}

--- a/docs/task_packets/motion-000-phase0-scaffold.json
+++ b/docs/task_packets/motion-000-phase0-scaffold.json
@@ -1,9 +1,10 @@
 {
-  "issue": 0,
+  "issue": 3,
   "human_owner": "cyathea152-bit",
-  "objective": "Motion phase 0: scaffold the workbench_motion ROS 2 package (package.xml/setup, source dir, config/, launch/, test/), uv environment, unified logging_setup, and the evidence.py EvidenceSink interface + FakeEvidenceSink. No arm, no MoveIt, no grasp logic yet.",
+  "objective": "Motion phase 0: scaffold the workbench_motion ROS 2 package (package.xml/setup, source dir, launch/, test/), uv environment, unified logging_setup, and the evidence.py EvidenceSink interface + FakeEvidenceSink. No arm, no MoveIt, no grasp logic yet.",
   "allowed_paths": [
-    "robot/control/**"
+    "robot/control/**",
+    "docs/task_packets/motion-000-phase0-scaffold.json"
   ],
   "read_only_paths": [
     "interfaces/**",

--- a/robot/control/.gitignore
+++ b/robot/control/.gitignore
@@ -1,0 +1,7 @@
+# colcon / ament build artifacts (also covered globally, kept here for clarity)
+build/
+install/
+log/
+.venv/
+# uv.lock IS committed: package-local lock for reproducibility. Only a
+# root-level uv.lock needs Linux/Integration sign-off (PLAN.md stop condition).

--- a/robot/control/.gitignore
+++ b/robot/control/.gitignore
@@ -5,3 +5,10 @@ log/
 .venv/
 # uv.lock IS committed: package-local lock for reproducibility. Only a
 # root-level uv.lock needs Linux/Integration sign-off (PLAN.md stop condition).
+
+# Motion internal planning — kept local, not in public repo.
+PLAN.md
+
+# Local private planning notes — do not commit.
+05-机械臂资产.md
+06-抓取与恢复.md

--- a/robot/control/README.md
+++ b/robot/control/README.md
@@ -1,3 +1,73 @@
 # Robot control (Owner: Motion)
 
-Implement semantic action adapters and ActionResult production here. This module receives validated actions; it must reject raw joint commands from Agent Runtime.
+Implement semantic action adapters and ActionResult production here. This module
+receives validated actions; it must reject raw joint commands from Agent Runtime.
+
+Detailed construction plan and acceptance gates: `PLAN.md` (kept local, not in
+the public repo).
+
+## Package: `workbench_motion`
+
+ROS 2 (Jazzy) `ament_python` package. Phase 0 delivers the engineering scaffold
+only — no arm, no MoveIt, no grasp logic yet:
+
+```
+workbench_motion/
+  package.xml            # ament_python; ROS runtime deps (rclpy, launch, ...) via rosdep
+  setup.py / setup.cfg   # colcon entry point: scaffold_node
+  resource/…             # ament index marker
+  workbench_motion/
+    logging_setup.py     # unified stdlib logging: run_id/action_id, no print
+    evidence.py          # ExecutionEvent + EvidenceSink interface + FakeEvidenceSink
+    scaffold_node.py     # minimal node for the empty-world self test
+  launch/scaffold.launch.py   # empty-world self test, no external bringup
+  test/                  # pytest unit tests (evidence + logging)
+```
+
+### Two toolchains, on purpose
+
+- **Pure-Python layer** (evidence, logging, contracts, tests, tooling) is managed
+  by **uv**, scoped to this module (`robot/control/pyproject.toml` + `uv.lock`).
+  Per `PLAN.md`, a root-level `uv.lock` needs Linux/Integration sign-off; until
+  then uv stays package-local, which is what this env is.
+- **ROS 2 runtime** (rclpy, launch, launch_ros, and later moveit2 / ros2_control)
+  is apt/rosdep-managed and declared in `workbench_motion/package.xml`. uv does
+  not manage these.
+
+`evidence.py` and `logging_setup.py` deliberately have **no ROS imports**, and
+`scaffold_node.py` imports `rclpy` lazily inside `main()`, so the pure-Python
+parts import and test under a plain uv venv with no ROS installed.
+
+## Build & test
+
+Pure-Python unit tests (no ROS needed), from `robot/control/`:
+
+```bash
+uv sync
+uv run pytest        # -> workbench_motion/test  (10 tests)
+```
+
+> Works whether or not a ROS 2 env is sourced. When ROS is sourced, its pytest
+> plugins (`launch_testing`, `launch_ros`, `ament_*`) leak in via `PYTHONPATH`
+> and would fail to import inside this isolated venv; the pytest config blocks
+> them by name. Bulletproof fallback if that ever drifts:
+> `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest`.
+
+ROS build + package visibility + launch self test (needs ROS 2 Jazzy sourced;
+run from a colcon workspace whose `src/` contains this package):
+
+```bash
+colcon build --packages-select workbench_motion
+ros2 pkg list | grep workbench_motion
+ros2 launch workbench_motion scaffold.launch.py   # empty-world self test
+```
+
+> The uv venv used to *run* the node must see `/opt/ros/jazzy` site-packages so
+> apt `rclpy` is importable — create it with `--system-site-packages` or point at
+> the ROS site-packages. The pure-Python tests above do not need this.
+
+### Swapping the arm later (forward pointer)
+
+Arm-specific names (planning group, base/end-effector/gripper links, joint count)
+are kept in config/params, never hard-coded in adapter logic, so a later arm swap
+touches config only. Details land with phase 1.

--- a/robot/control/README.md
+++ b/robot/control/README.md
@@ -44,7 +44,7 @@ Pure-Python unit tests (no ROS needed), from `robot/control/`:
 
 ```bash
 uv sync
-uv run pytest        # -> workbench_motion/test  (10 tests)
+uv run pytest        # -> workbench_motion/test
 ```
 
 > Works whether or not a ROS 2 env is sourced. When ROS is sourced, its pytest

--- a/robot/control/pyproject.toml
+++ b/robot/control/pyproject.toml
@@ -1,0 +1,51 @@
+# Package-local uv environment for robot/control (Motion), per PLAN.md:
+# "退而把 uv 环境限定在 robot/control/ 本包内". This is NOT a distributable
+# package and NOT the ROS 2 package — the ament_python package lives in
+# workbench_motion/ and is built by colcon via its own setup.py/package.xml.
+# This file only pins the pure-Python dev toolchain (pytest) so the evidence /
+# logging modules and their tests run under `uv run` without a full ROS install.
+#
+# ROS 2 runtime deps (rclpy, launch, launch_ros, moveit2, ros2_control, ...) are
+# apt/rosdep-managed and declared in workbench_motion/package.xml — uv does not
+# manage them. When running the node, the uv venv must see /opt/ros/jazzy
+# site-packages (use --system-site-packages or point at it) so apt rclpy is
+# importable; the pure-Python tests below do not need it.
+[project]
+name = "workbench-motion-devenv"
+version = "0.0.0"
+description = "Package-local uv dev environment for the Motion (robot/control) module."
+requires-python = ">=3.12"
+dependencies = []
+
+[dependency-groups]
+dev = [
+  "pytest>=8,<9",
+]
+
+[tool.uv]
+# This project is an environment, not an installable package. Do not try to
+# build robot/control as a wheel (that is colcon's job for workbench_motion).
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["workbench_motion/test"]
+# Put the ament package's inner source dir on sys.path so `import
+# workbench_motion` resolves without installing anything.
+pythonpath = ["workbench_motion"]
+python_files = ["test_*.py"]
+addopts = [
+  "-v",
+  "--tb=short",
+  # These pure-Python tests need no external pytest plugins. When a ROS 2 env is
+  # sourced, ROS's pytest11 plugins (launch_testing, launch_ros, ament_*) leak in
+  # via PYTHONPATH and fail to import (they pull in `launch`/`yaml` which are not
+  # in this isolated uv venv). Block them so `uv run pytest` works whether or not
+  # ROS is sourced. Bulletproof fallback: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1.
+  "-p", "no:launch_testing",
+  "-p", "no:launch_ros",
+  "-p", "no:ament_copyright",
+  "-p", "no:ament_lint",
+  "-p", "no:ament_flake8",
+  "-p", "no:ament_xmllint",
+  "-p", "no:ament_pep257",
+]

--- a/robot/control/uv.lock
+++ b/robot/control/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "workbench-motion-devenv"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8,<9" }]

--- a/robot/control/workbench_motion/launch/scaffold.launch.py
+++ b/robot/control/workbench_motion/launch/scaffold.launch.py
@@ -1,0 +1,22 @@
+"""Phase-0 self-test launch: bring up the scaffold node in an empty world.
+
+Deliberately depends on nothing external (no bringup, no Gazebo, no arm). It
+only proves the package installs and its node starts and logs. Later phases add
+the arm + world launches.
+"""
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    return LaunchDescription(
+        [
+            Node(
+                package="workbench_motion",
+                executable="scaffold_node",
+                name="workbench_motion_scaffold",
+                output="screen",
+            ),
+        ]
+    )

--- a/robot/control/workbench_motion/package.xml
+++ b/robot/control/workbench_motion/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>workbench_motion</name>
+  <version>0.1.0</version>
+  <description>
+    Motion (robot/control) semantic-action adapter package: entry validation,
+    grasp/place/stop execution over a replaceable backend, and ActionResult
+    production. Phase 0 delivers the package skeleton, unified logging, and the
+    EvidenceSink interface only.
+  </description>
+  <maintainer email="motion-owner@workbench-1.invalid">Motion Owner</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <!-- ROS 2 runtime deps are apt/rosdep-managed, not uv-managed. -->
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/robot/control/workbench_motion/setup.cfg
+++ b/robot/control/workbench_motion/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/workbench_motion
+[install]
+install_scripts=$base/lib/workbench_motion

--- a/robot/control/workbench_motion/setup.py
+++ b/robot/control/workbench_motion/setup.py
@@ -1,0 +1,29 @@
+from glob import glob
+
+from setuptools import find_packages, setup
+
+package_name = "workbench_motion"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["test", "test.*"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+        ("share/" + package_name + "/launch", glob("launch/*.launch.py")),
+        ("share/" + package_name + "/config", glob("config/*.yaml")),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Motion Owner",
+    maintainer_email="motion-owner@workbench-1.invalid",
+    description="Motion semantic-action adapter package (phase 0 scaffold).",
+    license="Apache-2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "scaffold_node = workbench_motion.scaffold_node:main",
+        ],
+    },
+)

--- a/robot/control/workbench_motion/test/test_evidence.py
+++ b/robot/control/workbench_motion/test/test_evidence.py
@@ -1,0 +1,68 @@
+"""Unit tests for the EvidenceSink interface and FakeEvidenceSink.
+
+Proves the phase-0 acceptance criterion: ``append()`` returns a stable, unique
+reference, and Motion holds no persistence implementation (no ``get`` on the
+interface).
+"""
+
+from __future__ import annotations
+
+from workbench_motion.evidence import EvidenceSink, ExecutionEvent, FakeEvidenceSink
+
+
+def _event(action_id: str = "a-1") -> ExecutionEvent:
+    return ExecutionEvent(
+        event_type="trajectory_completed",
+        run_id="run-1",
+        action_id=action_id,
+        payload={"controller": "succeeded"},
+    )
+
+
+def test_fake_sink_satisfies_interface() -> None:
+    sink = FakeEvidenceSink()
+    # runtime_checkable Protocol: the fake structurally implements EvidenceSink.
+    assert isinstance(sink, EvidenceSink)
+
+
+def test_append_returns_reference() -> None:
+    sink = FakeEvidenceSink()
+    ref = sink.append(_event())
+    assert isinstance(ref, str)
+    assert ref
+
+
+def test_reference_is_unique_even_for_identical_events() -> None:
+    sink = FakeEvidenceSink()
+    ref_a = sink.append(_event())
+    ref_b = sink.append(_event())  # identical payload/ids
+    assert ref_a != ref_b
+    assert len(set(sink.refs)) == len(sink.refs) == 2
+
+
+def test_reference_is_stable_and_maps_to_its_event() -> None:
+    sink = FakeEvidenceSink()
+    ref_first = sink.append(_event("a-1"))
+    ref_second = sink.append(_event("a-2"))
+    # The reference returned for an append does not change and keeps pointing at
+    # the same event position it was minted for.
+    assert sink.refs == [ref_first, ref_second]
+    assert sink.events[0].action_id == "a-1"
+    assert sink.events[1].action_id == "a-2"
+
+
+def test_events_are_immutable() -> None:
+    event = _event()
+    try:
+        event.action_id = "mutated"  # type: ignore[misc]
+    except Exception:  # noqa: BLE001 - frozen dataclass raises FrozenInstanceError
+        pass
+    else:
+        raise AssertionError("ExecutionEvent must be frozen/immutable")
+
+
+def test_motion_side_holds_no_read_api() -> None:
+    # Enforce the boundary: the interface Motion talks to exposes append only,
+    # never a get/query. Motion must not become a second event store.
+    assert hasattr(EvidenceSink, "append")
+    assert not hasattr(EvidenceSink, "get")

--- a/robot/control/workbench_motion/test/test_evidence.py
+++ b/robot/control/workbench_motion/test/test_evidence.py
@@ -7,6 +7,10 @@ interface).
 
 from __future__ import annotations
 
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
 from workbench_motion.evidence import EvidenceSink, ExecutionEvent, FakeEvidenceSink
 
 
@@ -52,13 +56,167 @@ def test_reference_is_stable_and_maps_to_its_event() -> None:
 
 
 def test_events_are_immutable() -> None:
-    event = _event()
-    try:
-        event.action_id = "mutated"  # type: ignore[misc]
-    except Exception:  # noqa: BLE001 - frozen dataclass raises FrozenInstanceError
+    sink = FakeEvidenceSink()
+    sink.append(_event())
+    archived = sink.events[0]
+
+    with pytest.raises(FrozenInstanceError):
+        archived.action_id = "mutated"  # type: ignore[misc]
+
+
+def test_payload_is_deeply_immutable_from_dict_input() -> None:
+    """Archived events cannot be tampered with, at ANY nesting depth.
+
+    Covers the review concern that the earlier fix was only shallow: mutating the
+    original dict (top-level or nested), or writing through ``event.payload`` at
+    top level or into a nested dict/list, must all fail to reach the archive.
+    """
+    original = {"status": "ok", "nested": {"count": 1}, "items": [1, 2]}
+    event = ExecutionEvent(event_type="t", run_id="r", action_id="a", payload=original)
+    sink = FakeEvidenceSink()
+    sink.append(event)
+    archived = sink.events[0]
+
+    # 1. Mutating the ORIGINAL input (any depth) must not reach the archive.
+    original["status"] = "corrupted"
+    original["nested"]["count"] = 999
+    original["items"].append(3)
+    assert archived.payload["status"] == "ok"
+    assert archived.payload["nested"]["count"] == 1
+    assert archived.payload["items"] == (1, 2)
+
+    # 2. Writing through event.payload at top level must raise.
+    with pytest.raises(TypeError):
+        archived.payload["status"] = "x"  # type: ignore[index]
+
+    # 3. Writing into a NESTED dict must also raise (this is what shallow failed).
+    with pytest.raises(TypeError):
+        archived.payload["nested"]["count"] = 0  # type: ignore[index]
+
+    # 4. Nested sequences become tuples — no append/mutation possible.
+    assert isinstance(archived.payload["items"], tuple)
+    with pytest.raises(AttributeError):
+        archived.payload["items"].append(4)  # type: ignore[attr-defined]
+
+
+def test_payload_is_isolated_from_mappingproxy_input() -> None:
+    """Passing an existing MappingProxyType must NOT leak its backing dict.
+
+    Covers the review concern: the earlier fix skipped copying when the input was
+    already a MappingProxyType, so a caller holding the backing dict could still
+    mutate the archived event. _freeze rebuilds regardless, closing that hole.
+    """
+    from types import MappingProxyType
+
+    backing = {"k": {"n": 1}}
+    proxy = MappingProxyType(backing)
+    event = ExecutionEvent(event_type="t", run_id="r", action_id="a", payload=proxy)
+    sink = FakeEvidenceSink()
+    sink.append(event)
+    archived = sink.events[0]
+
+    # Mutate the underlying dict the proxy was built from.
+    backing["k"]["n"] = 999
+    backing["added"] = True
+
+    assert archived.payload["k"]["n"] == 1
+    assert "added" not in archived.payload
+
+
+def test_as_serializable_returns_plain_json_ready_dict() -> None:
+    """The frozen payload is not JSON-serializable; as_serializable() thaws it.
+
+    Covers the serialization-regression concern: json.dumps must work on the
+    output, and nested structures come back as plain dict/list.
+    """
+    event = ExecutionEvent(
+        event_type="grasp_done",
+        run_id="run-1",
+        action_id="a-1",
+        payload={"controller": "succeeded", "joints": [0.1, 0.2], "meta": {"ok": True}},
+    )
+    data = event.as_serializable()
+
+    # Plain types, round-trips through JSON without error.
+    assert isinstance(data["payload"], dict)
+    assert isinstance(data["payload"]["joints"], list)
+    assert isinstance(data["payload"]["meta"], dict)
+    restored = json.loads(json.dumps(data, allow_nan=False))
+    assert restored["payload"]["controller"] == "succeeded"
+    assert restored["payload"]["joints"] == [0.1, 0.2]
+    assert restored["event_type"] == "grasp_done"
+
+
+def test_set_payload_is_deeply_immutable_and_json_ready() -> None:
+    original = {3, 1, 2}
+    event = ExecutionEvent(
+        event_type="controller_failed",
+        run_id="run-1",
+        action_id="a-1",
+        payload={"fault_codes": original, "nested": {"labels": frozenset({"b", "a"})}},
+    )
+    sink = FakeEvidenceSink()
+    sink.append(event)
+    archived = sink.events[0]
+
+    original.add(4)
+    assert archived.payload["fault_codes"] == frozenset({1, 2, 3})
+    assert archived.payload["nested"]["labels"] == frozenset({"a", "b"})
+    with pytest.raises(AttributeError):
+        archived.payload["fault_codes"].add(5)  # type: ignore[attr-defined]
+
+    serialized = archived.as_serializable()
+    assert serialized["payload"]["fault_codes"] == [1, 2, 3]
+    assert serialized["payload"]["nested"]["labels"] == ["a", "b"]
+    assert json.loads(json.dumps(serialized)) == serialized
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_float_payloads_fail_closed(value: float) -> None:
+    with pytest.raises(ValueError, match="float values must be finite"):
+        ExecutionEvent(
+            event_type="controller_failed",
+            run_id="run-1",
+            action_id="a-1",
+            payload={"position_error": value},
+        )
+
+
+def test_invalid_payload_types_fail_closed() -> None:
+    class MutableValue:
         pass
-    else:
-        raise AssertionError("ExecutionEvent must be frozen/immutable")
+
+    with pytest.raises(TypeError, match="payload must be a mapping"):
+        ExecutionEvent(event_type="t", run_id="r", action_id="a", payload=[])  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        ExecutionEvent(event_type="t", run_id="r", action_id="a", payload={1: "bad"})  # type: ignore[dict-item]
+
+    with pytest.raises(TypeError, match="unsupported payload value type: MutableValue"):
+        ExecutionEvent(
+            event_type="t",
+            run_id="r",
+            action_id="a",
+            payload={"bad": MutableValue()},
+        )
+
+
+def test_recursive_payload_fails_closed() -> None:
+    recursive: dict[str, object] = {}
+    recursive["self"] = recursive
+
+    with pytest.raises(TypeError, match="must not contain recursive containers"):
+        ExecutionEvent(event_type="t", run_id="r", action_id="a", payload=recursive)
+
+
+def test_sink_append_error_propagates_without_minting_reference() -> None:
+    sink = FakeEvidenceSink(append_error=RuntimeError("durable append failed"))
+
+    with pytest.raises(RuntimeError, match="durable append failed"):
+        sink.append(_event())
+
+    assert len(sink) == 0
+    assert sink.refs == []
 
 
 def test_motion_side_holds_no_read_api() -> None:

--- a/robot/control/workbench_motion/test/test_logging_setup.py
+++ b/robot/control/workbench_motion/test/test_logging_setup.py
@@ -1,0 +1,70 @@
+"""Unit tests for the unified logging configuration.
+
+Proves the phase-0 acceptance criterion: the unified format carries run_id and
+the setup is idempotent (no stacked handlers, no reliance on ``print``).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from workbench_motion.logging_setup import (
+    LOG_FORMAT,
+    _ContextDefaultsFilter,
+    configure_logging,
+    get_action_logger,
+)
+
+
+def _capture_handler(logger: logging.Logger) -> io.StringIO:
+    """Attach a StringIO handler mirroring the unified format + context filter.
+
+    We cannot rely on capsys/capfd here: the real StreamHandler binds sys.stderr
+    at construction, before pytest swaps the stream, so capsys never sees it.
+    This handler captures deterministically while exercising the same LOG_FORMAT
+    and defaults filter the package installs.
+    """
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    handler.addFilter(_ContextDefaultsFilter())
+    logger.addHandler(handler)
+    return stream
+
+
+def test_configure_is_idempotent() -> None:
+    logger = logging.getLogger("workbench_motion")
+    configure_logging()
+    count_after_first = len(logger.handlers)
+    configure_logging()
+    count_after_second = len(logger.handlers)
+    assert count_after_first == count_after_second
+
+
+def test_package_logger_does_not_propagate_to_root() -> None:
+    configure_logging()
+    assert logging.getLogger("workbench_motion").propagate is False
+
+
+def test_format_carries_run_and_action_ids() -> None:
+    configure_logging()
+    logger = logging.getLogger("workbench_motion.fmt")
+    stream = _capture_handler(logger)
+    log = get_action_logger("workbench_motion.fmt", run_id="run-xyz", action_id="act-7")
+    log.info("action started")
+    line = stream.getvalue()
+    assert "run=run-xyz" in line
+    assert "action=act-7" in line
+    assert "action started" in line
+
+
+def test_plain_log_without_context_uses_defaults() -> None:
+    configure_logging()
+    logger = logging.getLogger("workbench_motion.plain")
+    stream = _capture_handler(logger)
+    logger.warning("no context here")
+    line = stream.getvalue()
+    # The context filter must supply defaults so the formatter never crashes.
+    assert "run=-" in line
+    assert "action=-" in line

--- a/robot/control/workbench_motion/workbench_motion/__init__.py
+++ b/robot/control/workbench_motion/workbench_motion/__init__.py
@@ -1,0 +1,17 @@
+"""Motion (robot/control) semantic-action adapter package.
+
+Phase 0 delivers only the engineering scaffold: unified logging setup and the
+EvidenceSink interface plus a test double. No arm, MoveIt, or grasp logic yet.
+"""
+
+from .evidence import EvidenceRef, EvidenceSink, ExecutionEvent, FakeEvidenceSink
+from .logging_setup import configure_logging, get_action_logger
+
+__all__ = [
+    "EvidenceRef",
+    "EvidenceSink",
+    "ExecutionEvent",
+    "FakeEvidenceSink",
+    "configure_logging",
+    "get_action_logger",
+]

--- a/robot/control/workbench_motion/workbench_motion/evidence.py
+++ b/robot/control/workbench_motion/workbench_motion/evidence.py
@@ -1,0 +1,97 @@
+"""Execution-event structure and the EvidenceSink interface.
+
+Design boundary (see robot/control/PLAN.md, phase 0):
+
+- Motion does NOT own a fact store. This module defines *what* an execution
+  event looks like and the *append-only* sink interface Motion talks to. It does
+  not implement persistence, and it deliberately exposes no ``get``/query.
+- Motion calls ``append(event)`` and receives back a **stable reference** it can
+  drop into an ActionResult's ``evidence_refs``. Production persistence is
+  provided by the World Model side (Event Store adapter) — see the "待确认"
+  note in PLAN.md; that adapter is a cross-module dependency and is NOT assumed
+  to exist yet.
+- Unit tests use :class:`FakeEvidenceSink`.
+
+Why events and not log lines: ``evidence_refs`` must point at something with a
+stable id (an MCU frame number, or a structured event with a stable
+``event_id``). Log lines are for humans and are not referenceable evidence.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+# A stable, opaque reference returned by a sink after it durably records an
+# event. Motion treats it as an opaque token and only stores it in evidence_refs.
+EvidenceRef = str
+
+
+@dataclass(frozen=True)
+class ExecutionEvent:
+    """An observed execution fact emitted by Motion.
+
+    Frozen so an event cannot be mutated after it is handed to a sink. Carries
+    ``run_id``/``action_id`` so it can be correlated with the (separate) human
+    log stream, and a monotonic-clock-friendly ``clock_id`` per PLAN.md's
+    timestamp discipline. This is intentionally minimal for phase 0; richer
+    execution-fact fields land alongside the adapter in later phases.
+    """
+
+    event_type: str
+    run_id: str
+    action_id: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    clock_id: str = "monotonic"
+
+
+@runtime_checkable
+class EvidenceSink(Protocol):
+    """Append-only sink Motion writes execution events to.
+
+    The *only* operation Motion needs. Implementations must return a reference
+    that is:
+      - **stable**: identifies exactly the event that was appended, for later
+        lookup by whoever owns the store.
+      - **unique**: distinct per appended event, even for identical payloads.
+
+    Motion holds no persistence itself and never reads back — there is no
+    ``get`` here on purpose (no second event store).
+    """
+
+    def append(self, event: ExecutionEvent) -> EvidenceRef:
+        """Durably record ``event`` and return a stable, unique reference."""
+        ...
+
+
+class FakeEvidenceSink:
+    """In-memory test double implementing :class:`EvidenceSink`.
+
+    For unit tests only. Keeps appended events so tests can assert on them, and
+    mints a stable unique reference per append. This is NOT the production
+    store — it exists so Motion tests never depend on the World Model adapter.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[tuple[EvidenceRef, ExecutionEvent]] = []
+
+    def append(self, event: ExecutionEvent) -> EvidenceRef:
+        ref: EvidenceRef = f"evt:{uuid.uuid4()}"
+        self._events.append((ref, event))
+        return ref
+
+    # --- test-only inspection helpers (not part of the EvidenceSink interface) ---
+
+    @property
+    def events(self) -> list[ExecutionEvent]:
+        """Events in append order."""
+        return [event for _, event in self._events]
+
+    @property
+    def refs(self) -> list[EvidenceRef]:
+        """References in append order."""
+        return [ref for ref, _ in self._events]
+
+    def __len__(self) -> int:
+        return len(self._events)

--- a/robot/control/workbench_motion/workbench_motion/evidence.py
+++ b/robot/control/workbench_motion/workbench_motion/evidence.py
@@ -1,15 +1,14 @@
 """Execution-event structure and the EvidenceSink interface.
 
-Design boundary (see robot/control/PLAN.md, phase 0):
+Design boundary:
 
 - Motion does NOT own a fact store. This module defines *what* an execution
   event looks like and the *append-only* sink interface Motion talks to. It does
   not implement persistence, and it deliberately exposes no ``get``/query.
 - Motion calls ``append(event)`` and receives back a **stable reference** it can
   drop into an ActionResult's ``evidence_refs``. Production persistence is
-  provided by the World Model side (Event Store adapter) — see the "待确认"
-  note in PLAN.md; that adapter is a cross-module dependency and is NOT assumed
-  to exist yet.
+  provided by the World Model side (Event Store adapter); that adapter is a
+  cross-module dependency and is NOT assumed to exist yet.
 - Unit tests use :class:`FakeEvidenceSink`.
 
 Why events and not log lines: ``evidence_refs`` must point at something with a
@@ -19,8 +18,12 @@ stable id (an MCU frame number, or a structured event with a stable
 
 from __future__ import annotations
 
+import json
+import math
 import uuid
+from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any, Protocol, runtime_checkable
 
 # A stable, opaque reference returned by a sink after it durably records an
@@ -28,22 +31,140 @@ from typing import Any, Protocol, runtime_checkable
 EvidenceRef = str
 
 
+def _freeze(value: Any, *, _ancestors: set[int] | None = None) -> Any:
+    """Recursively rebuild ``value`` into a deeply-immutable structure.
+
+    - ``dict``/``Mapping`` -> ``MappingProxyType`` of frozen items.
+    - ``list``/``tuple`` (non-str Sequence) -> ``tuple`` of frozen items.
+    - ``set``/``frozenset`` -> ``frozenset`` of frozen items.
+    - strict-JSON scalar values are returned as-is; NaN/Infinity are rejected.
+    - unsupported values, non-string mapping keys, and cycles fail closed.
+
+    Because containers are rebuilt from scratch, the result shares no mutable
+    object with the caller's input — passing an existing dict OR MappingProxyType
+    and then mutating the original cannot reach the frozen copy. This is what
+    ``frozen=True`` alone does NOT give you (it only blocks field reassignment,
+    not mutation of a dict the field points at).
+    """
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("payload float values must be finite")
+        return value
+    if value is None or isinstance(value, str | int | bool):
+        return value
+
+    ancestors = set() if _ancestors is None else _ancestors
+    identity = id(value)
+    if identity in ancestors:
+        raise TypeError("payload must not contain recursive containers")
+
+    if isinstance(value, Mapping):
+        ancestors.add(identity)
+        try:
+            frozen: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise TypeError("payload mapping keys must be strings")
+                frozen[key] = _freeze(item, _ancestors=ancestors)
+            return MappingProxyType(frozen)
+        finally:
+            ancestors.remove(identity)
+
+    if isinstance(value, Set):
+        ancestors.add(identity)
+        try:
+            return frozenset(_freeze(item, _ancestors=ancestors) for item in value)
+        finally:
+            ancestors.remove(identity)
+
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        ancestors.add(identity)
+        try:
+            return tuple(_freeze(item, _ancestors=ancestors) for item in value)
+        finally:
+            ancestors.remove(identity)
+
+    raise TypeError(f"unsupported payload value type: {type(value).__name__}")
+
+
+def _json_sort_key(value: Any) -> str:
+    """Return a stable key for values thawed from an unordered set."""
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _thaw(value: Any) -> Any:
+    """Inverse of :func:`_freeze`: rebuild plain ``dict``/``list`` for serialization.
+
+    ``MappingProxyType`` is not JSON-serializable and breaks ``json.dumps`` /
+    ``dataclasses.asdict``. Consumers that need to persist an event call
+    :meth:`ExecutionEvent.as_serializable` (which routes through this) to get a
+    plain, JSON-ready structure back. Frozen sets become deterministically
+    ordered lists so repeated serialization produces stable evidence bytes.
+    """
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    if isinstance(value, frozenset):
+        return sorted((_thaw(item) for item in value), key=_json_sort_key)
+    return value
+
+
 @dataclass(frozen=True)
 class ExecutionEvent:
     """An observed execution fact emitted by Motion.
 
-    Frozen so an event cannot be mutated after it is handed to a sink. Carries
-    ``run_id``/``action_id`` so it can be correlated with the (separate) human
-    log stream, and a monotonic-clock-friendly ``clock_id`` per PLAN.md's
-    timestamp discipline. This is intentionally minimal for phase 0; richer
-    execution-fact fields land alongside the adapter in later phases.
+    An archived event must be tamper-proof. ``frozen=True`` alone is not enough:
+    it blocks field reassignment but not mutation of a ``dict``/``list`` a field
+    points at. So ``__post_init__`` recursively rebuilds ``payload`` into a
+    deeply-immutable structure (``MappingProxyType``/``tuple``, see :func:`_freeze`)
+    that shares no mutable object with the caller — nested values cannot be
+    changed, and the input reference (dict OR MappingProxyType) cannot reach the
+    stored copy afterwards.
+
+    Because that structure is not JSON-serializable, :meth:`as_serializable`
+    thaws it back to plain ``dict``/``list`` for a persisting EvidenceSink.
+
+    Carries ``run_id``/``action_id`` so it can be correlated with the (separate)
+    human log stream, and a monotonic-clock-friendly ``clock_id`` for consistent
+    timestamps. Intentionally minimal for phase 0; richer fields land alongside
+    the adapter in later phases.
     """
 
     event_type: str
     run_id: str
     action_id: str
-    payload: dict[str, Any] = field(default_factory=dict)
+    payload: Mapping[str, Any] = field(default_factory=dict)
     clock_id: str = "monotonic"
+
+    def __post_init__(self) -> None:
+        # Deep-freeze payload. frozen=True blocks reassignment, so set via
+        # object.__setattr__. _freeze rebuilds every container, so this is safe
+        # (and correct) whether payload came in as a dict or a MappingProxyType.
+        if not isinstance(self.payload, Mapping):
+            raise TypeError("payload must be a mapping")
+        object.__setattr__(self, "payload", _freeze(self.payload))
+
+    def as_serializable(self) -> dict[str, Any]:
+        """Return a plain, strict-JSON-ready dict of this event (payload thawed).
+
+        Use this for persistence/serialization — ``json.dumps`` and
+        ``dataclasses.asdict`` cannot handle the frozen ``MappingProxyType``
+        payload directly.
+        """
+        return {
+            "event_type": self.event_type,
+            "run_id": self.run_id,
+            "action_id": self.action_id,
+            "payload": _thaw(self.payload),
+            "clock_id": self.clock_id,
+        }
 
 
 @runtime_checkable
@@ -58,10 +179,19 @@ class EvidenceSink(Protocol):
 
     Motion holds no persistence itself and never reads back — there is no
     ``get`` here on purpose (no second event store).
+
+    ``ExecutionEvent`` deliberately stores a deeply immutable payload and is
+    therefore not directly JSON-serializable. A persisting implementation MUST
+    serialize :meth:`ExecutionEvent.as_serializable`; it must not use
+    ``json.dumps(event)`` or ``dataclasses.asdict(event)``.
+
+    Validation, serialization, or durable-write failures MUST be raised to the
+    caller. An implementation must not swallow a failure or mint an evidence
+    reference for an event that was not durably recorded.
     """
 
     def append(self, event: ExecutionEvent) -> EvidenceRef:
-        """Durably record ``event`` and return a stable, unique reference."""
+        """Durably record ``event.as_serializable()`` and return its reference."""
         ...
 
 
@@ -71,12 +201,16 @@ class FakeEvidenceSink:
     For unit tests only. Keeps appended events so tests can assert on them, and
     mints a stable unique reference per append. This is NOT the production
     store — it exists so Motion tests never depend on the World Model adapter.
+    ``append_error`` provides deterministic failure injection for caller tests.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, append_error: Exception | None = None) -> None:
         self._events: list[tuple[EvidenceRef, ExecutionEvent]] = []
+        self._append_error = append_error
 
     def append(self, event: ExecutionEvent) -> EvidenceRef:
+        if self._append_error is not None:
+            raise self._append_error
         ref: EvidenceRef = f"evt:{uuid.uuid4()}"
         self._events.append((ref, event))
         return ref

--- a/robot/control/workbench_motion/workbench_motion/logging_setup.py
+++ b/robot/control/workbench_motion/workbench_motion/logging_setup.py
@@ -1,0 +1,61 @@
+"""Unified logging configuration for the Motion package.
+
+Rules (see robot/control/PLAN.md, "全局约定"):
+- Every module uses ``logging.getLogger(__name__)``; ``print`` is never used.
+- Levels: DEBUG planning detail / INFO action start-stop / WARNING retry-degrade
+  / ERROR failure-and-rejection.
+- Every action log line carries ``run_id`` + ``action_id`` for human trace-back.
+
+Logs are for humans and debugging. They are deliberately NOT the evidence
+channel: anything referenced by ``evidence_refs`` must have a stable id and go
+through :mod:`workbench_motion.evidence`, not a log line.
+"""
+
+from __future__ import annotations
+
+import logging
+
+# Fields we always want present on a record so the formatter never crashes on a
+# plain ``logger.info(...)`` call that did not supply action context.
+_DEFAULT_CONTEXT = {"run_id": "-", "action_id": "-"}
+
+LOG_FORMAT = "%(asctime)s %(levelname)s [run=%(run_id)s action=%(action_id)s] %(name)s: %(message)s"
+
+
+class _ContextDefaultsFilter(logging.Filter):
+    """Fill in ``run_id``/``action_id`` defaults for records that omit them."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        for key, value in _DEFAULT_CONTEXT.items():
+            if not hasattr(record, key):
+                setattr(record, key, value)
+        return True
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Install the unified handler + formatter on the ``workbench_motion`` logger.
+
+    Idempotent: calling it more than once does not stack handlers. Attaches to
+    the package logger (not the root) so the host application keeps control of
+    global logging config.
+    """
+    logger = logging.getLogger("workbench_motion")
+    logger.setLevel(level)
+    logger.propagate = False
+
+    if any(getattr(h, "_workbench_motion", False) for h in logger.handlers):
+        return
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    handler.addFilter(_ContextDefaultsFilter())
+    handler._workbench_motion = True  # type: ignore[attr-defined]  # marker for idempotency
+    logger.addHandler(handler)
+
+
+def get_action_logger(name: str, *, run_id: str, action_id: str = "-") -> logging.LoggerAdapter:
+    """Return a logger adapter that stamps ``run_id``/``action_id`` on every line.
+
+    Use one per action so all of an action's log lines carry the same ids.
+    """
+    return logging.LoggerAdapter(logging.getLogger(name), {"run_id": run_id, "action_id": action_id})

--- a/robot/control/workbench_motion/workbench_motion/scaffold_node.py
+++ b/robot/control/workbench_motion/workbench_motion/scaffold_node.py
@@ -1,0 +1,67 @@
+"""Minimal Motion node used for the phase-0 empty-world self test.
+
+It does nothing but come up, log a unified start line carrying a ``run_id``,
+append a startup ExecutionEvent to a (fake) EvidenceSink, then either run a
+bounded self test and exit cleanly (default) or spin indefinitely. It exists so
+the package's launch can be exercised without any external bringup (no Gazebo,
+no arm, no MCU). Real adapter behaviour lands in later phases.
+
+Behaviour is controlled by the ``self_test_seconds`` ROS parameter:
+- ``> 0`` (default 2.0): spin for that long, log "self-test passed", exit 0.
+  This is the CI-friendly path — no SIGINT needed, launch sees a clean exit.
+- ``<= 0``: spin indefinitely (interactive use; stop with Ctrl-C).
+
+``rclpy`` is an apt/rosdep-managed ROS 2 runtime dependency, not a uv-managed
+one. The import is done lazily inside ``main`` so the pure-Python parts of this
+package (evidence, logging_setup and their tests) import and run under a plain
+uv environment where rclpy is not present.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+from .evidence import ExecutionEvent, FakeEvidenceSink
+from .logging_setup import configure_logging, get_action_logger
+
+
+def main(args: list[str] | None = None) -> None:
+    import rclpy
+    from rclpy.executors import ExternalShutdownException
+    from rclpy.node import Node
+
+    configure_logging(logging.INFO)
+    run_id = uuid.uuid4().hex[:12]
+
+    class ScaffoldNode(Node):
+        def __init__(self) -> None:
+            super().__init__("workbench_motion_scaffold")
+            self.log = get_action_logger("workbench_motion.scaffold", run_id=run_id)
+            self.self_test_seconds = self.declare_parameter("self_test_seconds", 2.0).get_parameter_value().double_value
+            # Phase-0 sink is the test double; production sink is wired in later
+            # phases via the World Model Event Store adapter.
+            self._sink = FakeEvidenceSink()
+            ref = self._sink.append(ExecutionEvent(event_type="node_started", run_id=run_id, action_id="-"))
+            self.log.info("workbench_motion scaffold node up; startup event ref=%s", ref)
+
+    rclpy.init(args=args)
+    node = ScaffoldNode()
+    try:
+        if node.self_test_seconds > 0:
+            deadline = time.monotonic() + node.self_test_seconds
+            while rclpy.ok() and time.monotonic() < deadline:
+                rclpy.spin_once(node, timeout_sec=0.1)
+            node.log.info("self-test passed; shutting down cleanly")
+        else:
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Related Issue
Related to #3
## What changed
  - Added the `workbench_motion` ROS 2 Jazzy `ament_python` package scaffold.
  - Added package metadata, setup files, resource marker and launch file.
  - Added unified logging with `run_id` and `action_id`.
  - Added deeply immutable `ExecutionEvent`, `EvidenceSink` and `FakeEvidenceSink`, with strict-JSON serialization and fail-closed payload validation.
  - Added unit tests for evidence references, nested immutability, serialization, append failures and logging behavior.
  - Added package-local uv environment and lockfile.
  - Added Motion-local ignore rules for build artifacts and private planning notes.
  - No arm, MoveIt, grasp logic or hardware control was added.
## Interfaces affected
  No files under `interfaces/` or `libs/contracts/` were changed.

  `EvidenceSink` is an internal Motion-side interface. Implementations serialize through
  `ExecutionEvent.as_serializable()` and propagate append failures without minting an evidence reference. Production persistence ownership remains a follow-up decision for the World Model Owner.
## Tests and commands
Motion checks:

  - `uv sync` — passed
  - `uv run pytest` — 20 passed
  - `colcon build --packages-select workbench_motion` — passed
  - `ros2 pkg list | grep workbench_motion` — package found
  - `ros2 launch workbench_motion scaffold.launch.py` — self-test passed and exited cleanly
  - `make task-check PACKET=docs/task_packets/motion-000-phase0-scaffold.json` — passed

  Repository checks:

  - `make test` — 29 passed
  - `make contract` — passed
  - `make scenario-check` — passed for 12 frozen and 18 expanded manifests
  - `make context-check` — passed
  - `make demo-scripted` — passed
  - `make lint` — passed (`ruff check` clean; `ruff format --check`: 49 files already formatted)
  - `make golden-check` — passed for 20 tasks and 10 dangerous requests
  - `make demo-offline` — passed
## Evidence
  - Feature branch head: `f9244f4`
  - Motion unit test output: 20 passed
  - Repository test output: 29 passed
  - ROS Jazzy verification: colcon build passed, package was listed, launch self-test passed and exited cleanly
  - Task Packet validation passed
## Risks and rollback
This is phase-0 scaffolding only. It does not control an arm, invoke MoveIt, execute grasp logic or publish hardware commands.
Rollback: revert the phase-0 scaffold commits.
## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] No interface changed; examples/docs update was not required.
- [x] I did not add secrets, private data or unreviewed assets.
