### PR TITLE
feat(hardware): add unified release readiness gates

### DIFF
--- a/docs/task_packets/hardware-engineering-release-readiness.json
+++ b/docs/task_packets/hardware-engineering-release-readiness.json
@@ -1,0 +1,39 @@
+{
+  "issue": "19,22,23,24,28-release",
+  "issues": [19, 22, 23, 24, 28],
+  "human_owner": "Quchaosheng",
+  "objective": "Unify the hardware engineering, procurement, quality, manufacturing, and field-validation evidence into a deterministic release-readiness gate.",
+  "allowed_paths": [
+    "hardware/release/**",
+    "hardware/README.md",
+    "tests/hardware/**",
+    "docs/task_packets/hardware-engineering-release-readiness.json"
+  ],
+  "read_only_paths": [
+    "hardware/pcb/**",
+    "hardware/procurement/**",
+    "hardware/qa/**",
+    "hardware/manufacturing/**",
+    "hardware/validation/**"
+  ],
+  "forbidden": ["robot/control/**", "firmware/**", "services/**", "interfaces/**"],
+  "acceptance": [
+    "release gate register covers engineering, commercial, physical, quality, compliance, and field evidence",
+    "validator cross-checks all referenced repository evidence and never promotes NOT_EXECUTED or ORDER_RELEASE_BLOCKED to PASS",
+    "deterministic release report and hardware tests pass"
+  ],
+  "commands": [
+    "python hardware/release/tools/check_release_readiness.py",
+    "python -m unittest discover -s tests/hardware -v"
+  ],
+  "evidence": [
+    "hardware/release/generated/release_readiness_report.json",
+    "hardware/release/evidence-register.csv",
+    "hardware package unit-test output"
+  ],
+  "stop_conditions": [
+    "physical, supplier, lab, or certification evidence is unavailable",
+    "a gate would require changing a producer-owned path",
+    "an external record is missing a serial, revision, date, operator, or raw evidence reference"
+  ]
+}

--- a/docs/task_packets/kernel-lint-cleanup.json
+++ b/docs/task_packets/kernel-lint-cleanup.json
@@ -1,0 +1,22 @@
+{
+  "issue": "kernel-lint-followup",
+  "human_owner": "Quchaosheng",
+  "objective": "Make the newly merged libs/kernel K1-K10 layer pass the repository Ruff gate without changing its behavior.",
+  "allowed_paths": [
+    "libs/kernel/**",
+    "docs/task_packets/kernel-lint-cleanup.json"
+  ],
+  "read_only_paths": ["interfaces/**", "AGENTS.md"],
+  "forbidden": ["robot/control/**", "firmware/**", "services/**", "hardware/**"],
+  "acceptance": [
+    "ruff check passes for libs/kernel",
+    "libs/kernel/tests/test_k1_k10.py passes",
+    "public kernel behavior remains unchanged"
+  ],
+  "commands": [
+    "python -m ruff check libs/kernel",
+    "python libs/kernel/tests/test_k1_k10.py"
+  ],
+  "evidence": ["Ruff output", "K1-K10 integration test output"],
+  "stop_conditions": ["behavioral test changes are required", "interface schema changes are required"]
+}

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -16,6 +16,7 @@ hardware/
   procurement/      Controlled BOM, quote requests, supplier review and PO gates
   qa/               Inspection standards, FMEA, AQL and compliance evidence gates
   validation/       SIM2REAL, diagnostics, fault injection and field acceptance
+  release/          Cross-package release-readiness register and fail-closed gate
 ```
 
 **Rule**: every adapter here must satisfy the same contract as its simulation counterpart.

--- a/hardware/release/README.md
+++ b/hardware/release/README.md
@@ -1,0 +1,18 @@
+# Hardware release-readiness gate
+
+This is the single release view for the engineering package. It joins the
+existing PCB and manufacturing reports with the procurement, QA, and field
+validation reports. A green engineering check does not release a physical
+product: commercial, safety, laboratory, production, and field gates remain
+blocked until dated evidence is attached.
+
+Run:
+
+```bash
+python hardware/release/tools/check_release_readiness.py
+```
+
+The command writes `generated/release_readiness_report.json`. Update
+`evidence-register.csv` only with controlled records. Every external record must
+identify the unit/lot, revision, operator, date, instrument or supplier source,
+and a raw evidence path.

--- a/hardware/release/evidence-register.csv
+++ b/hardware/release/evidence-register.csv
@@ -1,0 +1,16 @@
+gate_id,domain,gate,owner,status,evidence_ref,next_action,release_blocker
+REL-001,engineering,mechanical analytical package,Mechanical Owner,PASS,hardware/mechanical/generated/analysis.json,complete physical stability/drop validation,no
+REL-002,engineering,PCB architecture/ERC/DRC/connectivity,Electrical Owner,PASS,hardware/pcb/generated/release_readiness.json,close component schematic and AVL,no
+REL-003,engineering,manufacturing route and controlled traveller,Manufacturing Owner,PASS,hardware/manufacturing/generated/route_report.json,run pilot units,no
+REL-004,procurement,dated quotes and approved MPNs,Procurement Owner,BLOCKED,hardware/procurement/generated/procurement_report.json,attach dated quotes and AVL approval,yes
+REL-005,commercial,PO and lead-time decision,Project Owner,BLOCKED,hardware/procurement/po-checklist.csv,complete PO checklist with sign-off,yes
+REL-006,safety,approved safety analysis and E-stop timing,Safety Owner,BLOCKED,hardware/pcb/safety-gate-truth-table.csv,attach signed safety analysis and measured trip time,yes
+REL-007,manufacturing,supplier DFM and mating-part closure,Manufacturing Owner,BLOCKED,hardware/manufacturing/generated/harness_report.json,attach supplier DFM and physical harness tests,yes
+REL-008,quality,incoming and in-process inspection execution,Quality Owner,BLOCKED,hardware/qa/generated/qa_report.json,execute inspection plan on serialized units,yes
+REL-009,quality,FMEA and defect corrective-action closure,Quality Owner,BLOCKED,hardware/qa/fmea.csv,record observed defects and verify corrective actions,yes
+REL-010,compliance,RoHS/EMC/electrical-safety technical file,Quality Owner,BLOCKED,hardware/qa/compliance-matrix.csv,attach supplier declarations and lab reports,yes
+REL-011,physical,first-batch acceptance,Validation Owner,BLOCKED,hardware/validation/first-batch-acceptance.csv,build and test ten serialized units,yes
+REL-012,field,SIM2REAL benchmark,Validation Owner,BLOCKED,hardware/validation/sim2real-matrix.csv,run paired simulation/real-machine measurements,yes
+REL-013,field,fault-injection recovery library,Validation Owner,BLOCKED,hardware/validation/fault-scenarios.csv,execute all 20 scenarios and attach logs,yes
+REL-014,reliability,48-hour continuous run,Validation Owner,BLOCKED,hardware/validation/long-run-protocol.md,execute protocol with raw event log,yes
+REL-015,release,final GO/NO-GO decision,Project Owner,BLOCKED,hardware/manufacturing/pilot-and-release.md,obtain all sign-offs and close blockers,yes

--- a/hardware/release/generated/release_readiness_report.json
+++ b/hardware/release/generated/release_readiness_report.json
@@ -1,0 +1,31 @@
+{
+  "blocker_count": 12,
+  "blockers": [
+    "REL-004",
+    "REL-005",
+    "REL-006",
+    "REL-007",
+    "REL-008",
+    "REL-009",
+    "REL-010",
+    "REL-011",
+    "REL-012",
+    "REL-013",
+    "REL-014",
+    "REL-015"
+  ],
+  "checks": {
+    "all_blockers_are_explicit": true,
+    "all_gates_have_owner_and_next_action": true,
+    "blocked_gates_are_not_pass": true,
+    "evidence_references_exist": true,
+    "gate_ids_are_unique": true,
+    "statuses_are_controlled": true,
+    "upstream_reports_remain_fail_closed": true
+  },
+  "gate_count": 15,
+  "note": "PASS means repository evidence is present; it never substitutes for external physical or commercial evidence.",
+  "package": "hardware-release-readiness",
+  "pass": true,
+  "status": "RELEASE_BLOCKED"
+}

--- a/hardware/release/tools/check_release_readiness.py
+++ b/hardware/release/tools/check_release_readiness.py
@@ -1,0 +1,66 @@
+"""Cross-check the hardware release register and preserve fail-closed status."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+PACKAGE = ROOT / "hardware" / "release"
+
+
+def read_rows() -> list[dict[str, str]]:
+    with (PACKAGE / "evidence-register.csv").open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def load_report(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def validate() -> dict:
+    rows = read_rows()
+    statuses = {"PASS", "BLOCKED", "NOT_EXECUTED", "HOLD"}
+    report_checks = {
+        "gate_ids_are_unique": len(rows) == len({row["gate_id"] for row in rows}),
+        "all_gates_have_owner_and_next_action": all(row["owner"] and row["next_action"] for row in rows),
+        "statuses_are_controlled": all(row["status"] in statuses for row in rows),
+        "evidence_references_exist": all((ROOT / row["evidence_ref"]).exists() for row in rows),
+        "all_blockers_are_explicit": all(row["release_blocker"] in {"yes", "no"} for row in rows),
+        "blocked_gates_are_not_pass": all(
+            row["status"] == "BLOCKED" for row in rows if row["release_blocker"] == "yes"
+        ),
+        "upstream_reports_remain_fail_closed": (
+            load_report("hardware/pcb/generated/release_readiness.json")["status"] == "ORDER_RELEASE_BLOCKED"
+            and load_report("hardware/procurement/generated/procurement_report.json")["status"]
+            == "ORDER_RELEASE_BLOCKED"
+            and load_report("hardware/qa/generated/qa_report.json")["physical_results"] == "NOT_EXECUTED"
+            and load_report("hardware/validation/generated/validation_report.json")["physical_results"]
+            == "NOT_EXECUTED"
+        ),
+    }
+    blockers = [row["gate_id"] for row in rows if row["release_blocker"] == "yes" and row["status"] != "PASS"]
+    report = {
+        "package": "hardware-release-readiness",
+        "checks": report_checks,
+        "pass": all(report_checks.values()),
+        "gate_count": len(rows),
+        "blocker_count": len(blockers),
+        "blockers": blockers,
+        "status": "RELEASE_BLOCKED" if blockers else "RELEASE_READY_FOR_SIGNOFF",
+        "note": (
+            "PASS means repository evidence is present; it never substitutes for "
+            "external physical or commercial evidence."
+        ),
+    }
+    output = PACKAGE / "generated" / "release_readiness_report.json"
+    output.parent.mkdir(exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+if __name__ == "__main__":
+    result = validate()
+    print(json.dumps(result, indent=2, sort_keys=True))
+    raise SystemExit(0 if result["pass"] else 1)

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -1,45 +1,46 @@
 """K1-K10 integration test"""
-import sys
-from pathlib import Path
-import tempfile
+
 import json
+import sys
+import tempfile
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from workbench.kernel.schema_compiler import SchemaCompiler
 from workbench.kernel.communication import Message
 from workbench.kernel.event_store import EventStore
 from workbench.kernel.lifecycle import LifecycleManager
+from workbench.kernel.schema_compiler import SchemaCompiler
 from workbench.kernel.startup import SystemBootstrapper
+
 
 def test_all():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
-        
+
         # K1-K2: Schema compiler
         schema_dir = tmp_path / "schemas"
         schema_dir.mkdir()
-        (schema_dir / "action.schema.json").write_text(json.dumps({
-            "title": "action",
-            "properties": {"id": {"type": "string"}},
-        }))
-        
+        (schema_dir / "action.schema.json").write_text(
+            json.dumps(
+                {
+                    "title": "action",
+                    "properties": {"id": {"type": "string"}},
+                }
+            )
+        )
+
         compiler = SchemaCompiler(schema_dir)
         compiler.load_schemas()
         output_dir = tmp_path / "output"
         compiler.compile_all(output_dir / "py", output_dir / "ts")
         print("[PASS] K1-K2 Schema compiler")
-        
+
         # K4-K5: Communication
-        msg = Message(
-            payload={"action": "grasp"},
-            message_type="action",
-            version="1.0.0",
-            actor="planner"
-        )
+        msg = Message(payload={"action": "grasp"}, message_type="action", version="1.0.0", actor="planner")
         assert msg.checksum
         print("[PASS] K4-K5 Communication")
-        
+
         # K6-K7: Event Store
         log = tmp_path / "events.jsonl"
         store = EventStore(log)
@@ -51,23 +52,24 @@ def test_all():
         assert len(replayed) == 10
         assert store.verify_integrity()
         print("[PASS] K6-K7 Event Store")
-        
+
         # K8: Lifecycle
         manager = LifecycleManager()
-        node = manager.create_node("kernel")
+        manager.create_node("kernel")
         assert manager.startup_sequence()
         states = manager.get_all_states()
         assert states["kernel"] == "active"
         print("[PASS] K8 Lifecycle")
-        
+
         # K9-K10: Bootstrap
         bootstrapper = SystemBootstrapper(tmp_path / "config")
         assert bootstrapper.bootstrap()
         print("[PASS] K9-K10 Bootstrap")
-        
-        print("\n" + "="*50)
+
+        print("\n" + "=" * 50)
         print("[SUCCESS] K1-K10 all tests passed")
-        print("="*50)
+        print("=" * 50)
+
 
 if __name__ == "__main__":
     test_all()

--- a/libs/kernel/workbench/kernel/communication.py
+++ b/libs/kernel/workbench/kernel/communication.py
@@ -1,22 +1,23 @@
 """K4-K5: 通信层和版本检查"""
-import json
+
 import hashlib
-import uuid
+import json
 from dataclasses import dataclass
-from typing import Dict, Any
+from typing import Any
+
 
 @dataclass
 class Message:
-    payload: Dict[str, Any]
+    payload: dict[str, Any]
     message_type: str
     version: str
     actor: str
-    
+
     @property
     def checksum(self):
         content = json.dumps(self.payload, sort_keys=True)
         return hashlib.sha256(content.encode()).hexdigest()[:16]
-    
+
     def to_dict(self):
         return {
             **self.payload,
@@ -25,20 +26,22 @@ class Message:
             "_actor": self.actor,
         }
 
+
 class VersionValidator:
     def __init__(self, compatible_versions):
         self.compatible_versions = compatible_versions
-    
+
     def validate(self, message: Message) -> bool:
         if message.message_type not in self.compatible_versions:
             return False
         return message.version in self.compatible_versions[message.message_type]
 
+
 class CommunicationBroker:
     def __init__(self, version_registry):
         self.version_registry = version_registry
         self.message_log = []
-    
+
     def publish(self, payload, message_type, version, actor):
         msg = Message(payload, message_type, version, actor)
         self.message_log.append(msg)

--- a/libs/kernel/workbench/kernel/event_store.py
+++ b/libs/kernel/workbench/kernel/event_store.py
@@ -1,7 +1,9 @@
 """K6-K7: Event Store"""
+
 import json
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Any
+
 
 class EventStore:
     def __init__(self, log_file: Path):
@@ -9,40 +11,40 @@ class EventStore:
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
         self.events = []
         self.checkpoints = []
-    
-    def append(self, event: Dict[str, Any]):
+
+    def append(self, event: dict[str, Any]):
         with open(self.log_file, "a") as f:
             f.write(json.dumps(event) + "\n")
         self.events.append(event)
-    
+
     def create_checkpoint(self):
         checkpoint_id = len(self.events)
         self.checkpoints.append(checkpoint_id)
         return checkpoint_id
-    
-    def replay(self, from_checkpoint: Optional[int] = None):
+
+    def replay(self, from_checkpoint: int | None = None):
         if not self.log_file.exists():
             return []
-        
+
         with open(self.log_file) as f:
             lines = f.readlines()
-        
+
         start_idx = from_checkpoint or 0
         replayed = []
         for line in lines[start_idx:]:
             if line.strip():
                 replayed.append(json.loads(line))
         return replayed
-    
+
     def verify_integrity(self):
         if not self.log_file.exists():
             return True
-        
+
         with open(self.log_file) as f:
             for line in f:
                 if line.strip():
                     try:
                         json.loads(line)
-                    except:
+                    except json.JSONDecodeError:
                         return False
         return True

--- a/libs/kernel/workbench/kernel/lifecycle.py
+++ b/libs/kernel/workbench/kernel/lifecycle.py
@@ -1,5 +1,7 @@
 """K8: ROS 2 Lifecycle 状态机"""
+
 from enum import Enum
+
 
 class LifecycleState(Enum):
     CREATED = "created"
@@ -8,35 +10,37 @@ class LifecycleState(Enum):
     DEACTIVATED = "deactivated"
     FINALIZED = "finalized"
 
+
 class LifecycleNode:
     def __init__(self, node_name: str):
         self.node_name = node_name
         self.state = LifecycleState.CREATED
-    
+
     def configure(self):
         if self.state == LifecycleState.CREATED:
             self.state = LifecycleState.CONFIGURED
             return True
         return False
-    
+
     def activate(self):
         if self.state == LifecycleState.CONFIGURED:
             self.state = LifecycleState.ACTIVE
             return True
         return False
-    
+
     def get_state(self):
         return self.state
+
 
 class LifecycleManager:
     def __init__(self):
         self.nodes = {}
-    
+
     def create_node(self, node_name):
         node = LifecycleNode(node_name)
         self.nodes[node_name] = node
         return node
-    
+
     def startup_sequence(self):
         for node in self.nodes.values():
             if not node.configure():
@@ -44,6 +48,6 @@ class LifecycleManager:
             if not node.activate():
                 return False
         return True
-    
+
     def get_all_states(self):
         return {name: node.get_state().value for name, node in self.nodes.items()}

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+
 
 class SchemaCompiler:
     """JSON Schema 编译器 - 生成类型安全的模型"""
@@ -24,7 +24,7 @@ class SchemaCompiler:
         output_py.mkdir(parents=True, exist_ok=True)
         output_ts.mkdir(parents=True, exist_ok=True)
 
-        for name, schema in self.schemas.items():
+        for name, _schema in self.schemas.items():
             # Python
             py_code = f"# {name}\nclass {name.title()}(BaseModel):\n    pass\n"
             (output_py / f"{name}.py").write_text(py_code)

--- a/libs/kernel/workbench/kernel/startup.py
+++ b/libs/kernel/workbench/kernel/startup.py
@@ -1,6 +1,7 @@
 """K9-K10: 启动脚本和检查清单"""
+
 from pathlib import Path
-from typing import Dict, Any
+
 
 class StartupChecklist:
     def __init__(self):
@@ -16,15 +17,16 @@ class StartupChecklist:
             "config_loaded": True,
             "memory_available": True,
         }
-    
+
     def verify_all(self, config):
         return all(self.checks.values())
+
 
 class SystemBootstrapper:
     def __init__(self, config_dir: Path):
         self.config_dir = config_dir
         self.config = {}
-    
+
     def load_config(self):
         self.config = {
             "schemas": ["action", "state", "result"],
@@ -32,7 +34,7 @@ class SystemBootstrapper:
             "version": "1.0.0",
         }
         return True
-    
+
     def bootstrap(self):
         if not self.load_config():
             return False

--- a/libs/kernel/workbench/kernel/version_registry.py
+++ b/libs/kernel/workbench/kernel/version_registry.py
@@ -1,12 +1,13 @@
 """K3: 版本注册表"""
-import yaml
+
 from pathlib import Path
+
 
 class VersionRegistry:
     def __init__(self, registry_file: Path):
         self.registry_file = registry_file
         self.versions = {}
-    
+
     def register_schema(self, name: str, version: str, content):
         if name not in self.versions:
             self.versions[name] = {}

--- a/tests/hardware/test_engineering_packages.py
+++ b/tests/hardware/test_engineering_packages.py
@@ -208,6 +208,17 @@ class ValidationPackageTests(unittest.TestCase):
         self.assertEqual(report["physical_results"], "NOT_EXECUTED")
 
 
+class ReleaseReadinessTests(unittest.TestCase):
+    def test_release_register_is_fail_closed_and_cross_package(self) -> None:
+        module = load_module("release_readiness_checks", ROOT / "hardware/release/tools/check_release_readiness.py")
+        report = module.validate()
+        self.assertTrue(report["pass"])
+        self.assertEqual(report["status"], "RELEASE_BLOCKED")
+        self.assertGreaterEqual(report["blocker_count"], 10)
+        self.assertIn("REL-004", report["blockers"])
+        self.assertIn("REL-014", report["blockers"])
+
+
 class TaskPacketTests(unittest.TestCase):
     def test_task_packet_limits_writes_to_hardware_and_tests(self) -> None:
         packet = json.loads(
@@ -227,6 +238,14 @@ class TaskPacketTests(unittest.TestCase):
         self.assertIn("hardware/qa/**", packet["allowed_paths"])
         self.assertIn("hardware/validation/**", packet["allowed_paths"])
         self.assertIn("firmware/**", packet["forbidden"])
+
+    def test_release_readiness_packet_is_bounded(self) -> None:
+        packet = json.loads(
+            (ROOT / "docs/task_packets/hardware-engineering-release-readiness.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(packet["issues"], [19, 22, 23, 24, 28])
+        self.assertIn("hardware/release/**", packet["allowed_paths"])
+        self.assertIn("interfaces/**", packet["forbidden"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Adds the final repository-side release gate for the hardware engineering package (#19/#22/#23/#24/#28).

- Adds a controlled cross-package evidence register covering engineering, procurement, safety, manufacturing, quality, compliance, first-batch, field, reliability, and final GO/NO-GO gates.
- Adds deterministic `hardware/release/tools/check_release_readiness.py` validation. It verifies every evidence reference exists, enforces controlled statuses, and prevents `NOT_EXECUTED` or `ORDER_RELEASE_BLOCKED` upstream reports from being promoted to release-ready.
- Adds a Task Packet and hardware regression tests.
- Keeps the current truth explicit: 3 repository engineering gates pass; 12 external evidence gates remain blocked.

## Verification

- `python hardware/release/tools/check_release_readiness.py`
- `python -m unittest discover -s tests/hardware -v` (22 passed)
- `python -m unittest discover -s tests -p "test_*.py" -v` (26 passed)
- Task Packet, contract, scenario, context, Ruff and format checks passed

## External evidence still required

Dated supplier quotes/AVL, physical PCB bring-up, safety sign-off, pilot builds, QA execution, compliance reports, ten-unit acceptance, 20 fault-injection runs, and the 48-hour reliability run remain explicit release blockers. This PR does not fabricate those records.