### PR TITLE
fix(kernel): generate valid schema models

### DIFF
--- a/docs/task_packets/kernel-schema-compiler-correctness.json
+++ b/docs/task_packets/kernel-schema-compiler-correctness.json
@@ -1,0 +1,41 @@
+{
+  "issue": "kernel-schema-compiler-correctness",
+  "human_owner": "Quchaosheng",
+  "objective": "Generate syntactically valid and minimally typed Python and TypeScript models from object-shaped JSON Schema files.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/schema_compiler.py",
+    "libs/kernel/tests/test_k1_k10.py",
+    "tests/unit/test_kernel_schema_compiler.py",
+    "docs/task_packets/kernel-schema-compiler-correctness.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "schema suffixes do not leak into generated identifiers",
+    "generated Python compiles and produces an instantiable Pydantic model",
+    "generated TypeScript has a valid interface declaration and typed fields",
+    "repository lint and tests pass"
+  ],
+  "commands": [
+    "python libs/kernel/tests/test_k1_k10.py",
+    "python -m ruff check libs/kernel",
+    "python -m pytest tests/ -q"
+  ],
+  "evidence": [
+    "generated-model compile and instantiation assertions",
+    "K1-K10 integration test output",
+    "repository test output"
+  ],
+  "stop_conditions": [
+    "interface schema changes are required",
+    "generated models would replace the canonical contracts package",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -5,6 +5,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from pydantic import BaseModel
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from workbench.kernel.communication import Message
@@ -24,16 +26,36 @@ def test_all():
         (schema_dir / "action.schema.json").write_text(
             json.dumps(
                 {
-                    "title": "action",
-                    "properties": {"id": {"type": "string"}},
+                    "title": "Action",
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "retry_count": {"type": "integer"},
+                    },
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         compiler = SchemaCompiler(schema_dir)
         compiler.load_schemas()
         output_dir = tmp_path / "output"
         compiler.compile_all(output_dir / "py", output_dir / "ts")
+        python_model = output_dir / "py" / "action.py"
+        typescript_model = output_dir / "ts" / "action.ts"
+        namespace = {}
+        exec(compile(python_model.read_text(encoding="utf-8"), str(python_model), "exec"), namespace)
+        action_model = namespace["Action"]
+        assert issubclass(action_model, BaseModel)
+        assert action_model(id="act-001").id == "act-001"
+        assert action_model.model_fields["id"].is_required()
+        assert action_model(id="act-001", retry_count=2).retry_count == 2
+        typescript = typescript_model.read_text(encoding="utf-8")
+        assert "export interface Action {" in typescript
+        assert '"id": string;' in typescript
+        assert '"retry_count"?: number;' in typescript
+        assert compiler.verify_type_compatibility() == {"action": True}
         print("[PASS] K1-K2 Schema compiler")
 
         # K4-K5: Communication

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -1,45 +1,140 @@
-"""K1-K2: JSON Schema → TypeScript + Python Model Compiler"""
+"""K1-K2: compile object-shaped JSON Schemas to Python and TypeScript models."""
 
 import json
+import keyword
+import re
 from pathlib import Path
+from typing import Any
+
+SCHEMA_SUFFIX = ".schema.json"
+
+
+def _model_name(value: str) -> str:
+    if value.isidentifier() and not keyword.iskeyword(value):
+        return value
+    parts = [part for part in re.split(r"[^A-Za-z0-9]+", value) if part]
+    candidate = "".join(part[:1].upper() + part[1:] for part in parts)
+    if not candidate or not candidate.isidentifier() or keyword.iskeyword(candidate):
+        raise ValueError(f"schema cannot produce a valid model name: {value!r}")
+    return candidate
+
+
+def _python_type(definition: dict[str, Any]) -> str:
+    if "enum" in definition:
+        values = ", ".join(repr(value) for value in definition["enum"])
+        return f"Literal[{values}]"
+    schema_type = definition.get("type")
+    if isinstance(schema_type, list):
+        types = [_python_type({"type": item}) for item in schema_type]
+        return " | ".join(dict.fromkeys(types))
+    if "$ref" in definition:
+        return "dict[str, Any]"
+    if schema_type == "string":
+        return "str"
+    if schema_type == "integer":
+        return "int"
+    if schema_type == "number":
+        return "float"
+    if schema_type == "boolean":
+        return "bool"
+    if schema_type == "array":
+        items = definition.get("items")
+        item_type = _python_type(items) if isinstance(items, dict) else "Any"
+        return f"list[{item_type}]"
+    if schema_type == "null":
+        return "None"
+    if schema_type == "object" or "properties" in definition:
+        return "dict[str, Any]"
+    return "Any"
+
+
+def _typescript_type(definition: dict[str, Any]) -> str:
+    if "enum" in definition:
+        return " | ".join(json.dumps(value) for value in definition["enum"])
+    schema_type = definition.get("type")
+    if isinstance(schema_type, list):
+        types = [_typescript_type({"type": item}) for item in schema_type]
+        return " | ".join(dict.fromkeys(types))
+    if schema_type == "string":
+        return "string"
+    if schema_type in {"integer", "number"}:
+        return "number"
+    if schema_type == "boolean":
+        return "boolean"
+    if schema_type == "array":
+        items = definition.get("items")
+        item_type = _typescript_type(items) if isinstance(items, dict) else "unknown"
+        return f"Array<{item_type}>"
+    if schema_type == "null":
+        return "null"
+    if schema_type == "object" or "properties" in definition:
+        return "Record<string, unknown>"
+    return "unknown"
 
 
 class SchemaCompiler:
-    """JSON Schema 编译器 - 生成类型安全的模型"""
+    """Generate importable Pydantic models and valid TypeScript interfaces."""
 
     def __init__(self, schemas_dir: Path):
         self.schemas_dir = schemas_dir
+        self.schemas: dict[str, dict[str, Any]] = {}
+
+    def load_schemas(self) -> None:
         self.schemas = {}
-        self.py_models = {}
-        self.ts_models = {}
+        for schema_file in sorted(self.schemas_dir.glob(f"*{SCHEMA_SUFFIX}")):
+            name = schema_file.name.removesuffix(SCHEMA_SUFFIX)
+            with schema_file.open(encoding="utf-8") as handle:
+                schema = json.load(handle)
+            if not isinstance(schema, dict):
+                raise ValueError(f"schema root must be an object: {schema_file.name}")
+            self.schemas[name] = schema
 
-    def load_schemas(self):
-        """加载所有 JSON schema"""
-        for schema_file in self.schemas_dir.glob("*.schema.json"):
-            with open(schema_file) as f:
-                self.schemas[schema_file.stem] = json.load(f)
-
-    def compile_all(self, output_py: Path, output_ts: Path):
-        """编译所有 schema 到 TS + Py"""
+    def compile_all(self, output_py: Path, output_ts: Path) -> None:
         output_py.mkdir(parents=True, exist_ok=True)
         output_ts.mkdir(parents=True, exist_ok=True)
 
-        for name, _schema in self.schemas.items():
-            # Python
-            py_code = f"# {name}\nclass {name.title()}(BaseModel):\n    pass\n"
-            (output_py / f"{name}.py").write_text(py_code)
+        for name, schema in self.schemas.items():
+            model_name = _model_name(schema.get("title", name))
+            properties = schema.get("properties", {})
+            if schema.get("type") != "object" or not isinstance(properties, dict):
+                raise ValueError(f"schema must describe an object: {name}")
+            required = set(schema.get("required", []))
 
-            # TypeScript
-            ts_code = f"export interface {name.title()} {{}}\n"
-            (output_ts / f"{name}.ts").write_text(ts_code)
+            python_fields = []
+            typescript_fields = []
+            for field_name, definition in properties.items():
+                if not isinstance(definition, dict):
+                    raise ValueError(f"property definition must be an object: {name}.{field_name}")
+                if not field_name.isidentifier() or keyword.iskeyword(field_name):
+                    raise ValueError(f"property cannot produce a Python field: {name}.{field_name}")
+                python_annotation = _python_type(definition)
+                optional = field_name not in required
+                if optional and "None" not in python_annotation.split(" | "):
+                    python_annotation += " | None"
+                default = "" if not optional else " = None"
+                python_fields.append(f"    {field_name}: {python_annotation}{default}")
+                marker = "" if not optional else "?"
+                typescript_fields.append(f"  {json.dumps(field_name)}{marker}: {_typescript_type(definition)};")
 
-    def verify_type_compatibility(self):
-        """验证 TS vs Py 兼容"""
-        return {name: True for name in self.schemas}
+            python_body = "\n".join(python_fields) or "    pass"
+            python_code = (
+                "from typing import Any, Literal\n\n"
+                "from pydantic import BaseModel\n\n\n"
+                f"class {model_name}(BaseModel):\n{python_body}\n"
+            )
+            typescript_body = "\n".join(typescript_fields)
+            typescript_code = f"export interface {model_name} {{\n{typescript_body}\n}}\n"
+            (output_py / f"{name}.py").write_text(python_code, encoding="utf-8")
+            (output_ts / f"{name}.ts").write_text(typescript_code, encoding="utf-8")
+
+    def verify_type_compatibility(self) -> dict[str, bool]:
+        return {
+            name: schema.get("type") == "object" and isinstance(schema.get("properties", {}), dict)
+            for name, schema in self.schemas.items()
+        }
 
 
 def compile_schemas(schemas_dir: Path, output_dir: Path) -> bool:
-    """一键编译"""
     compiler = SchemaCompiler(schemas_dir)
     compiler.load_schemas()
     compiler.compile_all(output_dir / "python_models", output_dir / "typescript_models")

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+from pydantic import BaseModel
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "kernel"))
+
+from workbench.kernel.schema_compiler import SchemaCompiler
+
+
+def test_generated_models_are_valid_and_typed(tmp_path: Path) -> None:
+    compiler = SchemaCompiler(ROOT / "interfaces" / "json_schema")
+    compiler.load_schemas()
+
+    python_dir = tmp_path / "python"
+    typescript_dir = tmp_path / "typescript"
+    compiler.compile_all(python_dir, typescript_dir)
+
+    generated = python_dir / "action_result.py"
+    namespace = {}
+    exec(compile(generated.read_text(encoding="utf-8"), str(generated), "exec"), namespace)
+    model = namespace["ActionResult"]
+    assert issubclass(model, BaseModel)
+    assert model.model_fields["action_id"].is_required()
+    assert not model.model_fields["error_code"].is_required()
+
+    typescript = (typescript_dir / "action_result.ts").read_text(encoding="utf-8")
+    assert "export interface ActionResult {" in typescript
+    assert '"action_id": string;' in typescript
+    assert '"error_code"?: number | null;' in typescript
+    assert all(compiler.verify_type_compatibility().values())


### PR DESCRIPTION
## Related Issue

Repository-wide health audit follow-up: kernel schema compiler correctness.

## What changed

- Strip the full `.schema.json` suffix before naming generated files.
- Generate valid Pydantic models and TypeScript interfaces for object schemas.
- Map required/optional fields and basic JSON Schema types.
- Fail closed on unsupported schema roots or invalid Python field identifiers.
- Add a root-level regression test so `make test` exercises generated artifacts.

## Interfaces affected

None. `interfaces/**` is read-only in this change; the existing 11 schemas are used as fixtures.

## Tests and commands

- `python libs/kernel/tests/test_k1_k10.py`
- `python -m pytest tests/ -q` (52 passed)
- `python -m ruff check .`
- `python -m ruff format --check .`
- contract, scenario, golden-set, context, and offline demo checks
- generated and imported Python models for all 11 repository schemas

## Evidence

Before this fix, `action.schema.json` generated `class Action.Schema(BaseModel)`, which is invalid Python, and `export interface Action.Schema`, which is invalid TypeScript. The regression test now compiles and executes the generated Python model and verifies TypeScript declarations.

## Risks and rollback

The compiler remains intentionally limited to object-shaped schemas and basic field types. Canonical Pydantic contracts remain in `libs/contracts`; generated output does not replace them. Revert commit `c2c46e8` to roll back.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I did not change interface schemas.
- [x] I did not add secrets, private data or unreviewed assets.
