### PR TITLE
fix(kernel): preserve event checkpoints across restarts

### DIFF
--- a/docs/task_packets/kernel-event-store-checkpoints.json
+++ b/docs/task_packets/kernel-event-store-checkpoints.json
@@ -1,0 +1,44 @@
+{
+  "issue": "kernel-event-store-checkpoints",
+  "human_owner": "Quchaosheng",
+  "objective": "Keep append-only event checkpoints correct across process restarts and reject unsafe replay boundaries.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/event_store.py",
+    "libs/kernel/tests/test_k1_k10.py",
+    "tests/unit/test_kernel_event_store.py",
+    "docs/task_packets/kernel-event-store-checkpoints.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "a checkpoint created after reopening a log equals the persisted event count",
+    "replay from the current checkpoint returns no historical events",
+    "negative, boolean, and out-of-range checkpoints are rejected",
+    "malformed and non-object log records fail closed",
+    "repository lint and tests pass"
+  ],
+  "commands": [
+    "python libs/kernel/tests/test_k1_k10.py",
+    "python -m pytest tests/unit/test_kernel_event_store.py -q",
+    "python -m ruff check .",
+    "python -m pytest tests/ -q"
+  ],
+  "evidence": [
+    "restart checkpoint regression assertions",
+    "corrupt-log failure assertions",
+    "K1-K10 integration test output",
+    "repository test output"
+  ],
+  "stop_conditions": [
+    "event schema changes are required",
+    "cross-process locking is required",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -73,6 +73,11 @@ def test_all():
         replayed = store.replay(from_checkpoint=0)
         assert len(replayed) == 10
         assert store.verify_integrity()
+        reopened = EventStore(log)
+        reopened.append({"id": 10})
+        restart_checkpoint = reopened.create_checkpoint()
+        assert restart_checkpoint == 11
+        assert reopened.replay(from_checkpoint=restart_checkpoint) == []
         print("[PASS] K6-K7 Event Store")
 
         # K8: Lifecycle

--- a/libs/kernel/workbench/kernel/event_store.py
+++ b/libs/kernel/workbench/kernel/event_store.py
@@ -1,50 +1,76 @@
 """K6-K7: Event Store"""
 
 import json
+import threading
 from pathlib import Path
 from typing import Any
+
+
+class EventStoreError(ValueError):
+    """Raised when the persisted event log cannot be replayed safely."""
 
 
 class EventStore:
     def __init__(self, log_file: Path):
         self.log_file = log_file
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
-        self.events = []
-        self.checkpoints = []
+        self.events: list[dict[str, Any]] = []
+        self.checkpoints: list[int] = []
+        self._lock = threading.RLock()
 
-    def append(self, event: dict[str, Any]):
-        with open(self.log_file, "a") as f:
-            f.write(json.dumps(event) + "\n")
-        self.events.append(event)
-
-    def create_checkpoint(self):
-        checkpoint_id = len(self.events)
-        self.checkpoints.append(checkpoint_id)
-        return checkpoint_id
-
-    def replay(self, from_checkpoint: int | None = None):
+    def _read_events(self) -> list[dict[str, Any]]:
         if not self.log_file.exists():
             return []
-
-        with open(self.log_file) as f:
-            lines = f.readlines()
-
-        start_idx = from_checkpoint or 0
-        replayed = []
-        for line in lines[start_idx:]:
-            if line.strip():
-                replayed.append(json.loads(line))
-        return replayed
-
-    def verify_integrity(self):
-        if not self.log_file.exists():
-            return True
-
-        with open(self.log_file) as f:
-            for line in f:
-                if line.strip():
+        events = []
+        try:
+            with self.log_file.open(encoding="utf-8") as handle:
+                for line_number, line in enumerate(handle, start=1):
+                    if not line.strip():
+                        continue
                     try:
-                        json.loads(line)
-                    except json.JSONDecodeError:
-                        return False
-        return True
+                        event = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise EventStoreError(f"invalid event JSON at line {line_number}") from exc
+                    if not isinstance(event, dict):
+                        raise EventStoreError(f"event at line {line_number} must be an object")
+                    events.append(event)
+        except (OSError, UnicodeError) as exc:
+            raise EventStoreError(f"event log is unavailable or not UTF-8: {self.log_file}") from exc
+        return events
+
+    def append(self, event: dict[str, Any]) -> None:
+        if not isinstance(event, dict):
+            raise TypeError("event must be an object")
+        serialized = json.dumps(event, ensure_ascii=False)
+        persisted_event = json.loads(serialized)
+        with self._lock:
+            events = self._read_events()
+            try:
+                with self.log_file.open("a", encoding="utf-8", newline="\n") as handle:
+                    handle.write(serialized + "\n")
+            except OSError as exc:
+                raise EventStoreError(f"event log could not be appended: {self.log_file}") from exc
+            self.events = [*events, persisted_event]
+
+    def create_checkpoint(self) -> int:
+        with self._lock:
+            self.events = self._read_events()
+            checkpoint_id = len(self.events)
+            self.checkpoints.append(checkpoint_id)
+            return checkpoint_id
+
+    def replay(self, from_checkpoint: int | None = None) -> list[dict[str, Any]]:
+        with self._lock:
+            self.events = self._read_events()
+            start_index = 0 if from_checkpoint is None else from_checkpoint
+            if type(start_index) is not int or not 0 <= start_index <= len(self.events):
+                raise ValueError(f"checkpoint must be between 0 and {len(self.events)}")
+            return self.events[start_index:]
+
+    def verify_integrity(self) -> bool:
+        with self._lock:
+            try:
+                self._read_events()
+            except EventStoreError:
+                return False
+            return True

--- a/tests/unit/test_kernel_event_store.py
+++ b/tests/unit/test_kernel_event_store.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "kernel"))
+
+from workbench.kernel.event_store import EventStore, EventStoreError
+
+
+def test_checkpoint_counts_persisted_events_after_restart(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    first = EventStore(log)
+    for event_id in range(3):
+        first.append({"id": event_id})
+
+    reopened = EventStore(log)
+    reopened.append({"id": 3})
+    checkpoint = reopened.create_checkpoint()
+
+    assert checkpoint == 4
+    assert reopened.replay(from_checkpoint=3) == [{"id": 3}]
+    assert reopened.replay(from_checkpoint=checkpoint) == []
+
+
+def test_replay_rejects_invalid_checkpoints(tmp_path: Path) -> None:
+    store = EventStore(tmp_path / "events.jsonl")
+    store.append({"id": 0})
+
+    for checkpoint in (-1, True, 2):
+        with pytest.raises(ValueError, match="checkpoint must be between"):
+            store.replay(from_checkpoint=checkpoint)
+
+
+def test_corrupt_or_non_object_events_fail_integrity_check(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    store = EventStore(log)
+
+    log.write_text('{"id": 0}\n{bad-json}\n', encoding="utf-8")
+    assert not store.verify_integrity()
+    with pytest.raises(EventStoreError, match="invalid event JSON"):
+        store.create_checkpoint()
+
+    log.write_text('{"id": 0}\n["not-an-object"]\n', encoding="utf-8")
+    assert not store.verify_integrity()
+
+
+def test_append_rejects_non_object_before_writing(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    store = EventStore(log)
+
+    with pytest.raises(TypeError, match="event must be an object"):
+        store.append(["not-an-object"])
+    assert not log.exists()


### PR DESCRIPTION
## Related Issue

Repository-wide health audit follow-up: persistent kernel event checkpoints.

## What changed

- Define checkpoints from the persisted event count instead of process-local appends.
- Refresh disk state before append, checkpoint creation, and replay.
- Reject negative, boolean, and out-of-range replay checkpoints.
- Fail closed on malformed, non-UTF-8, or non-object event records.
- Reject non-object events before writing and use explicit UTF-8 JSONL output.
- Add root-level restart and corruption regression tests.

## Interfaces affected

None. No schema or contract files changed.

## Tests and commands

- `python libs/kernel/tests/test_k1_k10.py`
- `python -m pytest tests/ -q` (56 passed)
- `python -m ruff check .`
- `python -m ruff format --check .`
- contract, scenario, golden-set, context, and offline demo checks

## Evidence

Before this fix, reopening a three-event log, appending one event, and creating a checkpoint returned `1`; replay from that checkpoint incorrectly returned three historical events. The same sequence now returns checkpoint `4` and an empty replay from that boundary.

## Risks and rollback

The in-process lock prevents threads sharing one store instance from interleaving operations. Cross-process locking is explicitly out of scope and recorded as a stop condition. Revert commit `84ae7f7` to roll back.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I did not change interface schemas.
- [x] I did not add secrets, private data or unreviewed assets.
