### PR TITLE
ci: pin GitHub Actions to immutable commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
           load: true

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Scripted fixtures exercise the 90-run pipeline only."
           echo "They are not Gazebo or release evidence."
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: always()
         with:
           name: nightly-scripted-pipeline

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -13,9 +13,9 @@ jobs:
   verify-build-publish:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
           cache: pip
@@ -26,16 +26,16 @@ jobs:
           python -m pip install -e ".[dev]"
           make check
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         id: metadata
         with:
           images: ghcr.io/${{ github.repository }}
@@ -43,7 +43,7 @@ jobs:
             type=ref,event=tag
             type=sha
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         id: build
         with:
           context: .
@@ -56,7 +56,7 @@ jobs:
       - name: Smoke-test image
         run: docker run --rm workbench-1:release-candidate python tools/scripts/local_runner.py --goal "Place the red block in the tray"
 
-      - uses: anchore/sbom-action@v0
+      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
           image: workbench-1:release-candidate
           format: spdx-json
@@ -74,7 +74,7 @@ jobs:
             fi
           done <<< "$IMAGE_TAGS"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: workbench-1-sbom
           path: workbench-1.spdx.json

--- a/docs/task_packets/github-actions-pinning.json
+++ b/docs/task_packets/github-actions-pinning.json
@@ -1,0 +1,42 @@
+{
+  "issue": "github-actions-pinning",
+  "human_owner": "Quchaosheng",
+  "objective": "Pin every third-party GitHub Action used by repository workflows to an immutable commit SHA while retaining a human-readable release comment.",
+  "allowed_paths": [
+    ".github/workflows/ci.yml",
+    ".github/workflows/nightly-regression.yml",
+    ".github/workflows/release-image.yml",
+    "docs/task_packets/github-actions-pinning.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**",
+    ".github/workflows/** outside the listed files"
+  ],
+  "acceptance": [
+    "all third-party uses references in the listed workflows are 40-character commit SHAs",
+    "each pinned action retains a version comment",
+    "workflow YAML remains parseable",
+    "repository lint and tests pass"
+  ],
+  "commands": [
+    "python -m pytest tests/ -q",
+    "python -m ruff check .",
+    "python -m ruff format --check ."
+  ],
+  "evidence": [
+    "workflow reference audit output",
+    "repository test output",
+    "Ruff output"
+  ],
+  "stop_conditions": [
+    "an action tag cannot be resolved to a commit",
+    "workflow behavior changes are required",
+    "robot-control or firmware changes are required"
+  ]
+}


### PR DESCRIPTION
## Related Issue

Repository-wide health audit follow-up: mutable GitHub Actions references in CI and release workflows.

## What changed

- Pin every third-party Action in the repository workflows to an immutable commit SHA.
- Keep the resolved release tag in a comment for review and controlled upgrades.
- Preserve the existing major versions for behavior stability.

## Interfaces affected

None. No runtime code, schemas, firmware, or hardware artifacts changed.

## Tests and commands

- Workflow reference audit: all `uses:` refs are 40-character SHAs.
- `python tools/scripts/check_task_packet.py docs/task_packets/github-actions-pinning.json`
- `python -m pytest tests/ -q` (56 passed)
- `python -m ruff check .`
- `python -m ruff format --check .`

## Evidence

Before this change, `ci.yml`, `nightly-regression.yml`, and `release-image.yml` used moving refs such as `@v3`, `@v6`, `@v4`, and `@v0`. These refs could change without a repository commit, including in the release publishing workflow.

## Risks and rollback

Action behavior remains on the same major lines and is pinned to the resolved current stable release commits. Revert commit `bc46bdf` to roll back.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered workflow reference behavior.
- [x] I did not add secrets, private data or unreviewed assets.
