### PR TITLE
fix(kernel): preserve envelope identity and lifecycle shutdown

### DIFF
--- a/docs/task_packets/kernel-envelope-lifecycle.json
+++ b/docs/task_packets/kernel-envelope-lifecycle.json
@@ -1,0 +1,45 @@
+{
+  "issue": "kernel-envelope-lifecycle",
+  "human_owner": "Quchaosheng",
+  "objective": "Preserve communication envelope identity and implement the declared lifecycle shutdown transitions without silent node replacement.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/communication.py",
+    "libs/kernel/workbench/kernel/lifecycle.py",
+    "libs/kernel/tests/test_k1_k10.py",
+    "tests/unit/test_kernel_envelope_lifecycle.py",
+    "docs/task_packets/kernel-envelope-lifecycle.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "serialized messages retain message_type",
+    "message checksums differ when envelope identity differs",
+    "active nodes can transition through deactivated to finalized",
+    "duplicate node creation is rejected",
+    "repository lint and tests pass"
+  ],
+  "commands": [
+    "python libs/kernel/tests/test_k1_k10.py",
+    "python -m pytest tests/unit/test_kernel_envelope_lifecycle.py -q",
+    "python -m ruff check .",
+    "python -m pytest tests/ -q"
+  ],
+  "evidence": [
+    "envelope identity regression assertions",
+    "lifecycle transition regression assertions",
+    "K1-K10 integration test output",
+    "repository test output"
+  ],
+  "stop_conditions": [
+    "interface schema changes are required",
+    "ROS 2 lifecycle integration is required",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -86,6 +86,9 @@ def test_all():
         assert manager.startup_sequence()
         states = manager.get_all_states()
         assert states["kernel"] == "active"
+        assert manager.nodes["kernel"].deactivate()
+        assert manager.nodes["kernel"].finalize()
+        assert manager.get_all_states()["kernel"] == "finalized"
         print("[PASS] K8 Lifecycle")
 
         # K9-K10: Bootstrap

--- a/libs/kernel/workbench/kernel/communication.py
+++ b/libs/kernel/workbench/kernel/communication.py
@@ -14,13 +14,20 @@ class Message:
     actor: str
 
     @property
-    def checksum(self):
-        content = json.dumps(self.payload, sort_keys=True)
-        return hashlib.sha256(content.encode()).hexdigest()[:16]
+    def checksum(self) -> str:
+        envelope = {
+            "actor": self.actor,
+            "message_type": self.message_type,
+            "payload": self.payload,
+            "version": self.version,
+        }
+        content = json.dumps(envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             **self.payload,
+            "_message_type": self.message_type,
             "_version": self.version,
             "_checksum": self.checksum,
             "_actor": self.actor,

--- a/libs/kernel/workbench/kernel/lifecycle.py
+++ b/libs/kernel/workbench/kernel/lifecycle.py
@@ -28,6 +28,18 @@ class LifecycleNode:
             return True
         return False
 
+    def deactivate(self):
+        if self.state == LifecycleState.ACTIVE:
+            self.state = LifecycleState.DEACTIVATED
+            return True
+        return False
+
+    def finalize(self):
+        if self.state == LifecycleState.DEACTIVATED:
+            self.state = LifecycleState.FINALIZED
+            return True
+        return False
+
     def get_state(self):
         return self.state
 
@@ -37,6 +49,8 @@ class LifecycleManager:
         self.nodes = {}
 
     def create_node(self, node_name):
+        if node_name in self.nodes:
+            raise ValueError(f"node already exists: {node_name}")
         node = LifecycleNode(node_name)
         self.nodes[node_name] = node
         return node

--- a/tests/unit/test_kernel_envelope_lifecycle.py
+++ b/tests/unit/test_kernel_envelope_lifecycle.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "kernel"))
+
+from workbench.kernel.communication import Message
+from workbench.kernel.lifecycle import LifecycleManager, LifecycleState
+
+
+def test_message_serialization_retains_type_and_checks_full_envelope() -> None:
+    grasp = Message({"target": "red_block"}, "grasp", "1.0.0", "planner")
+    place = Message({"target": "red_block"}, "place", "1.0.0", "planner")
+
+    encoded = grasp.to_dict()
+    assert encoded["_message_type"] == "grasp"
+    assert encoded["_version"] == "1.0.0"
+    assert encoded["_actor"] == "planner"
+    assert grasp.checksum != place.checksum
+
+
+def test_lifecycle_supports_shutdown_and_rejects_duplicate_nodes() -> None:
+    manager = LifecycleManager()
+    node = manager.create_node("kernel")
+    with pytest.raises(ValueError, match="node already exists"):
+        manager.create_node("kernel")
+
+    assert node.state is LifecycleState.CREATED
+    assert node.configure()
+    assert node.activate()
+    assert node.deactivate()
+    assert node.finalize()
+    assert not node.activate()
+    assert manager.get_all_states() == {"kernel": "finalized"}


### PR DESCRIPTION
## Related Issue

Repository-wide health audit follow-up: kernel communication envelope and lifecycle state behavior.

## What changed

- Include message type, version, actor, and payload in the message checksum.
- Preserve `_message_type` in serialized messages.
- Add ACTIVE -> DEACTIVATED -> FINALIZED lifecycle transitions.
- Reject duplicate node creation instead of silently replacing a live node.
- Add root-level regression tests for envelope identity and shutdown behavior.

## Interfaces affected

None. No schema, contract, firmware, hardware, or robot-control files changed.

## Tests and commands

- `python libs/kernel/tests/test_k1_k10.py`
- `python -m pytest tests/ -q` (58 passed)
- `python -m ruff check .`
- `python -m ruff format --check .`
- contract, scenario, golden-set, and context checks

## Evidence

Before this fix, `Message.to_dict()` omitted `message_type`, and two messages with identical payloads but different types produced the same checksum. The lifecycle enum declared shutdown states but had no transitions into them; duplicate names also overwrote existing nodes.

## Risks and rollback

This preserves existing startup transitions and only adds declared shutdown states. Revert commit `cf8e7cb` to roll back.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I did not add secrets, private data or unreviewed assets.
