### PR TITLE
fix(kernel): persist schema version registry

### DIFF
--- a/docs/task_packets/kernel-version-registry.json
+++ b/docs/task_packets/kernel-version-registry.json
@@ -1,0 +1,44 @@
+{
+  "issue": "kernel-version-registry",
+  "human_owner": "Quchaosheng",
+  "objective": "Persist schema versions durably and fail closed when the registry file is malformed or cannot be written.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/version_registry.py",
+    "libs/kernel/tests/test_k1_k10.py",
+    "tests/unit/test_kernel_version_registry.py",
+    "docs/task_packets/kernel-version-registry.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "registered versions survive a new registry instance",
+    "schema names and versions are validated",
+    "malformed registry content fails closed",
+    "failed persistence does not update in-memory state",
+    "repository lint and tests pass"
+  ],
+  "commands": [
+    "python libs/kernel/tests/test_k1_k10.py",
+    "python -m pytest tests/unit/test_kernel_version_registry.py -q",
+    "python -m ruff check .",
+    "python -m pytest tests/ -q"
+  ],
+  "evidence": [
+    "registry reopen regression assertions",
+    "malformed and failed-write assertions",
+    "K1-K10 integration test output",
+    "repository test output"
+  ],
+  "stop_conditions": [
+    "version registry format conflicts with an external consumer",
+    "interface schema changes are required",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -14,6 +14,7 @@ from workbench.kernel.event_store import EventStore
 from workbench.kernel.lifecycle import LifecycleManager
 from workbench.kernel.schema_compiler import SchemaCompiler
 from workbench.kernel.startup import SystemBootstrapper
+from workbench.kernel.version_registry import VersionRegistry
 
 
 def test_all():
@@ -62,6 +63,12 @@ def test_all():
         msg = Message(payload={"action": "grasp"}, message_type="action", version="1.0.0", actor="planner")
         assert msg.checksum
         print("[PASS] K4-K5 Communication")
+
+        # K3: Version registry
+        registry = VersionRegistry(tmp_path / "versions.json")
+        registry.register_schema("action", "1.0.0", {"type": "object"})
+        assert VersionRegistry(tmp_path / "versions.json").versions["action"]["1.0.0"]
+        print("[PASS] K3 Version registry")
 
         # K6-K7: Event Store
         log = tmp_path / "events.jsonl"

--- a/libs/kernel/workbench/kernel/version_registry.py
+++ b/libs/kernel/workbench/kernel/version_registry.py
@@ -1,14 +1,55 @@
-"""K3: 版本注册表"""
+"""K3: durable schema version registry."""
 
+import json
+import threading
 from pathlib import Path
+from typing import Any
+
+
+class VersionRegistryError(ValueError):
+    """Raised when a version registry cannot be loaded or written safely."""
 
 
 class VersionRegistry:
     def __init__(self, registry_file: Path):
         self.registry_file = registry_file
-        self.versions = {}
+        self.versions: dict[str, dict[str, Any]] = {}
+        self._lock = threading.RLock()
+        self._load()
 
-    def register_schema(self, name: str, version: str, content):
-        if name not in self.versions:
-            self.versions[name] = {}
-        self.versions[name][version] = content
+    def _load(self) -> None:
+        if not self.registry_file.exists():
+            return
+        try:
+            payload = json.loads(self.registry_file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise VersionRegistryError(f"registry is unavailable or invalid: {self.registry_file}") from exc
+        if not isinstance(payload, dict) or any(
+            not isinstance(name, str)
+            or not isinstance(versions, dict)
+            or any(not isinstance(version, str) for version in versions)
+            for name, versions in payload.items()
+        ):
+            raise VersionRegistryError(f"registry must map schema names to version maps: {self.registry_file}")
+        self.versions = payload
+
+    def _persist(self, versions: dict[str, dict[str, Any]]) -> None:
+        try:
+            self.registry_file.parent.mkdir(parents=True, exist_ok=True)
+            temporary = self.registry_file.with_name(f".{self.registry_file.name}.tmp")
+            serialized = json.dumps(versions, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+            temporary.write_text(serialized, encoding="utf-8")
+            temporary.replace(self.registry_file)
+        except (OSError, TypeError, ValueError) as exc:
+            raise VersionRegistryError(f"registry could not be persisted: {self.registry_file}") from exc
+
+    def register_schema(self, name: str, version: str, content: Any) -> None:
+        if not isinstance(name, str) or not name:
+            raise ValueError("schema name must be a non-empty string")
+        if not isinstance(version, str) or not version:
+            raise ValueError("schema version must be a non-empty string")
+        with self._lock:
+            updated = {schema: dict(versions) for schema, versions in self.versions.items()}
+            updated.setdefault(name, {})[version] = content
+            self._persist(updated)
+            self.versions = updated

--- a/tests/unit/test_kernel_version_registry.py
+++ b/tests/unit/test_kernel_version_registry.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "kernel"))
+
+from workbench.kernel.version_registry import VersionRegistry, VersionRegistryError
+
+
+def test_registry_survives_reopen_and_keeps_versions_separate(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    registry = VersionRegistry(path)
+    registry.register_schema("action", "1.0.0", {"type": "object"})
+    registry.register_schema("action", "1.1.0", {"type": "object", "required": ["id"]})
+    registry.register_schema("result", "1.0.0", {"type": "object"})
+
+    reopened = VersionRegistry(path)
+    assert reopened.versions == {
+        "action": {
+            "1.0.0": {"type": "object"},
+            "1.1.0": {"required": ["id"], "type": "object"},
+        },
+        "result": {"1.0.0": {"type": "object"}},
+    }
+
+
+def test_invalid_registry_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    path.write_text(json.dumps({"action": ["not-a-version-map"]}), encoding="utf-8")
+
+    with pytest.raises(VersionRegistryError, match="must map schema names"):
+        VersionRegistry(path)
+
+
+def test_unserializable_content_does_not_replace_in_memory_state(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    registry = VersionRegistry(path)
+    with pytest.raises(VersionRegistryError, match="could not be persisted"):
+        registry.register_schema("action", "1.0.0", {"bad": {1, 2}})
+    assert registry.versions == {}
+    assert not path.exists()


### PR DESCRIPTION
## Related Issue

Repository-wide health audit follow-up: K3 VersionRegistry persistence.

## What changed

- Load an existing registry file on startup.
- Persist registrations with UTF-8 JSON and atomic temp-file replacement.
- Validate schema/version identifiers and registry shape.
- Keep in-memory state unchanged when persistence fails.
- Add root-level restart, malformed-file, and failed-write regression tests.

## Interfaces affected

None. No schema, contract, firmware, hardware, or robot-control files changed.

## Tests and commands

- `python libs/kernel/tests/test_k1_k10.py`
- `python -m pytest tests/ -q` (61 passed)
- `python -m ruff check .`
- `python -m ruff format --check .`
- contract, scenario, golden-set, and context checks

## Evidence

Before this fix, `VersionRegistry` accepted a `registry_file` but never read or wrote it, so all registered schema versions disappeared on process restart. The regression test now registers three versions, reopens the registry, and verifies the complete persisted mapping.

## Risks and rollback

The JSON file format is a simple schema-name to version-map object and preserves the existing in-memory mapping shape. Revert commit `9322a44` to roll back.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I did not add secrets, private data or unreviewed assets.
