### PR TITLE
fix(kernel): honor startup configuration checks

### DIFF
--- a/docs/task_packets/kernel-startup-config.json
+++ b/docs/task_packets/kernel-startup-config.json
@@ -1,0 +1,43 @@
+{
+  "issue": "kernel-startup-config",
+  "human_owner": "Quchaosheng",
+  "objective": "Load optional kernel bootstrap configuration and make declared startup check failures block bootstrap deterministically.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/startup.py",
+    "libs/kernel/tests/test_k1_k10.py",
+    "tests/unit/test_kernel_startup_config.py",
+    "docs/task_packets/kernel-startup-config.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "missing bootstrap.json preserves the documented offline defaults",
+    "valid configured failed checks block bootstrap",
+    "malformed, incomplete, and unknown-check configurations fail closed",
+    "repository lint and tests pass"
+  ],
+  "commands": [
+    "python libs/kernel/tests/test_k1_k10.py",
+    "python -m pytest tests/unit/test_kernel_startup_config.py -q",
+    "python -m ruff check .",
+    "python -m pytest tests/ -q"
+  ],
+  "evidence": [
+    "default and configured bootstrap assertions",
+    "malformed configuration failure assertions",
+    "K1-K10 integration test output",
+    "repository test output"
+  ],
+  "stop_conditions": [
+    "runtime-specific disk, memory, node, or dependency probes are required",
+    "interface schema changes are required",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -101,6 +101,19 @@ def test_all():
         # K9-K10: Bootstrap
         bootstrapper = SystemBootstrapper(tmp_path / "config")
         assert bootstrapper.bootstrap()
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / "bootstrap.json").write_text(
+            json.dumps(
+                {
+                    "schemas": ["action"],
+                    "nodes": ["kernel"],
+                    "version": "1.0.0",
+                    "checks": {"event_store_ready": False},
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert not SystemBootstrapper(tmp_path / "config").bootstrap()
         print("[PASS] K9-K10 Bootstrap")
 
         print("\n" + "=" * 50)

--- a/libs/kernel/workbench/kernel/startup.py
+++ b/libs/kernel/workbench/kernel/startup.py
@@ -1,42 +1,97 @@
-"""K9-K10: 启动脚本和检查清单"""
+"""K9-K10: startup configuration and fail-closed readiness checks."""
 
+import json
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
+
+CHECK_NAMES = (
+    "schema_compatibility",
+    "version_middleware",
+    "disk_space",
+    "all_nodes_online",
+    "event_store_ready",
+    "lifecycle_configured",
+    "contracts_valid",
+    "dependencies_resolved",
+    "config_loaded",
+    "memory_available",
+)
+REQUIRED_CONFIG_KEYS = ("schemas", "nodes", "version")
+DEFAULT_CONFIG = {
+    "schemas": ["action", "state", "result"],
+    "nodes": ["kernel", "hardware", "sim"],
+    "version": "1.0.0",
+}
 
 
 class StartupChecklist:
-    def __init__(self):
-        self.checks = {
-            "schema_compatibility": True,
-            "version_middleware": True,
-            "disk_space": True,
-            "all_nodes_online": True,
-            "event_store_ready": True,
-            "lifecycle_configured": True,
-            "contracts_valid": True,
-            "dependencies_resolved": True,
-            "config_loaded": True,
-            "memory_available": True,
-        }
+    def __init__(self, checks: Mapping[str, bool] | None = None):
+        self.checks = {name: True for name in CHECK_NAMES}
+        if checks is not None:
+            self._validate_checks(checks)
+            self.checks.update(checks)
 
-    def verify_all(self, config):
-        return all(self.checks.values())
+    @staticmethod
+    def _validate_checks(checks: Mapping[str, Any]) -> bool:
+        unknown = set(checks) - set(CHECK_NAMES)
+        if unknown:
+            raise ValueError(f"unknown startup checks: {sorted(unknown)}")
+        if any(type(value) is not bool for value in checks.values()):
+            raise ValueError("startup check values must be boolean")
+        return True
+
+    def verify_all(self, config: Mapping[str, Any]) -> bool:
+        if not isinstance(config, Mapping):
+            return False
+        configured_checks = config.get("checks", {})
+        if not isinstance(configured_checks, Mapping):
+            return False
+        try:
+            self._validate_checks(configured_checks)
+        except ValueError:
+            return False
+        effective_checks = {**self.checks, **configured_checks}
+        return all(effective_checks.values())
 
 
 class SystemBootstrapper:
     def __init__(self, config_dir: Path):
-        self.config_dir = config_dir
-        self.config = {}
+        self.config_dir = Path(config_dir)
+        self.config: dict[str, Any] = {}
 
-    def load_config(self):
-        self.config = {
-            "schemas": ["action", "state", "result"],
-            "nodes": ["kernel", "hardware", "sim"],
-            "version": "1.0.0",
-        }
+    @staticmethod
+    def _valid_config(config: Any) -> bool:
+        if not isinstance(config, dict):
+            return False
+        if any(key not in config for key in REQUIRED_CONFIG_KEYS):
+            return False
+        if not isinstance(config["version"], str) or not config["version"]:
+            return False
+        if any(
+            not isinstance(config[key], list)
+            or not config[key]
+            or any(not isinstance(item, str) or not item for item in config[key])
+            for key in ("schemas", "nodes")
+        ):
+            return False
         return True
 
-    def bootstrap(self):
+    def load_config(self) -> bool:
+        config_path = self.config_dir / "bootstrap.json"
+        if not config_path.exists():
+            self.config = dict(DEFAULT_CONFIG)
+            return True
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return False
+        if not self._valid_config(config):
+            return False
+        self.config = config
+        return True
+
+    def bootstrap(self) -> bool:
         if not self.load_config():
             return False
-        checklist = StartupChecklist()
-        return checklist.verify_all(self.config)
+        return StartupChecklist().verify_all(self.config)

--- a/tests/unit/test_kernel_startup_config.py
+++ b/tests/unit/test_kernel_startup_config.py
@@ -1,0 +1,46 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "kernel"))
+
+from workbench.kernel.startup import SystemBootstrapper
+
+
+def write_config(root: Path, payload: object) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "bootstrap.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_missing_config_keeps_offline_defaults(tmp_path: Path) -> None:
+    bootstrapper = SystemBootstrapper(tmp_path / "missing")
+    assert bootstrapper.bootstrap()
+    assert bootstrapper.config["nodes"] == ["kernel", "hardware", "sim"]
+
+
+def test_configured_failed_check_blocks_bootstrap(tmp_path: Path) -> None:
+    write_config(
+        tmp_path,
+        {
+            "schemas": ["action"],
+            "nodes": ["kernel"],
+            "version": "1.0.0",
+            "checks": {"contracts_valid": False},
+        },
+    )
+    assert not SystemBootstrapper(tmp_path).bootstrap()
+
+
+def test_malformed_or_unsafe_config_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / "bootstrap.json").write_text("{bad-json}", encoding="utf-8")
+    assert not SystemBootstrapper(tmp_path).bootstrap()
+
+    write_config(
+        tmp_path,
+        {"schemas": ["action"], "nodes": ["kernel"], "version": "1.0.0", "checks": {"unknown": True}},
+    )
+    assert not SystemBootstrapper(tmp_path).bootstrap()
+
+    write_config(tmp_path, {"schemas": [], "nodes": ["kernel"], "version": "1.0.0"})
+    assert not SystemBootstrapper(tmp_path).bootstrap()


### PR DESCRIPTION
## Related Issue

Repository-wide health audit follow-up: K9-K10 startup configuration and readiness checks.

## What changed

- Load optional `bootstrap.json` from the configured directory.
- Preserve documented offline defaults when no file is present.
- Validate required config keys and non-empty string lists.
- Apply configured boolean readiness checks and fail closed on malformed or unknown checks.
- Add root-level regression tests for defaults, configured failures, malformed input, and incomplete input.

## Interfaces affected

None. No schema, contract, firmware, hardware, or robot-control files changed.

## Tests and commands

- `python libs/kernel/tests/test_k1_k10.py`
- `python -m pytest tests/ -q` (64 passed)
- `python -m ruff check .`
- `python -m ruff format --check .`
- contract, scenario, golden-set, context, and offline demo checks

## Evidence

Before this fix, `SystemBootstrapper` ignored `config_dir` and `StartupChecklist.verify_all()` always returned the hardcoded boolean set. A config that declared `event_store_ready: false` could not block bootstrap. The regression tests now prove that it does.

## Risks and rollback

This does not invent runtime probes for disk, memory, ROS nodes, or dependencies; those remain explicit integration inputs. Revert commit `08666dd` to roll back.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I did not add secrets, private data or unreviewed assets.
