### PR TITLE
fix: restore lint gate for production modules

### DIFF
--- a/docs/task_packets/production-optimization-lint.json
+++ b/docs/task_packets/production-optimization-lint.json
@@ -1,0 +1,40 @@
+{
+  "issue": "production-optimization-lint",
+  "human_owner": "Quchaosheng",
+  "objective": "Restore the repository Ruff gate after the production optimization modules landed, without changing their behavior.",
+  "allowed_paths": [
+    "libs/application/workbench/application/monitoring.py",
+    "libs/application/workbench/application/system_manager_v2.py",
+    "libs/hardware/workbench/hardware/can_driver_safe.py",
+    "docs/task_packets/production-optimization-lint.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "Ruff check and format gates pass",
+    "the repository test suite passes",
+    "no production behavior is changed"
+  ],
+  "commands": [
+    "python -m ruff check .",
+    "python -m ruff format --check .",
+    "python -m pytest tests/ -q"
+  ],
+  "evidence": [
+    "Ruff output",
+    "repository test output",
+    "scoped diff"
+  ],
+  "stop_conditions": [
+    "behavioral changes are required",
+    "interface schema changes are required",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/libs/application/workbench/application/monitoring.py
+++ b/libs/application/workbench/application/monitoring.py
@@ -1,27 +1,29 @@
 """Prometheus metrics"""
+
 import logging
-from typing import Dict
 
 logger = logging.getLogger("Monitoring")
 
+
 class SystemMetrics:
     """Prometheus-compatible metrics collection"""
+
     def __init__(self):
         self.counters = {}
         self.gauges = {}
         self.histograms = {}
-    
+
     def increment_counter(self, name: str, value: int = 1) -> None:
         self.counters[name] = self.counters.get(name, 0) + value
-    
+
     def set_gauge(self, name: str, value: float) -> None:
         self.gauges[name] = value
-    
+
     def record_histogram(self, name: str, value: float) -> None:
         if name not in self.histograms:
             self.histograms[name] = []
         self.histograms[name].append(value)
-    
+
     def export_prometheus(self) -> str:
         lines = []
         for name, value in self.counters.items():
@@ -29,5 +31,6 @@ class SystemMetrics:
         for name, value in self.gauges.items():
             lines.append(f"{name} {value}")
         return "\n".join(lines)
+
 
 system_metrics = SystemMetrics()

--- a/libs/application/workbench/application/system_manager_v2.py
+++ b/libs/application/workbench/application/system_manager_v2.py
@@ -1,10 +1,11 @@
 """APP1: Production system manager"""
-import threading
+
 import logging
-from typing import Dict, List, Callable
+import threading
 from enum import Enum
 
 logger = logging.getLogger("SystemManager")
+
 
 class ComponentState(Enum):
     CREATED = "created"
@@ -12,13 +13,15 @@ class ComponentState(Enum):
     ERROR = "error"
     STOPPED = "stopped"
 
+
 class SystemManager:
     """Thread-safe lifecycle management"""
+
     def __init__(self):
         self.components = {}
         self.lock = threading.RLock()
         self.state = "initialized"
-    
+
     def register(self, name: str, instance) -> bool:
         with self.lock:
             if name in self.components:
@@ -26,22 +29,22 @@ class SystemManager:
             self.components[name] = {"state": ComponentState.CREATED, "instance": instance}
             logger.info(f"Registered: {name}")
             return True
-    
+
     def startup(self) -> bool:
         with self.lock:
-            for name, comp in self.components.items():
-                if hasattr(comp["instance"], 'startup'):
+            for _name, comp in self.components.items():
+                if hasattr(comp["instance"], "startup"):
                     if not comp["instance"].startup():
                         return False
                 comp["state"] = ComponentState.RUNNING
             self.state = "running"
             logger.info("System started")
             return True
-    
+
     def shutdown(self) -> bool:
         with self.lock:
-            for name, comp in self.components.items():
-                if hasattr(comp["instance"], 'shutdown'):
+            for _name, comp in self.components.items():
+                if hasattr(comp["instance"], "shutdown"):
                     comp["instance"].shutdown()
                 comp["state"] = ComponentState.STOPPED
             self.state = "stopped"

--- a/libs/hardware/workbench/hardware/can_driver_safe.py
+++ b/libs/hardware/workbench/hardware/can_driver_safe.py
@@ -1,42 +1,44 @@
 """Thread-safe CAN driver with retry"""
-import threading
+
 import logging
-from typing import Dict, Callable, List
-from queue import Queue, Empty
-import time
+import threading
+from collections.abc import Callable
+from queue import Queue
 
 logger = logging.getLogger("CANBusSafe")
 
+
 class SafeCANBus:
     """Async CAN with retry and error recovery"""
+
     def __init__(self):
         self.subscribers = {}
         self.send_lock = threading.Lock()
         self.send_queue = Queue(maxsize=100)
         self.running = False
         self.error_count = 0
-    
+
     def send(self, message, timeout=1.0) -> bool:
         try:
             self.send_queue.put(message, timeout=timeout)
             return True
-        except:
+        except BaseException:  # noqa: BLE001 - preserve the existing fail-closed send boundary.
             self.error_count += 1
             return False
-    
+
     def receive(self, can_id: int, data: bytes) -> bool:
         for handler in self.subscribers.get(can_id, []):
             try:
                 handler({"can_id": can_id, "data": data})
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - isolate failures from subscriber callbacks.
                 logger.error(f"Handler error: {e}")
                 self.error_count += 1
         return True
-    
+
     def subscribe(self, can_id: int, handler: Callable) -> None:
         if can_id not in self.subscribers:
             self.subscribers[can_id] = []
         self.subscribers[can_id].append(handler)
-    
+
     def get_error_count(self) -> int:
         return self.error_count


### PR DESCRIPTION
## Related Issue

Restore the repository lint gate after `942c3c1` added production optimization modules directly to `main`.

## What changed

- Remove unused and deprecated typing imports.
- Normalize import ordering and modern typing forms.
- Preserve existing broad exception boundaries with explicit rationale comments.
- Rename unused loop variables.

No runtime behavior is intentionally changed.

## Tests and commands

- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest tests/ -q` (65 passed)
- `python tools/scripts/check_task_packet.py docs/task_packets/production-optimization-lint.json`

## Risks and rollback

Scoped to lint/format cleanup in the three production optimization modules. Revert commit `5439126` to roll back.
