### PR TITLE
fix(devops): keep SBOM generation least privileged

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -63,6 +63,8 @@ jobs:
           image: workbench-1:release-candidate
           format: spdx-json
           output-file: workbench-1.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
 
       - name: Publish tested image
         id: publish

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -47,6 +47,8 @@ image or network.
 
 `.github/workflows/release-image.yml` runs `make check`, builds and smoke-tests the image, and emits an SPDX JSON SBOM. Version tags publish to GHCR; manual workflow runs build and validate without creating a release tag.
 
+The SBOM action only writes the local SPDX file. A separate, pinned artifact step retains that file for provenance and review; it does not attach assets to a GitHub Release or require `contents: write`.
+
 Publishing still requires a human-owned version tag and repository permissions. The workflow does not make Go/No-Go decisions and cannot turn scripted evaluation data into release evidence.
 
 ## Windows without Make

--- a/docs/task_packets/devops-release-sbom-permissions.json
+++ b/docs/task_packets/devops-release-sbom-permissions.json
@@ -1,0 +1,43 @@
+{
+  "issue": 20,
+  "human_owner": "Quchaosheng",
+  "objective": "Keep tag-triggered SBOM generation least-privileged while retaining the SPDX artifact and provenance input.",
+  "allowed_paths": [
+    ".github/workflows/release-image.yml",
+    "tests/unit/test_release_workflow.py",
+    "docs/deployment/container.md",
+    "docs/task_packets/devops-release-sbom-permissions.json"
+  ],
+  "read_only_paths": [
+    "Dockerfile",
+    "tools/scripts/release_manifest.py"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "robot/control/**",
+    "firmware/**",
+    "hardware/safety/**"
+  ],
+  "acceptance": [
+    "release workflow retains contents read instead of granting contents write",
+    "SBOM generation does not attempt to attach assets to a GitHub Release",
+    "the generated SPDX file is retained by the explicit artifact step and remains the provenance manifest input",
+    "a deterministic regression test protects the permission boundary"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/devops-release-sbom-permissions.json",
+    "python -m pytest tests/unit/test_release_workflow.py -q",
+    "make check"
+  ],
+  "evidence": [
+    "Task Packet validation output",
+    "release workflow regression test output",
+    "full repository check output",
+    "GitHub Actions result from a human-owned tag or manual dispatch"
+  ],
+  "stop_conditions": [
+    "the fix requires contents write or release credentials",
+    "a new release or version tag is required",
+    "the SBOM cannot be generated without changing the runtime image"
+  ]
+}

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "release-image.yml"
+
+
+def _step_block(workflow: str, marker: str) -> str:
+    start = workflow.index(marker)
+    next_step = workflow.find("\n      - ", start + len(marker))
+    return workflow[start:] if next_step == -1 else workflow[start:next_step]
+
+
+def test_sbom_generation_keeps_release_workflow_least_privileged() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    permissions = workflow.split("jobs:", maxsplit=1)[0]
+    assert "contents: read" in permissions
+    assert "contents: write" not in permissions
+
+    sbom_step = _step_block(workflow, "uses: anchore/sbom-action@")
+    assert "upload-artifact: false" in sbom_step
+    assert "upload-release-assets: false" in sbom_step
+
+    artifact_step = _step_block(workflow, "uses: actions/upload-artifact@")
+    assert "name: workbench-1-sbom" in artifact_step
+    assert "path: workbench-1.spdx.json" in artifact_step


### PR DESCRIPTION
## Summary

- stop `anchore/sbom-action` from automatically attaching tag-build SBOMs to a GitHub Release
- retain the generated SPDX JSON through the existing pinned artifact step and provenance manifest
- add a regression test and bounded Task Packet for the least-privilege release boundary

## Why

The `v0.1.0` tag run completed checks, image build and smoke test, then failed with `Resource not accessible by integration` when the SBOM action used its default `upload-release-assets: true` behavior. Granting `contents: write` would expand the workflow token unnecessarily.

Failed run: https://github.com/Quchaosheng/workbench-desk-robot/actions/runs/31406815969

## Verification

Windows equivalents of `make check` plus docs build:

- `python -m ruff check .` - passed
- `python -m ruff format --check .` - 106 files formatted
- `python -m pytest tests/ -v` - 104 passed
- contract, scenario, golden-set, and context validators - passed
- scripted and offline demos - passed
- `python -m mkdocs build --strict` - passed
- Task Packet validator - passed

A future human-owned tag remains the required end-to-end release proof; this PR does not create a tag, Release, or publication.

Closes #20