### PR TITLE
feat(security): establish continuous audit baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /robot/control
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:15"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      motion-python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "37 18 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  codeql-python:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        with:
+          languages: python
+          build-mode: none
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        with:
+          category: /language:python
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
+        with:
+          fail-on-severity: high
+          retry-on-snapshot-warnings: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,44 @@
 # Security policy
 
-Do not report secrets or vulnerabilities in public Issues. Send a private report to the project owner. v0.1 must not expose ROS bridge, robot-control topics, model keys or private logs to a public dashboard.
+## Supported versions
+
+Security fixes target the default branch and the latest published release. Older releases are unsupported unless the project owner explicitly names a backport. A published tag is not proof that hardware, simulation, or deployment safety gates passed.
+
+## Report a vulnerability privately
+
+Do not report vulnerabilities, credentials, private logs, or exploit details in a public Issue or pull request. Use [GitHub private vulnerability reporting](https://github.com/Quchaosheng/workbench-desk-robot/security/advisories/new). If that channel is unavailable, contact the project owner privately and include only enough information to establish a secure follow-up channel.
+
+Include, when safe:
+
+- affected commit, release, component, and configuration;
+- prerequisites, minimal reproduction, and expected versus observed behavior;
+- impact on confidentiality, integrity, availability, robot-control authority, or evidence integrity;
+- known exploitation and suggested containment;
+- whether any secret, personal data, physical device, or third party is involved.
+
+Do not include live credentials. Redact tokens and private event data from screenshots and logs.
+
+## Response targets
+
+These are response targets, not a bounty or guarantee:
+
+| Stage | Target |
+|---|---:|
+| acknowledgement | 3 business days |
+| initial severity and owner | 5 business days |
+| containment plan for critical/high findings | 2 business days after triage |
+| coordinated status update | at least every 7 days while open |
+
+The human project owner makes disclosure, release, and risk-acceptance decisions. CI and AI tools cannot close a vulnerability or approve a safety claim.
+
+## Security boundaries
+
+- The public dashboard is read-only and must not publish ROS bridge, robot-control, firmware, emergency-stop, model-key, or private-log interfaces.
+- Models may propose bounded semantic actions; they never receive joint, velocity, firmware, release, or completion authority.
+- Physical task completion belongs to the independent verifier and requires evidence references.
+- Default container execution is offline, non-root, read-only, capability-dropped, and separated from the optional model network.
+- Secrets must use repository/environment secret stores and least-privilege short-lived tokens. They do not belong in source, images, fixtures, logs, or artifacts.
+
+## Coordinated disclosure
+
+Please allow time for containment, a reviewed fix, regression evidence, and affected-user guidance before public disclosure. The project will credit reporters who request credit and whose identity can be disclosed safely.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,26 @@
+# Security engineering baseline
+
+Security controls protect code, dependencies, evidence integrity, deployment, and robot authority. They do not substitute for functional, simulation, or physical safety validation.
+
+## Security task map
+
+| Task | Control / artifact | State |
+|---|---|---|
+| SEC1 code audit standard | [Secure review standard](secure-review-standard.md) plus CodeQL | ACTIVE after workflow merge |
+| SEC2 SBOM generation | pinned Anchore workflow and [supply-chain policy](supply-chain.md) | ACTIVE; next release proof pending |
+| SEC3 dependency scanning | PR dependency review and Dependabot configuration | ACTIVE after workflow merge |
+| SEC4 penetration test | [authorized test plan](penetration-test-plan.md) | NOT_EXECUTED |
+| SEC5 security hardening | [Hardening baseline](hardening.md) | PARTIAL; review per deployment |
+| SEC6 incident response | [Incident response](incident-response.md) | DEFINED; exercise pending |
+| SEC7 security documentation | `SECURITY.md` plus this handbook | DEFINED |
+| SEC8 compliance review | [Control matrix](compliance-matrix.md) | READINESS_ONLY; not certified |
+
+## Release-blocking rules
+
+- unresolved critical/high code, dependency, secret, container, or authority-boundary finding;
+- a model or public interface gains raw control, emergency-stop, release, or completion authority;
+- required SBOM/provenance is missing or cannot be tied to the published digest;
+- penetration, compliance, or physical results are claimed without eligible evidence;
+- a response action would destroy incident or safety evidence.
+
+The Security Owner triages findings. Module owners implement fixes. A human Project Owner decides release and time-bounded risk acceptance.

--- a/docs/security/compliance-matrix.md
+++ b/docs/security/compliance-matrix.md
@@ -1,0 +1,18 @@
+# Security control readiness matrix
+
+This is an internal readiness crosswalk, not a legal opinion, audit, certification, or claim of compliance with any named standard.
+
+| Control objective | Repository evidence | State | External work still required |
+|---|---|---|---|
+| vulnerability reporting | `SECURITY.md` private advisory route and response targets | DEFINED | operate and measure response process |
+| secure development review | secure review standard, CodeQL, tests, protected branch | PARTIAL | enable/require reviewed security checks after baseline PR |
+| dependency governance | Dependabot, PR dependency review, SBOM, third-party review | PARTIAL | ongoing triage and license/legal approval |
+| least privilege | read-only workflow default, job-scoped permissions, non-root container | IMPLEMENTED_BASELINE | deployment-specific IAM/network review |
+| secret protection | secret scanning/push protection and documented handling | PARTIAL | validity checks, rotation drill, environment review |
+| logging and evidence integrity | structured run/sequence logs and evidence index | IMPLEMENTED_BASELINE | retention/access policy for deployment |
+| incident response | roles, lifecycle, severity, and exercise design | DEFINED | tabletop and measured corrective actions |
+| penetration testing | authorized scope, cases, stop conditions, evidence package | NOT_EXECUTED | independent authorized execution and retest |
+| physical safety boundary | model/control separation, owner restrictions, fail-closed verification | PARTIAL | formal Gazebo and physical safety evidence |
+| release provenance | tested image, SPDX SBOM, digest/provenance workflow | PARTIAL | successful next human-owned release proof |
+
+Review this matrix at every phase gate and after material architecture, deployment, model, hardware, or regulatory changes.

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -1,0 +1,28 @@
+# Hardening baseline
+
+## Application and authority
+
+- Dashboard endpoints remain `GET`-only; write methods fail closed.
+- The dashboard has no ROS, MCU, motion, emergency-stop, secret, or release publisher.
+- Models return a bounded route; trusted deterministic builders construct semantic actions.
+- Remote or credentialed model endpoints are rejected by default.
+- Verifier conclusions require evidence and remain separate from action/device status.
+
+## Container and network
+
+- Run as non-root UID `10001` with a read-only filesystem, `no-new-privileges`, and all Linux capabilities dropped.
+- Bind the dashboard to localhost by default.
+- Keep the optional model runtime on an internal network; only the bootstrap profile receives egress for explicit provisioning.
+- Pin base and model images by digest; rebuild and rescan after updates.
+- Use a small writable `tmpfs`; do not mount host control sockets or secret directories into the dashboard.
+
+## Secrets and logs
+
+- Use short-lived least-privilege GitHub/environment credentials and job-level permissions.
+- Never place tokens in source, image layers, Compose files, CLI arguments, screenshots, fixtures, event logs, or artifacts.
+- Structured logs retain run ID and monotonic sequence for investigation, but omit prompts/private payloads unless explicitly approved and access-controlled.
+- Rotate an exposed credential before investigating convenience or blame.
+
+## Deployment review
+
+This baseline must be re-evaluated for TLS termination, authentication, reverse proxies, remote access, orchestration, host mounts, device access, and physical networks. The current localhost/offline assumptions do not authorize an internet-facing deployment.

--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -1,0 +1,31 @@
+# Incident response
+
+## Roles
+
+| Role | Responsibility |
+|---|---|
+| Incident Commander | scope, priority, safety, communications, and closure decision |
+| Security Lead | triage, evidence plan, containment options, and retest |
+| System/Module Owner | technical diagnosis, remediation, and recovery validation |
+| Project Owner | release/deployment decision, risk acceptance, and external disclosure |
+| Scribe | immutable timeline, actions, evidence references, and decision record |
+
+## Lifecycle
+
+1. **Receive privately:** acknowledge, create restricted record, assign commander and security lead.
+2. **Triage:** identify affected versions/assets, data, authority boundary, exploitation, and severity.
+3. **Preserve:** record time source, commit/image digests, logs, hashes, access, and chain of custody before destructive action when safety permits.
+4. **Contain:** revoke/rotate credentials, isolate service/network, stop publication or physical operation, and preserve evidence.
+5. **Eradicate:** remove root cause, add regression detection, scan related paths and versions.
+6. **Recover:** restore from a verified source, validate security/function/safety gates, monitor for recurrence.
+7. **Disclose and learn:** human-approved advisory, affected-user guidance, timeline, root cause, corrective actions, and effectiveness review.
+
+Safety takes priority over evidence preservation during immediate physical danger. Record the action and rationale as soon as safe.
+
+## Severity triggers
+
+Critical/high examples include exposed credentials, raw robot/control authority, false-completion bypass, arbitrary code execution, evidence tampering, public private-log access, or an exploitable dependency in the runtime path. These block release and affected operation until fixed or covered by a time-bounded human risk decision.
+
+## Exercise
+
+Run a tabletop before P1 release using a synthetic leaked token plus forged evidence event. Verify private intake, rotation, service isolation, timeline/evidence capture, regression test, and coordinated status update. Record the exercise as a drill; do not call it a real incident or penetration test.

--- a/docs/security/penetration-test-plan.md
+++ b/docs/security/penetration-test-plan.md
@@ -1,0 +1,25 @@
+# Penetration-test plan
+
+Status: **NOT_EXECUTED**. This plan is not a penetration-test result, attestation, or release approval.
+
+## Authorization and scope
+
+A human Project Owner must approve dates, testers, target commits/images, network range, data handling, emergency contacts, stop conditions, and physical-device exclusions in writing. Default scope is the isolated dashboard/backend container and optional local model boundary using synthetic event data. Public GitHub, third-party services, production credentials, firmware, emergency stop, and physical motion are out of scope unless separately authorized.
+
+## Test cases
+
+| Area | Cases | Expected control |
+|---|---|---|
+| HTTP boundary | unsupported methods, traversal, malformed encoding, oversized identifiers, cache confusion | writes rejected; paths contained; bounded errors without sensitive data |
+| event ingestion | malformed JSONL, duplicate IDs, sequence rollback, forged evidence references | readiness fails closed; no partial trusted state |
+| model endpoint | remote hosts, redirects, credentials, DNS/host confusion, malformed output | request rejected before plan construction |
+| dashboard | stored/reflected script payloads, unsafe URLs, DOM injection, sensitive fixture data | output encoded; no executable attacker content or control path |
+| container | UID/capabilities, writable paths, host/network exposure, secret mounts | non-root, read-only, minimal network and mounts |
+| supply chain | dependency confusion, mutable action/image references, SBOM/provenance mismatch | immutable references and review gate detect drift |
+| availability | bounded malformed request rate and corrupted data source | service degrades predictably; evidence preserved |
+
+## Evidence package
+
+Retain authorization, target hashes/digests, tool names/versions/configuration, timestamps, raw findings, sanitized reproductions, severity rationale, remediation commits, retest results, unresolved risk acceptance, and tester signature. Store secrets and exploit material outside public artifacts.
+
+Stop immediately on unintended physical motion, access to real secrets/private data, third-party impact, loss of evidence integrity, or a target outside authorization. Follow the incident-response plan if active compromise is suspected.

--- a/docs/security/secure-review-standard.md
+++ b/docs/security/secure-review-standard.md
@@ -1,0 +1,39 @@
+# Secure review standard
+
+## Review inputs
+
+Every review identifies the change owner, affected trust boundary, data class, dependencies, secrets/permissions, failure mode, tests, and evidence. Review the diff and generated artifacts; never accept a green check without understanding what it measured.
+
+## Required checks
+
+| Change type | Required review |
+|---|---|
+| Python or service logic | CodeQL, Ruff correctness rules, behavior tests, input/error-path review |
+| dependency or action | dependency review, immutable action pin, license/source review, exit plan |
+| container or deployment | non-root/read-only/capability/network/secret review, image smoke test, SBOM |
+| model/runtime boundary | host allowlist, credential rejection, schema validation, no raw control authority |
+| interface or contract | three-owner approval, producer/consumer review, matching Pydantic model, `make contract` |
+| dashboard or logs | read-only HTTP boundary, output encoding, sensitive-data review, write-method rejection |
+| robot/control or firmware | human owner authorization and path-specific safety tests; outside routine AI write scope |
+
+## Reviewer checklist
+
+- Validate all externally controlled input before use; fail closed on malformed, missing, duplicate, or ambiguous identity.
+- Preserve dispatch state, device state, verification state, and evidence separately.
+- Avoid shell construction, unsafe deserialization, path traversal, unrestricted URLs, and broad exception suppression.
+- Keep credentials out of command lines, logs, exceptions, fixtures, images, and artifacts.
+- Use minimal workflow/job permissions and immutable third-party action commits.
+- Test denied and degraded paths, not only the happy path.
+- Confirm logs support incident reconstruction without exposing secrets or unnecessary personal data.
+- Check that a fixture, mock, screenshot, or successful validator is not mislabeled as physical evidence.
+
+## Severity and release response
+
+| Severity | Example | Response |
+|---|---|---|
+| critical | unauthenticated raw robot control, secret exfiltration, false-completion bypass | contain immediately; block release and affected deployment |
+| high | privilege escalation, remote code execution, evidence tampering, known exploitable dependency | fix or obtain documented human exception before release |
+| medium | bounded information disclosure or hardening gap with prerequisites | owner and due date required; evaluate release context |
+| low | defense-in-depth improvement with no demonstrated impact | backlog with rationale and review date |
+
+Risk acceptance records the finding, affected versions, compensating controls, owner, approver, expiry, and retest date. AI tools cannot accept risk.

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -1,0 +1,26 @@
+# Supply-chain security
+
+## Controlled inputs
+
+| Input | Control |
+|---|---|
+| Python dependencies | bounded version ranges, PR dependency review, weekly Dependabot updates |
+| GitHub Actions | full 40-character commit pins with readable release comments |
+| runtime/dev images | immutable digest pins and a shared-base regression test |
+| model weights | separate source, license, redistribution, data, and hardware-fit review |
+| vendored UI assets | local license record and versioned files |
+| release image | tested candidate, SPDX JSON SBOM, registry digest, provenance manifest |
+
+## Update process
+
+1. Dependabot proposes a bounded update; it never merges or publishes.
+2. Dependency review checks newly introduced vulnerabilities and fails on high/critical findings.
+3. The owner reviews upstream release notes, source, license, transitive changes, and rollback path.
+4. Required tests run against the exact pin or digest.
+5. A human reviewer merges. A separate human-owned tag may publish only after release gates pass.
+
+SBOM generation inventories the built candidate. It does not prove a component is safe, licensed for every use, or present in a deployed physical unit. Store the SBOM and provenance with the release evidence index.
+
+## Triage
+
+For every alert, record affected package/path, advisory/CVE, reachability, exploit prerequisites, severity, fixed version, owner, decision, evidence, and deadline. Dismissal requires a reason and review date; absence from the runtime path should be demonstrated, not assumed.

--- a/docs/task_packets/security-engineering-baseline.json
+++ b/docs/task_packets/security-engineering-baseline.json
@@ -1,0 +1,55 @@
+{
+  "issue": 24,
+  "human_owner": "Quchaosheng",
+  "objective": "Establish continuous least-privilege security review and response controls without claiming unexecuted penetration compliance or physical results.",
+  "allowed_paths": [
+    ".github/workflows/security.yml",
+    ".github/dependabot.yml",
+    "SECURITY.md",
+    "docs/security/**",
+    "docs/task_packets/security-engineering-baseline.json",
+    "tests/unit/test_security_baseline.py",
+    "mkdocs.yml"
+  ],
+  "read_only_paths": [
+    ".github/workflows/release-image.yml",
+    "Dockerfile",
+    "compose.yaml",
+    "THIRD_PARTY_REVIEW.md",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "robot/control/**",
+    "firmware/**",
+    "hardware/safety/**"
+  ],
+  "acceptance": [
+    "CodeQL and pull-request dependency review use immutable action commits",
+    "the workflow defaults to contents read and grants security-events write only to CodeQL",
+    "Dependabot covers Python GitHub Actions and both container definition roots",
+    "private reporting severity triage hardening incident response and supply-chain review are documented",
+    "penetration testing remains NOT_EXECUTED and the control matrix makes no certification claim",
+    "deterministic tests protect workflow permissions pins and evidence states"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/security-engineering-baseline.json",
+    "python -m pytest tests/unit/test_security_baseline.py -q",
+    "python -m mkdocs build --strict",
+    "make check"
+  ],
+  "evidence": [
+    "Task Packet validation output",
+    "security baseline test output",
+    "strict documentation build output",
+    "CodeQL and dependency-review GitHub Actions results",
+    "full repository check output"
+  ],
+  "stop_conditions": [
+    "a credential vulnerability exploit or private report would need to be exposed",
+    "robot control firmware or physical safety paths require modification",
+    "a penetration compliance or certification result would need to be inferred",
+    "a human risk release or disclosure decision is required"
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,9 @@ nav:
   - 90-minute demo: user-guide/demo-runbook.md
   - Dashboard design: design/dashboard-design-system.md
   - Dashboard usability test: design/dashboard-usability-test.md
+  - Security program: security/README.md
+  - Secure review: security/secure-review-standard.md
+  - Incident response: security/incident-response.md
   - System architecture: architecture/system.md
   - API reference: api.md
 plugins:

--- a/tests/unit/test_security_baseline.py
+++ b/tests/unit/test_security_baseline.py
@@ -1,0 +1,58 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "security.yml"
+
+
+def _job_block(workflow: str, job_name: str, next_job: str | None = None) -> str:
+    start = workflow.index(f"  {job_name}:\n")
+    if next_job is None:
+        return workflow[start:]
+    end = workflow.index(f"  {next_job}:\n", start)
+    return workflow[start:end]
+
+
+def test_security_workflow_is_pinned_and_least_privileged() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    header = workflow.split("jobs:", maxsplit=1)[0]
+    assert "permissions:\n  contents: read" in header
+    assert "security-events: write" not in header
+
+    action_lines = [line.strip() for line in workflow.splitlines() if "uses:" in line]
+    assert action_lines
+    assert all(re.search(r"@[0-9a-f]{40}\s+# v[0-9]", line) for line in action_lines)
+
+    codeql = _job_block(workflow, "codeql-python", "dependency-review")
+    assert "security-events: write" in codeql
+    assert "build-mode: none" in codeql
+
+    dependency_review = _job_block(workflow, "dependency-review")
+    assert "if: github.event_name == 'pull_request'" in dependency_review
+    assert "security-events: write" not in dependency_review
+    assert "fail-on-severity: high" in dependency_review
+
+
+def test_dependabot_covers_python_actions_and_container_inputs() -> None:
+    config = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    ecosystems = re.findall(r"package-ecosystem: ([a-z-]+)", config)
+    assert ecosystems.count("pip") == 2
+    assert ecosystems.count("github-actions") == 1
+    assert ecosystems.count("docker") == 2
+    assert "directory: /robot/control" in config
+    assert "directory: /.devcontainer" in config
+
+
+def test_security_handbook_preserves_unexecuted_and_not_certified_states() -> None:
+    index = (ROOT / "docs" / "security" / "README.md").read_text(encoding="utf-8")
+    for task_number in range(1, 9):
+        assert f"SEC{task_number}" in index
+
+    penetration_plan = (ROOT / "docs" / "security" / "penetration-test-plan.md").read_text(encoding="utf-8")
+    compliance = (ROOT / "docs" / "security" / "compliance-matrix.md").read_text(encoding="utf-8")
+    policy = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+
+    assert "Status: **NOT_EXECUTED**" in penetration_plan
+    assert "not a legal opinion, audit, certification" in compliance
+    assert "/security/advisories/new" in policy
+    assert "Do not report vulnerabilities" in policy


### PR DESCRIPTION
﻿## Summary

- add least-privilege CodeQL Python analysis and PR dependency review with immutable action commits
- add weekly Dependabot coverage for root and `robot/control` Python dependencies, GitHub Actions, and both container roots
- expand private vulnerability reporting, response targets, authority boundaries, and disclosure guidance
- add secure review, supply-chain, hardening, authorized penetration-test plan, incident response, and readiness-only compliance records covering SEC1-SEC8
- add deterministic policy tests and a bounded Task Packet

## Evidence boundaries

- penetration testing remains explicitly `NOT_EXECUTED`
- the compliance matrix is explicitly not a legal opinion, audit, certification, or compliance claim
- SBOM generation is inventory/provenance input, not proof of safety or licensing
- AI/CI cannot accept risk, disclose a vulnerability, release, or approve a physical claim without human authorization

## Verification

- Task Packet validation: passed
- security policy tests: 3 passed
- full test suite: 110 passed
- lint and format checks: passed
- workflow and Dependabot YAML parsing: passed
- contract, scenario, golden-set, and context validation: passed
- scripted and offline demos: passed
- strict MkDocs build: passed

## Merge readiness

- rebased onto current `main` after #31 and #32
- PR dependency review, CodeQL, foundation, container, kernel-module, MCU-QEMU, and Dependabot configuration checks passed
- the PR remains limited to the security Task Packet paths

Closes #24
