### PR TITLE
test(kernel): include K1-K10 in the default pytest gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ fmt:
 	$(PYTHON) -m ruff format .
 
 test:
-	$(PYTHON) -m pytest tests/ -v
+	$(PYTHON) -m pytest -v
 
 # Everything CI runs, in one command. Run this before opening a PR.
 check: lint test contract scenario-check golden-check context-check demo-scripted demo-offline

--- a/docs/task_packets/kernel-tests-default-gate.json
+++ b/docs/task_packets/kernel-tests-default-gate.json
@@ -1,0 +1,43 @@
+{
+  "issue": 29,
+  "human_owner": "Quchaosheng",
+  "objective": "Include the maintained K1-K10 kernel suites in default pytest discovery and the repository test gate.",
+  "allowed_paths": [
+    "pyproject.toml",
+    "Makefile",
+    "docs/task_packets/kernel-tests-default-gate.json"
+  ],
+  "read_only_paths": [
+    "libs/kernel/tests/**",
+    "libs/kernel/workbench/kernel/**",
+    "tests/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "robot/control/**",
+    "firmware/**",
+    "hardware/**"
+  ],
+  "acceptance": [
+    "default pytest discovery includes tests and libs/kernel/tests",
+    "the Makefile test gate uses default pytest discovery",
+    "the K1-K10 suites pass without production or test rewrites",
+    "repository lint and full checks pass"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/kernel-tests-default-gate.json",
+    "python -m pytest --collect-only -q",
+    "make test",
+    "make check"
+  ],
+  "evidence": [
+    "Task Packet validation output",
+    "default pytest collection output containing libs/kernel/tests",
+    "repository test and check output"
+  ],
+  "stop_conditions": [
+    "a production kernel or test rewrite is required",
+    "default discovery collects generated or unsupported test trees",
+    "robot control firmware interface or hardware changes are required"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ where = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "libs/kernel/tests"]
 python_files = ["test_*.py"]
 addopts = [
   "-v",


### PR DESCRIPTION
## Summary

- include `libs/kernel/tests` in the default pytest collection
- make `make test` run the same default pytest gate
- add a bounded Task Packet documenting the collection gap and verification

PR #32 superseded the earlier kernel-test rewrites. This PR intentionally keeps only the default collection configuration, Makefile gate, and Task Packet; it does not modify kernel tests or production code.

## Verification

- default pytest collection: 141 tests, including 37 kernel tests
- full default suite: 141 passed
- Ruff rules and format: passed (107 files)
- contract, scenario, golden-set, and context validation: passed
- scripted and offline demos: passed

Closes #29