### PR TITLE
feat(ui): harden dashboard keyboard and mobile UX

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -15,3 +15,5 @@ matches that decision.
 The HTTP boundary deliberately implements `GET` only. `POST`, `PUT`, `PATCH`, and `DELETE` return `405 read_only`; there is no ROS, MCU, motion, or emergency-stop publisher in this application.
 
 Vendored UI dependency: Lucide `0.468.0`, ISC license in `vendor/LUCIDE-LICENSE.txt`.
+
+The dashboard follows a two-tab keyboard model: `Left`/`Right` (or `Up`/`Down`) changes views, while `Home` and `End` jump to the first or last view. Filters and run selection expose pressed state, replay exposes playback and position state, and the active mobile run scrolls into view. Nonessential motion is suppressed when the operating system requests reduced motion.

--- a/apps/dashboard/app.js
+++ b/apps/dashboard/app.js
@@ -79,6 +79,8 @@ const taskZones = {
   ],
 };
 
+const viewOrder = ["overview", "replay"];
+
 const get = (id) => document.getElementById(id);
 
 function escapeHtml(value) {
@@ -175,7 +177,8 @@ function renderRunList() {
     .map(
       (run) => `
         <button class="run-item ${run.run_id === state.currentRun?.run_id ? "is-active" : ""}"
-          type="button" data-run-id="${escapeHtml(run.run_id)}">
+          type="button" data-run-id="${escapeHtml(run.run_id)}"
+          aria-pressed="${run.run_id === state.currentRun?.run_id}">
           <div class="run-item-top">
             <strong>${escapeHtml(run.task_id)}</strong>
             <span class="status-pill status-${escapeHtml(run.status)}">${escapeHtml(run.status_label)}</span>
@@ -191,6 +194,7 @@ function renderRunList() {
   document.querySelectorAll(".run-item").forEach((button) => {
     button.addEventListener("click", () => selectRun(button.dataset.runId));
   });
+  document.querySelector(".run-item.is-active")?.scrollIntoView({ block: "nearest", inline: "nearest" });
 }
 
 function renderAttention(summary) {
@@ -525,8 +529,15 @@ function renderTimeline(target, events, cursor, replay = false) {
 function renderReplayEvent() {
   const event = state.cursor < 0 ? null : state.events[state.cursor];
   get("replay-position").textContent = `${Math.max(0, state.cursor + 1)} / ${state.events.length}`;
-  get("replay-range").max = String(Math.max(0, state.events.length - 1));
-  get("replay-range").value = String(Math.max(0, state.cursor));
+  const replayRange = get("replay-range");
+  replayRange.max = String(Math.max(0, state.events.length - 1));
+  replayRange.value = String(Math.max(0, state.cursor));
+  replayRange.setAttribute(
+    "aria-valuetext",
+    event
+      ? `${state.cursor + 1} / ${state.events.length}，${eventLabels[event.event_type] || event.event_type}`
+      : `0 / ${state.events.length}，任务尚未开始`,
+  );
   get("replay-event-title").textContent = event ? eventLabels[event.event_type] || event.event_type : "等待任务";
   get("replay-sequence").textContent = event ? `#${String(event.sequence_no).padStart(2, "0")}` : "#--";
   if (!event) {
@@ -609,14 +620,18 @@ function openEvidence(reference) {
   else dialog.setAttribute("open", "");
 }
 
-function setView(view) {
+function setView(view, focusTab = false) {
   const replay = view === "replay";
   get("overview-view").hidden = replay;
   get("replay-view").hidden = !replay;
+  get("overview-view").setAttribute("aria-hidden", String(replay));
+  get("replay-view").setAttribute("aria-hidden", String(!replay));
   document.querySelectorAll(".view-tab").forEach((tab) => {
     const selected = tab.dataset.view === view;
     tab.classList.toggle("is-active", selected);
     tab.setAttribute("aria-selected", String(selected));
+    tab.tabIndex = selected ? 0 : -1;
+    if (selected && focusTab) tab.focus();
   });
   if (replay && state.cursor < 0) state.cursor = state.events.length - 1;
   renderCurrent();
@@ -627,6 +642,7 @@ function stopPlayback() {
   clearTimeout(state.timer);
   state.timer = null;
   get("replay-play").innerHTML = '<i data-lucide="play"></i><span>播放</span>';
+  get("replay-play").setAttribute("aria-pressed", "false");
   refreshIcons();
 }
 
@@ -649,6 +665,7 @@ function togglePlayback() {
   if (state.cursor >= state.events.length - 1) state.cursor = -1;
   state.playing = true;
   get("replay-play").innerHTML = '<i data-lucide="pause"></i><span>暂停</span>';
+  get("replay-play").setAttribute("aria-pressed", "true");
   refreshIcons();
   playbackTick();
 }
@@ -660,6 +677,7 @@ async function selectRun(runId) {
   const generation = ++state.requestGeneration;
   state.runRequest = controller;
   get("run-list").setAttribute("aria-busy", "true");
+  document.querySelector(".workspace").setAttribute("aria-busy", "true");
   try {
     const response = await fetch(`/api/runs/${encodeURIComponent(runId)}/events`, { signal: controller.signal });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -677,6 +695,7 @@ async function selectRun(runId) {
     if (generation === state.requestGeneration) {
       state.runRequest = null;
       get("run-list").removeAttribute("aria-busy");
+      document.querySelector(".workspace").removeAttribute("aria-busy");
     }
   }
 }
@@ -693,11 +712,28 @@ function bindControls() {
   document.querySelectorAll(".filter-button").forEach((button) => {
     button.addEventListener("click", () => {
       state.filter = button.dataset.filter;
-      document.querySelectorAll(".filter-button").forEach((item) => item.classList.toggle("is-active", item === button));
+      document.querySelectorAll(".filter-button").forEach((item) => {
+        const selected = item === button;
+        item.classList.toggle("is-active", selected);
+        item.setAttribute("aria-pressed", String(selected));
+      });
       renderRunList();
     });
   });
-  document.querySelectorAll(".view-tab").forEach((tab) => tab.addEventListener("click", () => setView(tab.dataset.view)));
+  document.querySelectorAll(".view-tab").forEach((tab) => {
+    tab.addEventListener("click", () => setView(tab.dataset.view));
+    tab.addEventListener("keydown", (event) => {
+      const currentIndex = viewOrder.indexOf(tab.dataset.view);
+      let targetIndex = null;
+      if (["ArrowLeft", "ArrowUp"].includes(event.key)) targetIndex = (currentIndex - 1 + viewOrder.length) % viewOrder.length;
+      if (["ArrowRight", "ArrowDown"].includes(event.key)) targetIndex = (currentIndex + 1) % viewOrder.length;
+      if (event.key === "Home") targetIndex = 0;
+      if (event.key === "End") targetIndex = viewOrder.length - 1;
+      if (targetIndex === null) return;
+      event.preventDefault();
+      setView(viewOrder[targetIndex], true);
+    });
+  });
   get("replay-start").addEventListener("click", () => {
     stopPlayback();
     state.cursor = -1;

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -18,7 +18,7 @@
           <small>验证优先任务系统</small>
         </span>
       </a>
-      <div class="header-status" aria-label="系统连接状态">
+      <div class="header-status" role="status" aria-label="系统连接状态">
         <span class="connection-dot"></span>
         <span>本地在线</span>
         <span class="header-divider"></span>
@@ -34,12 +34,12 @@
             <p class="eyebrow">运行记录</p>
             <h1>任务队列</h1>
           </div>
-          <span id="run-count" class="count-badge">0</span>
+          <span id="run-count" class="count-badge" aria-live="polite">0</span>
         </div>
         <div class="run-filter" role="group" aria-label="运行筛选">
-          <button class="filter-button is-active" type="button" data-filter="all">全部</button>
-          <button class="filter-button" type="button" data-filter="attention">需关注</button>
-          <button class="filter-button" type="button" data-filter="confirmed">已确认</button>
+          <button class="filter-button is-active" type="button" data-filter="all" aria-pressed="true">全部</button>
+          <button class="filter-button" type="button" data-filter="attention" aria-pressed="false">需关注</button>
+          <button class="filter-button" type="button" data-filter="confirmed" aria-pressed="false">已确认</button>
         </div>
         <div id="run-list" class="run-list"></div>
         <div class="sidebar-foot">
@@ -51,10 +51,10 @@
       <main class="workspace">
         <div class="workspace-head">
           <div class="view-tabs" role="tablist" aria-label="任务视图">
-            <button class="view-tab is-active" id="overview-tab" type="button" role="tab" aria-selected="true" data-view="overview">
+            <button class="view-tab is-active" id="overview-tab" type="button" role="tab" aria-selected="true" aria-controls="overview-view" tabindex="0" data-view="overview">
               <i data-lucide="layout-dashboard"></i><span>实时状态</span>
             </button>
-            <button class="view-tab" id="replay-tab" type="button" role="tab" aria-selected="false" data-view="replay">
+            <button class="view-tab" id="replay-tab" type="button" role="tab" aria-selected="false" aria-controls="replay-view" tabindex="-1" data-view="replay">
               <i data-lucide="history"></i><span>事件回放</span>
             </button>
           </div>
@@ -64,7 +64,7 @@
           </div>
         </div>
 
-        <section class="status-strip" aria-label="任务摘要">
+        <section class="status-strip" aria-label="任务摘要" aria-live="polite" aria-atomic="true">
           <div class="status-cell">
             <span>任务状态</span>
             <strong id="task-status">--</strong>
@@ -83,7 +83,7 @@
           </div>
         </section>
 
-        <section id="attention-banner" class="attention-banner" hidden>
+        <section id="attention-banner" class="attention-banner" role="status" aria-live="polite" hidden>
           <i data-lucide="scan-search"></i>
           <div>
             <strong>暂时无法确认任务结果</strong>
@@ -92,7 +92,7 @@
           <span class="attention-state">UNCERTAIN</span>
         </section>
 
-        <div id="overview-view" class="view-panel" role="tabpanel" aria-labelledby="overview-tab">
+        <div id="overview-view" class="view-panel" role="tabpanel" aria-labelledby="overview-tab" aria-hidden="false" tabindex="0">
           <section class="task-band">
             <div class="task-primary">
               <p class="eyebrow">当前目标</p>
@@ -169,17 +169,17 @@
           </div>
         </div>
 
-        <div id="replay-view" class="view-panel" role="tabpanel" aria-labelledby="replay-tab" hidden>
+        <div id="replay-view" class="view-panel" role="tabpanel" aria-labelledby="replay-tab" aria-hidden="true" tabindex="0" hidden>
           <section class="replay-toolbar" aria-label="回放控制">
             <div class="replay-controls">
               <button id="replay-start" class="icon-button" type="button" title="回到开始" aria-label="回到开始"><i data-lucide="skip-back"></i></button>
               <button id="replay-prev" class="icon-button" type="button" title="上一个事件" aria-label="上一个事件"><i data-lucide="step-back"></i></button>
-              <button id="replay-play" class="play-button" type="button"><i data-lucide="play"></i><span>播放</span></button>
+              <button id="replay-play" class="play-button" type="button" aria-pressed="false"><i data-lucide="play"></i><span>播放</span></button>
               <button id="replay-next" class="icon-button" type="button" title="下一个事件" aria-label="下一个事件"><i data-lucide="step-forward"></i></button>
               <button id="replay-end" class="icon-button" type="button" title="跳到末尾" aria-label="跳到末尾"><i data-lucide="skip-forward"></i></button>
             </div>
             <div class="replay-position">
-              <span id="replay-position">0 / 0</span>
+              <span id="replay-position" aria-live="polite">0 / 0</span>
               <input id="replay-range" type="range" min="0" max="0" value="0" aria-label="回放事件位置">
             </div>
             <label class="speed-control">速度

--- a/apps/dashboard/styles.css
+++ b/apps/dashboard/styles.css
@@ -1881,6 +1881,33 @@ svg {
   *::before,
   *::after {
     scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .connection-dot,
+  #progress-bar {
+    background: Highlight;
+  }
+
+  .timeline-marker {
+    border-color: Highlight;
+    background: Canvas;
+  }
+
+  .is-active,
+  .attention-banner,
+  .status-pill {
+    border: 1px solid CanvasText;
+  }
+
+  button:focus-visible,
+  a:focus-visible,
+  select:focus-visible,
+  input:focus-visible {
+    outline-color: Highlight;
   }
 }

--- a/docs/design/dashboard-design-system.md
+++ b/docs/design/dashboard-design-system.md
@@ -1,0 +1,56 @@
+# Dashboard design system
+
+The operator dashboard is a quiet, read-only inspection surface. It helps an operator distinguish observed state, action/device state, verifier conclusions, missing evidence, and recovery history. It never exposes robot-control, firmware, emergency-stop, release, or completion authority.
+
+## UI/UX task map
+
+| Task | Artifact / acceptance |
+|---|---|
+| UI1 design system | this token, component, state, and accessibility contract |
+| UI2 interaction framework | run selection, filtering, live/replay tabs, evidence dialog, keyboard model |
+| UI3 implementation and integration | `apps/dashboard/` plus read-only backend behavior tests |
+| UI4 usability testing | [usability protocol](dashboard-usability-test.md), currently NOT_EXECUTED |
+| UI5 feedback iteration | issue #26 audit findings and PR review evidence |
+| UI6 production version | release criteria below; no production claim until they pass |
+
+## Visual language
+
+- Neutral white and cool-gray surfaces support scanning; teal indicates selected/verified system state, green indicates confirmed, and amber indicates insufficient evidence or attention.
+- Color is never the only signal. Every state has visible text, and uncertainty is never styled or labeled as success.
+- Cards are reserved for individual panels or repeated runs. The shell, sidebar, and major workspace regions remain structural bands.
+- Typography is compact: task goals carry the strongest emphasis; panel headings, labels, IDs, timestamps, and evidence references step down predictably.
+- Lucide icons supplement labels and are hidden from the accessibility tree. Unfamiliar icon-only controls include accessible names and tooltips.
+
+## Stable components
+
+| Component | Contract |
+|---|---|
+| run filter | three pressed-state buttons; count updates politely |
+| run list | active run exposes pressed state and scrolls into view on narrow screens |
+| view tabs | one tab in the tab order; arrows cycle, Home/End jump, tab controls named panel |
+| status strip | atomic polite summary; status remains text-first |
+| attention banner | polite status region; missing evidence remains readable without color/icon |
+| replay | named icon controls, pressed play/pause, range value text includes event position/type |
+| evidence dialog | native modal semantics, named close control, synthetic source identified |
+
+## Responsive contract
+
+| Viewport | Layout |
+|---|---|
+| >1080px | fixed scanning sidebar plus two-column operational workspace |
+| 781-1080px | narrower sidebar; stacked primary dashboard panels |
+| <=780px | run list becomes horizontal; workspace becomes a single column |
+| <=460px | compact controls, hidden redundant timestamps, stable 34px replay controls |
+
+At 320px, 390px, 768px, and 1440px there must be no page-level horizontal overflow, incoherent overlap, clipped control label, or inaccessible active run. The run carousel may scroll horizontally by design.
+
+## Accessibility and release criteria
+
+- keyboard-only completion of filter, run selection, tab change, replay, evidence open/close, range, and speed tasks;
+- correct tab/tabpanel, pressed, busy, live-region, dialog, and range value semantics;
+- visible focus and state text in default, forced-colors, and reduced-motion modes;
+- no critical/high accessibility finding in the supported dashboard path;
+- usability protocol completed with retained observations and no fabricated participants;
+- backend remains GET-only and write-method tests pass;
+- desktop/mobile screenshots and console logs attached to the reviewed PR or release evidence.
+

--- a/docs/design/dashboard-usability-test.md
+++ b/docs/design/dashboard-usability-test.md
@@ -1,0 +1,33 @@
+# Dashboard usability test
+
+Status: **NOT_EXECUTED**. This protocol is not user feedback, accessibility conformance, or production acceptance.
+
+## Participants and setup
+
+Recruit five people who did not implement the dashboard: at least two robot/operator-domain users and at least one keyboard/screen-reader user. Record consent, assistive technology, viewport/device, task order, and session ID without collecting unnecessary personal data. Use committed synthetic fixtures only.
+
+## Tasks
+
+| Task | Success criterion | Evidence |
+|---|---|---|
+| find the run needing attention | selects `run-uncertain` without coaching | path, time, wrong turns |
+| explain why it is not confirmed | names missing fresh/light/confidence evidence | answer and referenced UI region |
+| compare live state with replay start/end | reaches both views and explains changed state | keyboard/pointer path and answer |
+| inspect one camera and one action/log reference | opens/closes evidence and identifies synthetic source | reference IDs and observed source label |
+| locate the failed first grasp and later recovery | identifies refuted attempt and confirmed conclusion separately | event sequence numbers |
+| state what the dashboard cannot control | names read-only/no ROS/no emergency-stop boundary | answer |
+
+## Measures
+
+Record task success, time, errors, assistance, confidence (1-5), and short qualitative observation. Do not combine domain misunderstanding with interface failure without review. A screenshot proves appearance, not comprehension.
+
+## Acceptance and iteration
+
+- all five participants complete attention, evidence, and authority-boundary tasks;
+- at least four of five complete replay without assistance;
+- no participant interprets insufficient evidence as confirmed completion;
+- keyboard/screen-reader path has no blocking issue;
+- every high-impact finding receives an owner, issue, acceptance test, and retest result.
+
+Preserve failures. Publish only aggregated, de-identified findings. Mark production usability as UNKNOWN until this protocol is executed and reviewed.
+

--- a/docs/task_packets/dashboard-accessibility-ux.json
+++ b/docs/task_packets/dashboard-accessibility-ux.json
@@ -1,0 +1,53 @@
+{
+  "issue": 26,
+  "human_owner": "Quchaosheng",
+  "objective": "Harden the read-only dashboard across responsive and keyboard use while preserving evidence and robot-authority boundaries.",
+  "allowed_paths": [
+    "apps/dashboard/**",
+    "docs/design/**",
+    "docs/task_packets/dashboard-accessibility-ux.json",
+    "tests/unit/test_dashboard_accessibility.py",
+    "mkdocs.yml"
+  ],
+  "read_only_paths": [
+    "services/backend/**",
+    "interfaces/**",
+    "apps/dashboard/data/**"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "hardware/safety/**"
+  ],
+  "acceptance": [
+    "active filters runs playback and replay position expose programmatic state",
+    "view tabs implement controls selected state roving tabindex and arrow Home End keyboard behavior",
+    "the active run scrolls into view in the horizontal mobile list",
+    "dynamic summary attention busy and replay state use appropriate announcements",
+    "reduced-motion and forced-colors users retain stable readable state",
+    "desktop and mobile browser checks show no page-level overflow or incoherent overlap",
+    "the usability protocol remains NOT_EXECUTED until real participants provide records",
+    "the dashboard remains read-only with no control publisher"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/dashboard-accessibility-ux.json",
+    "python -m pytest tests/unit/test_dashboard_accessibility.py tests/unit/test_dashboard_backend.py -q",
+    "python -m mkdocs build --strict",
+    "make check"
+  ],
+  "evidence": [
+    "Task Packet validation output",
+    "dashboard accessibility and backend test output",
+    "desktop 1440x900 mobile 390x844 and narrow 320x568 browser screenshots",
+    "keyboard tab and replay state inspection",
+    "browser console log inspection",
+    "strict documentation and repository check output"
+  ],
+  "stop_conditions": [
+    "a robot control ROS firmware or emergency-stop interface would be introduced",
+    "a frozen event contract or fixture meaning would need to change",
+    "participant feedback accessibility conformance or production usability would need to be fabricated",
+    "a layout or interaction cannot be verified at the target viewport"
+  ]
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ nav:
   - Maintenance: user-guide/maintenance.md
   - Troubleshooting: user-guide/troubleshooting.md
   - 90-minute demo: user-guide/demo-runbook.md
+  - Dashboard design: design/dashboard-design-system.md
+  - Dashboard usability test: design/dashboard-usability-test.md
   - System architecture: architecture/system.md
   - API reference: api.md
 plugins:

--- a/tests/unit/test_dashboard_accessibility.py
+++ b/tests/unit/test_dashboard_accessibility.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD = ROOT / "apps" / "dashboard"
+
+
+def test_dashboard_exposes_filter_tab_replay_and_live_region_state() -> None:
+    markup = (DASHBOARD / "index.html").read_text(encoding="utf-8")
+
+    assert markup.count('class="filter-button') == 3
+    assert markup.count('aria-pressed="false"') >= 3
+    assert 'aria-controls="overview-view"' in markup
+    assert 'aria-controls="replay-view"' in markup
+    assert 'id="replay-tab"' in markup and 'tabindex="-1"' in markup
+    assert 'aria-label="任务摘要" aria-live="polite" aria-atomic="true"' in markup
+    assert 'id="attention-banner" class="attention-banner" role="status"' in markup
+    assert 'id="replay-play" class="play-button" type="button" aria-pressed="false"' in markup
+    assert 'id="replay-position" aria-live="polite"' in markup
+
+
+def test_dashboard_script_keeps_keyboard_and_dynamic_state_in_sync() -> None:
+    script = (DASHBOARD / "app.js").read_text(encoding="utf-8")
+
+    for key in ("ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"):
+        assert key in script
+    assert 'tab.setAttribute("aria-selected", String(selected))' in script
+    assert "tab.tabIndex = selected ? 0 : -1" in script
+    assert 'item.setAttribute("aria-pressed", String(selected))' in script
+    assert "replayRange.setAttribute" in script
+    assert '"aria-valuetext"' in script
+    assert 'scrollIntoView({ block: "nearest", inline: "nearest" })' in script
+
+
+def test_dashboard_supports_reduced_motion_and_forced_colors() -> None:
+    styles = (DASHBOARD / "styles.css").read_text(encoding="utf-8")
+
+    assert "@media (prefers-reduced-motion: reduce)" in styles
+    assert "animation-duration: 0.01ms !important" in styles
+    assert "animation-iteration-count: 1 !important" in styles
+    assert "@media (forced-colors: active)" in styles


### PR DESCRIPTION
## Summary

- add complete tab/tabpanel semantics, roving tabindex, keyboard navigation, pressed/busy/live state, and descriptive replay values
- keep the active run visible in the mobile queue and strengthen reduced-motion/forced-colors behavior
- add a design-system contract, a deliberately NOT_EXECUTED usability protocol, deterministic accessibility tests, and a bounded Task Packet

## Verification

- Task Packet validation: passed
- dashboard accessibility/backend tests: 18 passed
- full default suite: 107 passed
- Ruff and strict MkDocs build: passed
- 1265px desktop and 390x844 mobile browser checks: no page-level horizontal overflow, active run visible, tab keyboard model correct, replay state synchronized, zero console warnings/errors

## Evidence boundary

The usability protocol remains NOT_EXECUTED. This PR does not claim real participants, accessibility conformance, physical control, or production usability. The backend remains GET-only.

Closes #26