### PR TITLE
feat(hardware): add fail-closed URDF motor config parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN printf 'Acquire::Retries "10";\nAcquire::http::Timeout "120";\nAcquire::http
 WORKDIR /app
 COPY pyproject.toml README.md README.zh-CN.md LICENSE NOTICE ./
 COPY libs/contracts ./libs/contracts
+COPY libs/hardware ./libs/hardware
+COPY libs/kernel ./libs/kernel
 COPY services/agent_runtime ./services/agent_runtime
 COPY services/backend ./services/backend
 COPY services/world_model ./services/world_model

--- a/docs/hardware/hw1-ur5e-extraction.md
+++ b/docs/hardware/hw1-ur5e-extraction.md
@@ -1,0 +1,96 @@
+# HW1 official UR5e extraction evidence
+
+Status: **EXECUTED** on 2026-08-12 in the repository development environment.
+
+This evidence uses the ROS Jazzy `ur_description` package as the controlled,
+non-generated source. The expanded URDF is a temporary generated artifact and
+is not treated as the source of the limits.
+
+## Controlled source references
+
+- `ros-jazzy-ur-description 3.5.1-1noble.20260615.175716`
+- `ros-jazzy-xacro 2.1.1-1noble.20260519.011123`
+- `/opt/ros/jazzy/share/ur_description/urdf/ur.urdf.xacro`
+  SHA-256: `d2eb6b60edf4c18b347c0612598f3c2b95fd0b189cf16fdb8c2f2ac119a0a82f`
+- `/opt/ros/jazzy/share/ur_description/config/ur5e/joint_limits.yaml`
+  SHA-256: `1e908454a0fb073761a0c675f708eb003ca7d5333a9e0863ef87fe40d9abb3c7`
+
+The package's `joint_limits.yaml` cites the Universal Robots e-Series UR5e user
+manual and Universal Robots' maximum-joint-torque article as its upstream
+sources.
+
+## Reproduction
+
+```bash
+/opt/ros/jazzy/bin/xacro \
+  /opt/ros/jazzy/share/ur_description/urdf/ur.urdf.xacro \
+  ur_type:=ur5e name:=ur5e \
+  -o /tmp/workbench-hw1-official-ur5e.urdf
+
+python3 libs/hardware/urdf_to_motor_config.py \
+  /tmp/workbench-hw1-official-ur5e.urdf \
+  --joint shoulder_pan_joint \
+  --joint shoulder_lift_joint \
+  --joint elbow_joint \
+  --joint wrist_1_joint \
+  --joint wrist_2_joint \
+  --joint wrist_3_joint
+```
+
+The expanded URDF had SHA-256
+`a21bf5fb70b3a1745bf2e4816e0f43654539737ba7f2585939ec773d159778d8`,
+was 11,870 bytes, and contained exactly six revolute joints. Every selected
+joint contained exactly one `<limit>` element. It contained no transmission,
+so every reduction below remains explicitly unknown.
+
+The extracted YAML below had SHA-256
+`9a32af8b6504b4e242d2f3bf9458d5a87c96ae45fb55a14e459644fe6c5fd7d1`
+and was 1,394 bytes.
+
+## Extracted motor configuration
+
+```yaml
+motors:
+  - name: "shoulder_pan_joint"
+    joint_type: "revolute"
+    max_torque_nm: 150.0
+    max_velocity_rad_s: 3.141592653589793
+    lower_limit_rad: -6.283185307179586
+    upper_limit_rad: 6.283185307179586
+    mechanical_reduction: null
+  - name: "shoulder_lift_joint"
+    joint_type: "revolute"
+    max_torque_nm: 150.0
+    max_velocity_rad_s: 3.141592653589793
+    lower_limit_rad: -6.283185307179586
+    upper_limit_rad: 6.283185307179586
+    mechanical_reduction: null
+  - name: "elbow_joint"
+    joint_type: "revolute"
+    max_torque_nm: 150.0
+    max_velocity_rad_s: 3.141592653589793
+    lower_limit_rad: -3.141592653589793
+    upper_limit_rad: 3.141592653589793
+    mechanical_reduction: null
+  - name: "wrist_1_joint"
+    joint_type: "revolute"
+    max_torque_nm: 28.0
+    max_velocity_rad_s: 3.141592653589793
+    lower_limit_rad: -6.283185307179586
+    upper_limit_rad: 6.283185307179586
+    mechanical_reduction: null
+  - name: "wrist_2_joint"
+    joint_type: "revolute"
+    max_torque_nm: 28.0
+    max_velocity_rad_s: 3.141592653589793
+    lower_limit_rad: -6.283185307179586
+    upper_limit_rad: 6.283185307179586
+    mechanical_reduction: null
+  - name: "wrist_3_joint"
+    joint_type: "revolute"
+    max_torque_nm: 28.0
+    max_velocity_rad_s: 3.141592653589793
+    lower_limit_rad: -6.283185307179586
+    upper_limit_rad: 6.283185307179586
+    mechanical_reduction: null
+```

--- a/docs/task_packets/hw1-urdf-parser.json
+++ b/docs/task_packets/hw1-urdf-parser.json
@@ -4,10 +4,12 @@
   "objective": "Extract deterministic motor-limit configuration from an expanded URDF without inventing hardware parameters that the URDF does not declare.",
   "allowed_paths": [
     "docs/task_packets/hw1-urdf-parser.json",
+    "docs/hardware/hw1-ur5e-extraction.md",
     "libs/hardware/README.md",
     "libs/hardware/urdf_to_motor_config.py",
     "libs/hardware/workbench/hardware/__init__.py",
     "libs/hardware/workbench/hardware/urdf_parser.py",
+    "pyproject.toml",
     "tests/unit/test_hardware_urdf.py"
   ],
   "read_only_paths": [
@@ -27,6 +29,8 @@
   ],
   "commands": [
     "python3 tools/scripts/check_task_packet.py docs/task_packets/hw1-urdf-parser.json",
+    "python3 -m pip install -e .",
+    "python3 -c \"from workbench.hardware import parse_urdf_motor_config\"",
     "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/unit/test_hardware_urdf.py -v",
     "make test",
     "make contract",
@@ -35,7 +39,7 @@
   ],
   "evidence": [
     "HW1 unit-test output",
-    "official UR5e xacro extraction output",
+    "docs/hardware/hw1-ur5e-extraction.md: official UR5e xacro extraction command, source references and output hashes",
     "generated deterministic motor configuration"
   ],
   "stop_conditions": [

--- a/docs/task_packets/hw1-urdf-parser.json
+++ b/docs/task_packets/hw1-urdf-parser.json
@@ -1,0 +1,47 @@
+{
+  "issue": "HW1",
+  "human_owner": "TH3478",
+  "objective": "Extract deterministic motor-limit configuration from an expanded URDF without inventing hardware parameters that the URDF does not declare.",
+  "allowed_paths": [
+    "docs/task_packets/hw1-urdf-parser.json",
+    "libs/hardware/README.md",
+    "libs/hardware/urdf_to_motor_config.py",
+    "libs/hardware/workbench/hardware/__init__.py",
+    "libs/hardware/workbench/hardware/urdf_parser.py",
+    "tests/unit/test_hardware_urdf.py"
+  ],
+  "read_only_paths": [
+    "robot/control/**",
+    "robot/description/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**"
+  ],
+  "acceptance": [
+    "an expanded official UR5e URDF yields exactly six requested arm joints with documented effort, velocity and position limits",
+    "mechanical reduction is emitted only when an explicit URDF transmission declares it",
+    "missing, duplicate, non-finite or malformed motor parameters fail closed",
+    "the generated YAML is deterministic for the same URDF and joint selection"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/hw1-urdf-parser.json",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/unit/test_hardware_urdf.py -v",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "HW1 unit-test output",
+    "official UR5e xacro extraction output",
+    "generated deterministic motor configuration"
+  ],
+  "stop_conditions": [
+    "the official description does not expose six requested arm joints",
+    "a requested value would need to be guessed rather than read from controlled input",
+    "the implementation would require a write under interfaces, firmware or robot/control",
+    "the requested source is not an expanded URDF document"
+  ]
+}

--- a/docs/task_packets/hw1-urdf-parser.json
+++ b/docs/task_packets/hw1-urdf-parser.json
@@ -3,6 +3,7 @@
   "human_owner": "TH3478",
   "objective": "Extract deterministic motor-limit configuration from an expanded URDF without inventing hardware parameters that the URDF does not declare.",
   "allowed_paths": [
+    "Dockerfile",
     "docs/task_packets/hw1-urdf-parser.json",
     "docs/hardware/hw1-ur5e-extraction.md",
     "libs/hardware/README.md",
@@ -10,6 +11,7 @@
     "libs/hardware/workbench/hardware/__init__.py",
     "libs/hardware/workbench/hardware/urdf_parser.py",
     "pyproject.toml",
+    "tests/unit/test_container_baseline.py",
     "tests/unit/test_hardware_urdf.py"
   ],
   "read_only_paths": [
@@ -31,7 +33,7 @@
     "python3 tools/scripts/check_task_packet.py docs/task_packets/hw1-urdf-parser.json",
     "python3 -m pip install -e .",
     "python3 -c \"from workbench.hardware import parse_urdf_motor_config\"",
-    "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/unit/test_hardware_urdf.py -v",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/unit/test_hardware_urdf.py tests/unit/test_container_baseline.py -v",
     "make test",
     "make contract",
     "make scenario-check",

--- a/libs/hardware/README.md
+++ b/libs/hardware/README.md
@@ -2,17 +2,17 @@
 
 ## Overview
 
-嵌入式工程师 P1 实现 (HW1-HW7)
+嵌入式工程师 P1 模块。当前实现 HW1 的展开 URDF 参数提取；HW2-HW7 仍是后续任务。
 
 ## Components
 
-- **HW1**: URDF Parser (extract motor parameters)
-- **HW2**: CAN Driver (communicate with MCU)
-- **HW3**: Motor Feedback Parser (position/velocity/current)
-- **HW4**: PID Controller (closed-loop control)
-- **HW5**: Sensor Simulator (read from Gazebo)
-- **HW6**: Realtime Executor (100Hz control loop)
-- **HW7**: Integration Test Framework
+- **HW1**: URDF Parser (implemented)
+- **HW2**: CAN Driver (planned)
+- **HW3**: Motor Feedback Parser (planned)
+- **HW4**: PID Controller (planned)
+- **HW5**: Sensor Simulator (planned)
+- **HW6**: Realtime Executor (planned)
+- **HW7**: Integration Test Framework (planned)
 
 ## Architecture
 
@@ -28,37 +28,33 @@ Hardware Layer
     └─ Realtime Executor (100Hz)
 ```
 
-## Key Features
+## HW1 usage
 
-- **100Hz control loop**: Real-time execution with thread-based scheduling
-- **CAN communication**: Versioned message protocol (via K4-K5 from kernel)
-- **Motor feedback**: Position, velocity, current parsing
-- **PID control**: Closed-loop feedback control
-- **Sensor integration**: IMU + joint states from Gazebo
+The parser consumes expanded URDF XML, not Xacro source. Generate an official
+UR5e description and extract the six arm joints:
 
-## Usage
-
-```python
-from workbench.hardware.realtime_executor import RealtimeExecutor
-from workbench.hardware.pid_controller import PIDController
-
-executor = RealtimeExecutor(frequency=100)
-pid = PIDController(kp=10, ki=0.1, kd=1)
-
-def control_loop():
-    output = pid.compute(setpoint=1.0, feedback=0.5)
-    # send to motor via CAN
-
-executor.add_task(control_loop)
-executor.start()
+```bash
+source /opt/ros/jazzy/setup.bash
+xacro /opt/ros/jazzy/share/ur_description/urdf/ur.urdf.xacro \
+  ur_type:=ur5e name:=ur5e > /tmp/ur5e.urdf
+python3 libs/hardware/urdf_to_motor_config.py /tmp/ur5e.urdf \
+  --joint shoulder_pan_joint \
+  --joint shoulder_lift_joint \
+  --joint elbow_joint \
+  --joint wrist_1_joint \
+  --joint wrist_2_joint \
+  --joint wrist_3_joint
 ```
+
+`max_torque_nm`, velocity and position limits come from each URDF `<limit>`.
+`mechanical_reduction` is populated only when an explicit URDF transmission
+declares it. `null` means the controlled input did not declare a reduction; it
+must not be replaced with a guessed physical gearbox ratio.
 
 ## P1 Deliverables
 
-- HW1: Motor configuration from URDF
-- HW2-3: CAN communication + feedback parsing
-- HW4: PID controller tested
-- HW5-6: 100Hz real-time control loop
-- HW7: Full integration test passing
-
-All tests passing. Ready for P1 application layer integration.
+- HW1: Motor configuration from expanded URDF (implemented)
+- HW2-3: CAN communication + feedback parsing (planned)
+- HW4: PID controller (planned)
+- HW5-6: Sensor simulation + 100Hz real-time control loop (planned)
+- HW7: Full integration test (planned)

--- a/libs/hardware/README.md
+++ b/libs/hardware/README.md
@@ -51,6 +51,10 @@ python3 libs/hardware/urdf_to_motor_config.py /tmp/ur5e.urdf \
 declares it. `null` means the controlled input did not declare a reduction; it
 must not be replaced with a guessed physical gearbox ratio.
 
+The audited official-source extraction command, package versions, hashes and
+generated motor configuration are recorded in
+[`docs/hardware/hw1-ur5e-extraction.md`](../../docs/hardware/hw1-ur5e-extraction.md).
+
 ## P1 Deliverables
 
 - HW1: Motor configuration from expanded URDF (implemented)

--- a/libs/hardware/urdf_to_motor_config.py
+++ b/libs/hardware/urdf_to_motor_config.py
@@ -1,0 +1,35 @@
+import argparse
+import sys
+from pathlib import Path
+
+HARDWARE_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(HARDWARE_ROOT))
+
+from workbench.hardware.urdf_parser import (
+    UrdfMotorConfigError,
+    dump_motor_config_yaml,
+    load_urdf_motor_config,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract deterministic motor limits from an expanded URDF")
+    parser.add_argument("urdf", type=Path, help="path to expanded URDF XML")
+    parser.add_argument("--joint", action="append", dest="joints", help="joint to include, repeat in desired order")
+    parser.add_argument("--output", type=Path, help="write YAML to this path instead of stdout")
+    args = parser.parse_args()
+
+    try:
+        configs = load_urdf_motor_config(args.urdf, args.joints)
+        serialized = dump_motor_config_yaml(configs)
+        if args.output is None:
+            sys.stdout.write(serialized)
+        else:
+            args.output.write_text(serialized, encoding="utf-8")
+    except (OSError, UrdfMotorConfigError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/hardware/workbench/hardware/__init__.py
+++ b/libs/hardware/workbench/hardware/__init__.py
@@ -1,0 +1,15 @@
+from .urdf_parser import (
+    MotorConfig,
+    UrdfMotorConfigError,
+    dump_motor_config_yaml,
+    load_urdf_motor_config,
+    parse_urdf_motor_config,
+)
+
+__all__ = [
+    "MotorConfig",
+    "UrdfMotorConfigError",
+    "dump_motor_config_yaml",
+    "load_urdf_motor_config",
+    "parse_urdf_motor_config",
+]

--- a/libs/hardware/workbench/hardware/urdf_parser.py
+++ b/libs/hardware/workbench/hardware/urdf_parser.py
@@ -36,19 +36,32 @@ def _required_float(value: str | None, field: str, joint_name: str, *, positive:
 
 def _transmission_reductions(root: ElementTree.Element) -> dict[str, float]:
     reductions: dict[str, float] = {}
+    transmission_joints: set[str] = set()
     for transmission in root.findall("./transmission"):
-        reduction_elements = transmission.findall("./actuator/mechanicalReduction")
-        if not reduction_elements:
-            continue
         joint_elements = transmission.findall("./joint")
-        if len(joint_elements) != 1 or len(reduction_elements) != 1:
-            transmission_name = transmission.get("name", "<unnamed>")
+        actuator_elements = transmission.findall("./actuator")
+        transmission_name = transmission.get("name", "<unnamed>")
+        if len(joint_elements) != 1 or len(actuator_elements) != 1:
             raise UrdfMotorConfigError(
-                f"transmission {transmission_name!r} must declare one joint and one mechanicalReduction"
+                f"transmission {transmission_name!r} must declare exactly one joint and one actuator"
             )
         joint_name = joint_elements[0].get("name")
-        if not joint_name:
+        if not joint_name or not joint_name.strip():
             raise UrdfMotorConfigError("a transmission joint is missing its name")
+        if joint_name in transmission_joints:
+            raise UrdfMotorConfigError(f"joint {joint_name!r} has multiple transmission declarations")
+        transmission_joints.add(joint_name)
+
+        actuator = actuator_elements[0]
+        reduction_elements = actuator.findall("./mechanicalReduction")
+        all_reduction_elements = transmission.findall(".//mechanicalReduction")
+        if len(reduction_elements) != len(all_reduction_elements) or len(reduction_elements) > 1:
+            raise UrdfMotorConfigError(
+                f"transmission {transmission_name!r} must declare at most one actuator mechanicalReduction"
+            )
+        if not reduction_elements:
+            continue
+
         reduction_text = reduction_elements[0].text
         try:
             reduction = float(reduction_text) if reduction_text is not None else float("nan")
@@ -60,8 +73,6 @@ def _transmission_reductions(root: ElementTree.Element) -> dict[str, float]:
             raise UrdfMotorConfigError(
                 f"transmission for joint {joint_name!r} requires a finite positive mechanicalReduction"
             )
-        if joint_name in reductions:
-            raise UrdfMotorConfigError(f"joint {joint_name!r} has multiple mechanicalReduction declarations")
         reductions[joint_name] = reduction
     return reductions
 
@@ -78,16 +89,19 @@ def parse_urdf_motor_config(
         raise UrdfMotorConfigError("expanded URDF root element must be <robot>")
 
     joints: dict[str, ElementTree.Element] = {}
+    declared_joint_names: set[str] = set()
     discovered_names: list[str] = []
     for joint in root.findall("./joint"):
+        joint_name = joint.get("name")
+        if not joint_name or not joint_name.strip():
+            raise UrdfMotorConfigError("a joint declaration is missing its name")
+        if joint_name in declared_joint_names:
+            raise UrdfMotorConfigError(f"duplicate joint declaration {joint_name!r}")
+        declared_joint_names.add(joint_name)
+
         joint_type = joint.get("type")
         if joint_type not in {"continuous", "revolute"}:
             continue
-        joint_name = joint.get("name")
-        if not joint_name:
-            raise UrdfMotorConfigError("an actuated joint is missing its name")
-        if joint_name in joints:
-            raise UrdfMotorConfigError(f"duplicate actuated joint {joint_name!r}")
         joints[joint_name] = joint
         discovered_names.append(joint_name)
 
@@ -97,7 +111,9 @@ def parse_urdf_motor_config(
         if isinstance(joint_names, str):
             raise UrdfMotorConfigError("joint_names must be a sequence, not a string")
         selected_names = tuple(joint_names)
-        if not selected_names or any(not isinstance(name, str) or not name for name in selected_names):
+        if not selected_names or any(
+            not isinstance(name, str) or not name or not name.strip() for name in selected_names
+        ):
             raise UrdfMotorConfigError("joint_names requires non-empty joint names")
         if len(selected_names) != len(set(selected_names)):
             raise UrdfMotorConfigError("joint_names must not contain duplicates")
@@ -112,9 +128,10 @@ def parse_urdf_motor_config(
         if joint is None:
             raise UrdfMotorConfigError(f"requested actuated joint {joint_name!r} is not present")
         joint_type = joint.get("type")
-        limit = joint.find("./limit")
-        if limit is None:
-            raise UrdfMotorConfigError(f"joint {joint_name!r} is missing its <limit> element")
+        limit_elements = joint.findall("./limit")
+        if len(limit_elements) != 1:
+            raise UrdfMotorConfigError(f"joint {joint_name!r} must declare exactly one <limit> element")
+        limit = limit_elements[0]
         lower_limit: float | None = None
         upper_limit: float | None = None
         if joint_type == "revolute":

--- a/libs/hardware/workbench/hardware/urdf_parser.py
+++ b/libs/hardware/workbench/hardware/urdf_parser.py
@@ -1,0 +1,167 @@
+import json
+import math
+import xml.etree.ElementTree as ElementTree
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class UrdfMotorConfigError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class MotorConfig:
+    name: str
+    joint_type: str
+    max_torque_nm: float
+    max_velocity_rad_s: float
+    lower_limit_rad: float | None
+    upper_limit_rad: float | None
+    mechanical_reduction: float | None
+
+
+def _required_float(value: str | None, field: str, joint_name: str, *, positive: bool) -> float:
+    if value is None:
+        raise UrdfMotorConfigError(f"joint {joint_name!r} is missing limit.{field}")
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise UrdfMotorConfigError(f"joint {joint_name!r} has invalid limit.{field}: {value!r}") from exc
+    if not math.isfinite(parsed) or (positive and parsed <= 0):
+        requirement = "finite positive" if positive else "finite"
+        raise UrdfMotorConfigError(f"joint {joint_name!r} requires a {requirement} limit.{field}")
+    return parsed
+
+
+def _transmission_reductions(root: ElementTree.Element) -> dict[str, float]:
+    reductions: dict[str, float] = {}
+    for transmission in root.findall("./transmission"):
+        reduction_elements = transmission.findall("./actuator/mechanicalReduction")
+        if not reduction_elements:
+            continue
+        joint_elements = transmission.findall("./joint")
+        if len(joint_elements) != 1 or len(reduction_elements) != 1:
+            transmission_name = transmission.get("name", "<unnamed>")
+            raise UrdfMotorConfigError(
+                f"transmission {transmission_name!r} must declare one joint and one mechanicalReduction"
+            )
+        joint_name = joint_elements[0].get("name")
+        if not joint_name:
+            raise UrdfMotorConfigError("a transmission joint is missing its name")
+        reduction_text = reduction_elements[0].text
+        try:
+            reduction = float(reduction_text) if reduction_text is not None else float("nan")
+        except ValueError as exc:
+            raise UrdfMotorConfigError(
+                f"transmission for joint {joint_name!r} has invalid mechanicalReduction"
+            ) from exc
+        if not math.isfinite(reduction) or reduction <= 0:
+            raise UrdfMotorConfigError(
+                f"transmission for joint {joint_name!r} requires a finite positive mechanicalReduction"
+            )
+        if joint_name in reductions:
+            raise UrdfMotorConfigError(f"joint {joint_name!r} has multiple mechanicalReduction declarations")
+        reductions[joint_name] = reduction
+    return reductions
+
+
+def parse_urdf_motor_config(
+    urdf_xml: str,
+    joint_names: Sequence[str] | None = None,
+) -> tuple[MotorConfig, ...]:
+    try:
+        root = ElementTree.fromstring(urdf_xml)
+    except ElementTree.ParseError as exc:
+        raise UrdfMotorConfigError("input is not valid expanded URDF XML") from exc
+    if root.tag != "robot":
+        raise UrdfMotorConfigError("expanded URDF root element must be <robot>")
+
+    joints: dict[str, ElementTree.Element] = {}
+    discovered_names: list[str] = []
+    for joint in root.findall("./joint"):
+        joint_type = joint.get("type")
+        if joint_type not in {"continuous", "revolute"}:
+            continue
+        joint_name = joint.get("name")
+        if not joint_name:
+            raise UrdfMotorConfigError("an actuated joint is missing its name")
+        if joint_name in joints:
+            raise UrdfMotorConfigError(f"duplicate actuated joint {joint_name!r}")
+        joints[joint_name] = joint
+        discovered_names.append(joint_name)
+
+    if joint_names is None:
+        selected_names = tuple(discovered_names)
+    else:
+        if isinstance(joint_names, str):
+            raise UrdfMotorConfigError("joint_names must be a sequence, not a string")
+        selected_names = tuple(joint_names)
+        if not selected_names or any(not isinstance(name, str) or not name for name in selected_names):
+            raise UrdfMotorConfigError("joint_names requires non-empty joint names")
+        if len(selected_names) != len(set(selected_names)):
+            raise UrdfMotorConfigError("joint_names must not contain duplicates")
+
+    if not selected_names:
+        raise UrdfMotorConfigError("expanded URDF contains no actuated joints")
+
+    reductions = _transmission_reductions(root)
+    configs: list[MotorConfig] = []
+    for joint_name in selected_names:
+        joint = joints.get(joint_name)
+        if joint is None:
+            raise UrdfMotorConfigError(f"requested actuated joint {joint_name!r} is not present")
+        joint_type = joint.get("type")
+        limit = joint.find("./limit")
+        if limit is None:
+            raise UrdfMotorConfigError(f"joint {joint_name!r} is missing its <limit> element")
+        lower_limit: float | None = None
+        upper_limit: float | None = None
+        if joint_type == "revolute":
+            lower_limit = _required_float(limit.get("lower"), "lower", joint_name, positive=False)
+            upper_limit = _required_float(limit.get("upper"), "upper", joint_name, positive=False)
+            if lower_limit >= upper_limit:
+                raise UrdfMotorConfigError(f"joint {joint_name!r} requires lower limit below upper limit")
+        configs.append(
+            MotorConfig(
+                name=joint_name,
+                joint_type=joint_type,
+                max_torque_nm=_required_float(limit.get("effort"), "effort", joint_name, positive=True),
+                max_velocity_rad_s=_required_float(limit.get("velocity"), "velocity", joint_name, positive=True),
+                lower_limit_rad=lower_limit,
+                upper_limit_rad=upper_limit,
+                mechanical_reduction=reductions.get(joint_name),
+            )
+        )
+    return tuple(configs)
+
+
+def load_urdf_motor_config(
+    urdf_path: Path,
+    joint_names: Sequence[str] | None = None,
+) -> tuple[MotorConfig, ...]:
+    try:
+        urdf_xml = urdf_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise UrdfMotorConfigError(f"could not read expanded URDF: {urdf_path}") from exc
+    return parse_urdf_motor_config(urdf_xml, joint_names)
+
+
+def dump_motor_config_yaml(configs: Sequence[MotorConfig]) -> str:
+    if not configs:
+        raise UrdfMotorConfigError("at least one motor config is required")
+    lines = ["motors:"]
+    for config in configs:
+        lines.extend(
+            [
+                f"  - name: {json.dumps(config.name, ensure_ascii=False)}",
+                f"    joint_type: {json.dumps(config.joint_type)}",
+                f"    max_torque_nm: {config.max_torque_nm!r}",
+                f"    max_velocity_rad_s: {config.max_velocity_rad_s!r}",
+                f"    lower_limit_rad: {'null' if config.lower_limit_rad is None else repr(config.lower_limit_rad)}",
+                f"    upper_limit_rad: {'null' if config.upper_limit_rad is None else repr(config.upper_limit_rad)}",
+                "    mechanical_reduction: "
+                + ("null" if config.mechanical_reduction is None else repr(config.mechanical_reduction)),
+            ]
+        )
+    return "\n".join(lines) + "\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,25 @@ docs = [
   "mkdocstrings[python]>=0.27,<1",
 ]
 
-[tool.setuptools.packages.find]
-where = [
-  "libs/contracts",
-  "services/agent_runtime",
-  "services/backend",
-  "services/world_model",
-  "firmware/virtual_mcu",
+[tool.setuptools]
+packages = [
+  "workbench.hardware",
+  "workbench.kernel",
+  "workbench_agent_runtime",
+  "workbench_backend",
+  "workbench_contracts",
+  "workbench_virtual_mcu",
+  "workbench_world_model",
 ]
+
+[tool.setuptools.package-dir]
+"workbench.hardware" = "libs/hardware/workbench/hardware"
+"workbench.kernel" = "libs/kernel/workbench/kernel"
+workbench_agent_runtime = "services/agent_runtime/workbench_agent_runtime"
+workbench_backend = "services/backend/workbench_backend"
+workbench_contracts = "libs/contracts/workbench_contracts"
+workbench_virtual_mcu = "firmware/virtual_mcu/workbench_virtual_mcu"
+workbench_world_model = "services/world_model/workbench_world_model"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "libs/kernel/tests"]

--- a/tests/unit/test_container_baseline.py
+++ b/tests/unit/test_container_baseline.py
@@ -8,3 +8,14 @@ def test_runtime_and_devcontainer_use_the_same_immutable_base() -> None:
     for relative_path in ("Dockerfile", ".devcontainer/Dockerfile"):
         first_line = (ROOT / relative_path).read_text(encoding="utf-8").splitlines()[0]
         assert first_line == f"FROM ubuntu@{UBUNTU_24_04_DIGEST}"
+
+
+def test_runtime_container_copies_installable_workbench_packages_before_install() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    install_offset = dockerfile.index("python -m pip install --no-compile .")
+
+    for package_copy in (
+        "COPY libs/hardware ./libs/hardware",
+        "COPY libs/kernel ./libs/kernel",
+    ):
+        assert dockerfile.index(package_copy) < install_offset

--- a/tests/unit/test_hardware_urdf.py
+++ b/tests/unit/test_hardware_urdf.py
@@ -1,23 +1,15 @@
-import importlib.util
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]
-MODULE_NAME = "workbench_hardware_urdf_parser"
-MODULE_PATH = ROOT / "libs/hardware/workbench/hardware/urdf_parser.py"
-MODULE_SPEC = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
-if MODULE_SPEC is None or MODULE_SPEC.loader is None:
-    raise RuntimeError(f"could not load HW1 parser from {MODULE_PATH}")
-URDF_PARSER = importlib.util.module_from_spec(MODULE_SPEC)
-sys.modules[MODULE_NAME] = URDF_PARSER
-MODULE_SPEC.loader.exec_module(URDF_PARSER)
-
-UrdfMotorConfigError = URDF_PARSER.UrdfMotorConfigError
-dump_motor_config_yaml = URDF_PARSER.dump_motor_config_yaml
-load_urdf_motor_config = URDF_PARSER.load_urdf_motor_config
-parse_urdf_motor_config = URDF_PARSER.parse_urdf_motor_config
+import workbench.kernel
+from workbench.hardware import (
+    MotorConfig,
+    UrdfMotorConfigError,
+    dump_motor_config_yaml,
+    load_urdf_motor_config,
+    parse_urdf_motor_config,
+)
 
 ARM_JOINTS = (
     "shoulder_pan_joint",
@@ -58,6 +50,10 @@ UR5E_SHAPE_URDF = """<?xml version="1.0"?>
 
 
 class HardwareUrdfTests(unittest.TestCase):
+    def test_installed_package_exposes_hardware_api(self) -> None:
+        self.assertEqual(MotorConfig.__module__, "workbench.hardware.urdf_parser")
+        self.assertIsNotNone(workbench.kernel.__path__)
+
     def test_extracts_requested_ur5e_motor_limits_in_order(self) -> None:
         configs = parse_urdf_motor_config(UR5E_SHAPE_URDF, ARM_JOINTS)
 
@@ -118,6 +114,60 @@ class HardwareUrdfTests(unittest.TestCase):
 
         with self.assertRaises(UrdfMotorConfigError):
             parse_urdf_motor_config(duplicate, ARM_JOINTS)
+
+    def test_rejects_duplicate_limit_elements(self) -> None:
+        duplicate = UR5E_SHAPE_URDF.replace(
+            '<limit effort="150.0" lower="-6.283185307179586" upper="6.283185307179586" '
+            'velocity="3.141592653589793"/>',
+            """<limit effort="150.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>
+    <limit effort="1.0" lower="-1.0" upper="1.0" velocity="1.0"/>""",
+            1,
+        )
+
+        with self.assertRaises(UrdfMotorConfigError):
+            parse_urdf_motor_config(duplicate, ARM_JOINTS)
+
+    def test_rejects_malformed_transmission_structures(self) -> None:
+        cases = {
+            "multiple actuators with reduction": UR5E_SHAPE_URDF.replace(
+                '<actuator name="shoulder_pan_motor"><mechanicalReduction>1</mechanicalReduction></actuator>',
+                """<actuator name="shoulder_pan_motor"><mechanicalReduction>1</mechanicalReduction></actuator>
+    <actuator name="ambiguous_motor"/>""",
+            ),
+            "multiple joints without reduction": UR5E_SHAPE_URDF.replace(
+                '<joint name="shoulder_pan_joint"/>\n    '
+                '<actuator name="shoulder_pan_motor"><mechanicalReduction>1</mechanicalReduction></actuator>',
+                '<joint name="shoulder_pan_joint"/>\n    <joint name="elbow_joint"/>\n    '
+                '<actuator name="shoulder_pan_motor"/>',
+            ),
+            "misplaced reduction": UR5E_SHAPE_URDF.replace(
+                '<actuator name="shoulder_pan_motor"><mechanicalReduction>1</mechanicalReduction></actuator>',
+                '<actuator name="shoulder_pan_motor"/>\n    <mechanicalReduction>1</mechanicalReduction>',
+            ),
+        }
+
+        for label, urdf_xml in cases.items():
+            with self.subTest(label=label), self.assertRaises(UrdfMotorConfigError):
+                parse_urdf_motor_config(urdf_xml, ARM_JOINTS)
+
+    def test_rejects_duplicate_and_empty_joint_declarations(self) -> None:
+        duplicate_joint = UR5E_SHAPE_URDF.replace(
+            '<joint name="world_joint" type="fixed"/>',
+            '<joint name="shoulder_pan_joint" type="fixed"/>',
+        )
+        empty_joint = UR5E_SHAPE_URDF.replace('name="world_joint"', 'name="   "')
+        empty_transmission_joint = UR5E_SHAPE_URDF.replace(
+            '<joint name="shoulder_pan_joint"/>\n    <actuator',
+            '<joint name=""/>\n    <actuator',
+        )
+
+        for label, urdf_xml in {
+            "duplicate joint": duplicate_joint,
+            "empty joint": empty_joint,
+            "empty transmission joint": empty_transmission_joint,
+        }.items():
+            with self.subTest(label=label), self.assertRaises(UrdfMotorConfigError):
+                parse_urdf_motor_config(urdf_xml, ARM_JOINTS)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_hardware_urdf.py
+++ b/tests/unit/test_hardware_urdf.py
@@ -1,0 +1,124 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_NAME = "workbench_hardware_urdf_parser"
+MODULE_PATH = ROOT / "libs/hardware/workbench/hardware/urdf_parser.py"
+MODULE_SPEC = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"could not load HW1 parser from {MODULE_PATH}")
+URDF_PARSER = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_NAME] = URDF_PARSER
+MODULE_SPEC.loader.exec_module(URDF_PARSER)
+
+UrdfMotorConfigError = URDF_PARSER.UrdfMotorConfigError
+dump_motor_config_yaml = URDF_PARSER.dump_motor_config_yaml
+load_urdf_motor_config = URDF_PARSER.load_urdf_motor_config
+parse_urdf_motor_config = URDF_PARSER.parse_urdf_motor_config
+
+ARM_JOINTS = (
+    "shoulder_pan_joint",
+    "shoulder_lift_joint",
+    "elbow_joint",
+    "wrist_1_joint",
+    "wrist_2_joint",
+    "wrist_3_joint",
+)
+
+UR5E_SHAPE_URDF = """<?xml version="1.0"?>
+<robot name="ur5e">
+  <joint name="world_joint" type="fixed"/>
+  <joint name="shoulder_pan_joint" type="revolute">
+    <limit effort="150.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>
+  </joint>
+  <joint name="shoulder_lift_joint" type="revolute">
+    <limit effort="150.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>
+  </joint>
+  <joint name="elbow_joint" type="revolute">
+    <limit effort="150.0" lower="-3.141592653589793" upper="3.141592653589793" velocity="3.141592653589793"/>
+  </joint>
+  <joint name="wrist_1_joint" type="revolute">
+    <limit effort="28.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>
+  </joint>
+  <joint name="wrist_2_joint" type="revolute">
+    <limit effort="28.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>
+  </joint>
+  <joint name="wrist_3_joint" type="revolute">
+    <limit effort="28.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>
+  </joint>
+  <transmission name="shoulder_pan_trans">
+    <joint name="shoulder_pan_joint"/>
+    <actuator name="shoulder_pan_motor"><mechanicalReduction>1</mechanicalReduction></actuator>
+  </transmission>
+</robot>
+"""
+
+
+class HardwareUrdfTests(unittest.TestCase):
+    def test_extracts_requested_ur5e_motor_limits_in_order(self) -> None:
+        configs = parse_urdf_motor_config(UR5E_SHAPE_URDF, ARM_JOINTS)
+
+        self.assertEqual(tuple(config.name for config in configs), ARM_JOINTS)
+        self.assertEqual(len(configs), 6)
+        self.assertEqual(configs[0].max_torque_nm, 150.0)
+        self.assertEqual(configs[3].max_torque_nm, 28.0)
+        self.assertEqual(configs[0].max_velocity_rad_s, 3.141592653589793)
+        self.assertEqual(configs[0].mechanical_reduction, 1.0)
+        self.assertIsNone(configs[1].mechanical_reduction)
+
+    def test_yaml_is_deterministic_and_keeps_unknown_reduction_explicit(self) -> None:
+        configs = parse_urdf_motor_config(UR5E_SHAPE_URDF, ARM_JOINTS)
+        first = dump_motor_config_yaml(configs)
+        second = dump_motor_config_yaml(configs)
+
+        self.assertEqual(first, second)
+        self.assertIn('  - name: "shoulder_pan_joint"', first)
+        self.assertIn("    mechanical_reduction: 1.0", first)
+        self.assertIn("    mechanical_reduction: null", first)
+
+    def test_loads_expanded_urdf_from_utf8_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            urdf_path = Path(temporary_directory) / "ur5e.urdf"
+            urdf_path.write_text(UR5E_SHAPE_URDF, encoding="utf-8")
+            configs = load_urdf_motor_config(urdf_path, ARM_JOINTS)
+
+        self.assertEqual(len(configs), 6)
+
+    def test_rejects_missing_or_untrusted_parameters(self) -> None:
+        cases = {
+            "invalid xml": "<robot>",
+            "missing joint": UR5E_SHAPE_URDF,
+            "missing effort": UR5E_SHAPE_URDF.replace('effort="150.0" ', "", 1),
+            "non finite velocity": UR5E_SHAPE_URDF.replace('velocity="3.141592653589793"', 'velocity="nan"', 1),
+            "reversed limits": UR5E_SHAPE_URDF.replace(
+                'lower="-6.283185307179586" upper="6.283185307179586"',
+                'lower="7" upper="6"',
+                1,
+            ),
+        }
+        for label, urdf_xml in cases.items():
+            with self.subTest(label=label), self.assertRaises(UrdfMotorConfigError):
+                requested = ("missing_joint",) if label == "missing joint" else ARM_JOINTS
+                parse_urdf_motor_config(urdf_xml, requested)
+
+    def test_rejects_duplicate_mechanical_reduction(self) -> None:
+        duplicate = UR5E_SHAPE_URDF.replace(
+            "</robot>",
+            """
+  <transmission name="shoulder_pan_trans_duplicate">
+    <joint name="shoulder_pan_joint"/>
+    <actuator name="second_motor"><mechanicalReduction>2</mechanicalReduction></actuator>
+  </transmission>
+</robot>
+""",
+        )
+
+        with self.assertRaises(UrdfMotorConfigError):
+            parse_urdf_motor_config(duplicate, ARM_JOINTS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- extract ordered motor limits from expanded URDF
- preserve only explicitly declared mechanical reductions
- add CLI, behavior tests, HW1 Task Packet and documentation
- correct the previous inaccurate HW1-HW7 completion claim

## Safety boundaries

- no changes under interfaces/
- no changes under firmware/
- no changes under robot/control/
- missing mechanical reduction remains null instead of being guessed

## Validation

- HW1 tests: 5 passed
- full test suite: 152 passed
- make contract: passed
- make scenario-check: 12 frozen + 24 expanded passed
- make context-check: passed
- make lint: passed

## Evidence

- official ROS Jazzy UR5e Xacro produces six arm joints
- Task Packet: docs/task_packets/hw1-urdf-parser.json

Refs: HW1