### PR TITLE
fix(kernel): verify immutable message envelopes

### DIFF
--- a/docs/task_packets/kernel-envelope-lifecycle.json
+++ b/docs/task_packets/kernel-envelope-lifecycle.json
@@ -1,11 +1,9 @@
 {
-  "issue": "kernel-envelope-lifecycle",
+  "issue": "94",
   "human_owner": "Quchaosheng",
-  "objective": "Preserve communication envelope identity and implement the declared lifecycle shutdown transitions without silent node replacement.",
+  "objective": "Make kernel message envelopes immutable and verify serialized checksums before ingress.",
   "allowed_paths": [
     "libs/kernel/workbench/kernel/communication.py",
-    "libs/kernel/workbench/kernel/lifecycle.py",
-    "libs/kernel/tests/test_k1_k10.py",
     "tests/unit/test_kernel_envelope_lifecycle.py",
     "docs/task_packets/kernel-envelope-lifecycle.json"
   ],
@@ -19,21 +17,19 @@
     "interfaces/**"
   ],
   "acceptance": [
-    "serialized messages retain message_type",
-    "message checksums differ when envelope identity differs",
-    "active nodes can transition through deactivated to finalized",
-    "duplicate node creation is rejected",
+    "message payloads are deeply immutable and detached from caller-owned containers",
+    "serialized messages round trip through checksum verification",
+    "tampered, malformed, non-JSON and unknown-reserved-field envelopes fail closed",
     "repository lint and tests pass"
   ],
   "commands": [
-    "python libs/kernel/tests/test_k1_k10.py",
-    "python -m pytest tests/unit/test_kernel_envelope_lifecycle.py -q",
+    "python -m pytest tests/unit/test_kernel_envelope_lifecycle.py libs/kernel/tests/test_k1_k10.py -q",
     "python -m ruff check .",
     "python -m pytest tests/ -q"
   ],
   "evidence": [
     "envelope identity regression assertions",
-    "lifecycle transition regression assertions",
+    "tamper and deep-immutability regression assertions",
     "K1-K10 integration test output",
     "repository test output"
   ],

--- a/libs/kernel/workbench/kernel/communication.py
+++ b/libs/kernel/workbench/kernel/communication.py
@@ -1,37 +1,134 @@
 """K4-K5: 通信层和版本检查"""
 
 import hashlib
+import hmac
 import json
-from dataclasses import dataclass
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any
 
 
-@dataclass
+class MessageIntegrityError(ValueError):
+    """Raised when a serialized message envelope cannot be trusted."""
+
+
+def _freeze_json(value: Any, ancestors: set[int] | None = None) -> Any:
+    if value is None or isinstance(value, str | bool | int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("message payload floats must be finite")
+        return value
+    if isinstance(value, bytes | bytearray):
+        raise TypeError("message payload must contain JSON values")
+
+    active = set() if ancestors is None else ancestors
+    identity = id(value)
+    if identity in active:
+        raise TypeError("message payload must not contain recursive containers")
+    active.add(identity)
+    try:
+        if isinstance(value, Mapping):
+            frozen: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise TypeError("message payload keys must be strings")
+                frozen[key] = _freeze_json(item, active)
+            return MappingProxyType(frozen)
+        if isinstance(value, Sequence) and not isinstance(value, str):
+            return tuple(_freeze_json(item, active) for item in value)
+    finally:
+        active.remove(identity)
+    raise TypeError(f"unsupported message payload type: {type(value).__name__}")
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _require_text(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+@dataclass(frozen=True)
 class Message:
-    payload: dict[str, Any]
+    payload: Mapping[str, Any]
     message_type: str
     version: str
     actor: str
+    _checksum: str = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.payload, Mapping):
+            raise TypeError("message payload must be an object")
+        object.__setattr__(self, "payload", _freeze_json(self.payload))
+        object.__setattr__(self, "message_type", _require_text(self.message_type, "message_type"))
+        object.__setattr__(self, "version", _require_text(self.version, "version"))
+        object.__setattr__(self, "actor", _require_text(self.actor, "actor"))
+        object.__setattr__(self, "_checksum", self._compute_checksum())
+
+    def _compute_checksum(self) -> str:
+        envelope = self._envelope()
+        content = json.dumps(
+            envelope,
+            allow_nan=False,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+
+    def _envelope(self) -> dict[str, Any]:
+        return {
+            "actor": self.actor,
+            "message_type": self.message_type,
+            "payload": _thaw_json(self.payload),
+            "version": self.version,
+        }
 
     @property
     def checksum(self) -> str:
-        envelope = {
-            "actor": self.actor,
-            "message_type": self.message_type,
-            "payload": self.payload,
-            "version": self.version,
-        }
-        content = json.dumps(envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-        return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+        return self._checksum
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            **self.payload,
+            **_thaw_json(self.payload),
             "_message_type": self.message_type,
             "_version": self.version,
             "_checksum": self.checksum,
             "_actor": self.actor,
         }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "Message":
+        if not isinstance(value, Mapping):
+            raise MessageIntegrityError("serialized message must be an object")
+        required = {"_message_type", "_version", "_checksum", "_actor"}
+        missing = required - set(value)
+        if missing:
+            raise MessageIntegrityError(f"serialized message is missing fields: {sorted(missing)}")
+        unknown_reserved = {key for key in value if key.startswith("_") and key not in required}
+        if unknown_reserved:
+            raise MessageIntegrityError(f"serialized message has unknown reserved fields: {sorted(unknown_reserved)}")
+        checksum = value["_checksum"]
+        if not isinstance(checksum, str) or not checksum:
+            raise MessageIntegrityError("serialized message checksum must be a non-empty string")
+        payload = {key: item for key, item in value.items() if key not in required}
+        try:
+            message = cls(payload, value["_message_type"], value["_version"], value["_actor"])
+        except (TypeError, ValueError) as exc:
+            raise MessageIntegrityError(f"serialized message is invalid: {exc}") from exc
+        if not hmac.compare_digest(message.checksum, checksum):
+            raise MessageIntegrityError("serialized message checksum does not match its envelope")
+        return message
 
 
 class VersionValidator:

--- a/tests/unit/test_kernel_envelope_lifecycle.py
+++ b/tests/unit/test_kernel_envelope_lifecycle.py
@@ -6,7 +6,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 
-from workbench.kernel.communication import Message
+from workbench.kernel.communication import Message, MessageIntegrityError
 from workbench.kernel.lifecycle import LifecycleManager, LifecycleState
 
 
@@ -19,6 +19,42 @@ def test_message_serialization_retains_type_and_checks_full_envelope() -> None:
     assert encoded["_version"] == "1.0.0"
     assert encoded["_actor"] == "planner"
     assert grasp.checksum != place.checksum
+
+
+def test_message_payload_is_deeply_immutable_and_detached() -> None:
+    source = {"target": {"id": "red_block"}, "attempts": [1, 2]}
+    message = Message(source, "grasp", "1.0.0", "planner")
+    encoded = message.to_dict()
+
+    source["target"]["id"] = "blue_cylinder"
+    source["attempts"].append(3)
+
+    assert message.to_dict() == encoded
+    with pytest.raises(TypeError):
+        message.payload["target"] = {"id": "other"}
+    with pytest.raises(TypeError):
+        message.payload["target"]["id"] = "other"
+
+
+def test_message_round_trip_verifies_checksum_and_reserved_fields() -> None:
+    encoded = Message({"target": "red_block"}, "grasp", "1.0.0", "planner").to_dict()
+    assert Message.from_dict(encoded).to_dict() == encoded
+
+    encoded["target"] = "blue_cylinder"
+    with pytest.raises(MessageIntegrityError, match="checksum"):
+        Message.from_dict(encoded)
+
+    encoded = Message({"target": "red_block"}, "grasp", "1.0.0", "planner").to_dict()
+    encoded["_future"] = "unsupported"
+    with pytest.raises(MessageIntegrityError, match="reserved"):
+        Message.from_dict(encoded)
+
+
+def test_message_rejects_non_json_and_non_finite_payloads() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        Message({"confidence": float("nan")}, "observation", "1.0.0", "perception")
+    with pytest.raises(TypeError, match="JSON"):
+        Message({"raw": b"bytes"}, "observation", "1.0.0", "perception")
 
 
 def test_lifecycle_supports_shutdown_and_rejects_duplicate_nodes() -> None:


### PR DESCRIPTION
## Summary
- deep-freeze and validate JSON message payloads
- verify serialized envelope checksums on ingress
- reject tampering, non-finite values, and unknown reserved fields

## Verification
- python -m pytest tests/unit/test_kernel_envelope_lifecycle.py -q
- python -m pytest libs/kernel/tests/test_k1_k10.py -q
- python -m ruff check libs/kernel/workbench/kernel/communication.py tests/unit/test_kernel_envelope_lifecycle.py
- python tools/scripts/check_task_packet.py docs/task_packets/kernel-envelope-lifecycle.json

Closes #94