### PR TITLE
fix(kernel): reject schema version conflicts

### DIFF
--- a/docs/task_packets/kernel-version-registry.json
+++ b/docs/task_packets/kernel-version-registry.json
@@ -1,7 +1,7 @@
 {
-  "issue": "kernel-version-registry",
+  "issue": "97",
   "human_owner": "Quchaosheng",
-  "objective": "Persist schema versions durably and fail closed when the registry file is malformed or cannot be written.",
+  "objective": "Prevent published schema versions from being silently overwritten while preserving idempotent registration.",
   "allowed_paths": [
     "libs/kernel/workbench/kernel/version_registry.py",
     "libs/kernel/tests/test_k1_k10.py",
@@ -22,6 +22,8 @@
     "schema names and versions are validated",
     "malformed registry content fails closed",
     "failed persistence does not update in-memory state",
+    "identical registration is idempotent and does not rewrite the registry",
+    "conflicting content for an existing schema version is rejected before persistence",
     "repository lint and tests pass"
   ],
   "commands": [
@@ -33,6 +35,7 @@
   "evidence": [
     "registry reopen regression assertions",
     "malformed and failed-write assertions",
+    "idempotent and conflicting registration assertions",
     "K1-K10 integration test output",
     "repository test output"
   ],

--- a/libs/kernel/workbench/kernel/version_registry.py
+++ b/libs/kernel/workbench/kernel/version_registry.py
@@ -10,6 +10,10 @@ class VersionRegistryError(ValueError):
     """Raised when a version registry cannot be loaded or written safely."""
 
 
+class VersionConflictError(VersionRegistryError):
+    """Raised when a published schema version is registered with new content."""
+
+
 class VersionRegistry:
     def __init__(self, registry_file: Path):
         self.registry_file = registry_file
@@ -49,6 +53,13 @@ class VersionRegistry:
         if not isinstance(version, str) or not version:
             raise ValueError("schema version must be a non-empty string")
         with self._lock:
+            existing = self.versions.get(name, {}).get(version)
+            if version in self.versions.get(name, {}):
+                if existing == content:
+                    return
+                raise VersionConflictError(
+                    f"schema {name!r} version {version!r} is already registered with different content"
+                )
             updated = {schema: dict(versions) for schema, versions in self.versions.items()}
             updated.setdefault(name, {})[version] = content
             self._persist(updated)

--- a/tests/unit/test_kernel_version_registry.py
+++ b/tests/unit/test_kernel_version_registry.py
@@ -7,7 +7,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 
-from workbench.kernel.version_registry import VersionRegistry, VersionRegistryError
+from workbench.kernel.version_registry import VersionConflictError, VersionRegistry, VersionRegistryError
 
 
 def test_registry_survives_reopen_and_keeps_versions_separate(tmp_path: Path) -> None:
@@ -42,3 +42,33 @@ def test_unserializable_content_does_not_replace_in_memory_state(tmp_path: Path)
         registry.register_schema("action", "1.0.0", {"bad": {1, 2}})
     assert registry.versions == {}
     assert not path.exists()
+
+
+def test_identical_registration_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    registry = VersionRegistry(path)
+    content = {"type": "object", "required": ["id"]}
+    registry.register_schema("action", "1.0.0", content)
+    before = path.read_bytes()
+    before_mtime = path.stat().st_mtime_ns
+
+    registry.register_schema("action", "1.0.0", {"type": "object", "required": ["id"]})
+
+    assert path.read_bytes() == before
+    assert path.stat().st_mtime_ns == before_mtime
+    assert VersionRegistry(path).versions["action"]["1.0.0"] == content
+
+
+def test_conflicting_registration_is_rejected_without_writing(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    registry = VersionRegistry(path)
+    registry.register_schema("action", "1.0.0", {"required": ["id"]})
+    before = path.read_bytes()
+
+    with pytest.raises(VersionConflictError, match="already registered"):
+        registry.register_schema("action", "1.0.0", {"required": ["target"]})
+
+    assert registry.versions["action"]["1.0.0"] == {"required": ["id"]}
+    assert path.read_bytes() == before
+    assert not path.with_name(f".{path.name}.tmp").exists()
+    assert VersionRegistry(path).versions == registry.versions


### PR DESCRIPTION
## Summary
- make identical schema registration idempotent
- reject conflicting content for a published version
- preserve in-memory and on-disk registry state on conflict

## Verification
- python -m pytest tests/unit/test_kernel_version_registry.py libs/kernel/tests/test_k1_k10_extended.py -q
- python -m ruff check libs/kernel/workbench/kernel/version_registry.py tests/unit/test_kernel_version_registry.py
- python tools/scripts/check_task_packet.py docs/task_packets/kernel-version-registry.json

Closes #97