### PR TITLE
fix(kernel): preserve schema constraints in generated models

### DIFF
--- a/docs/task_packets/kernel-schema-compiler-correctness.json
+++ b/docs/task_packets/kernel-schema-compiler-correctness.json
@@ -1,7 +1,7 @@
 {
-  "issue": "kernel-schema-compiler-correctness",
+  "issue": "100",
   "human_owner": "Quchaosheng",
-  "objective": "Generate syntactically valid and minimally typed Python and TypeScript models from object-shaped JSON Schema files.",
+  "objective": "Preserve supported JSON Schema validation constraints in generated Python models and TypeScript metadata.",
   "allowed_paths": [
     "libs/kernel/workbench/kernel/schema_compiler.py",
     "libs/kernel/tests/test_k1_k10.py",
@@ -21,6 +21,9 @@
     "schema suffixes do not leak into generated identifiers",
     "generated Python compiles and produces an instantiable Pydantic model",
     "generated TypeScript has a valid interface declaration and typed fields",
+    "numeric bounds, minItems, patterns and supported conditionals are enforced by generated Pydantic models",
+    "explicit additionalProperties false rejects extra fields",
+    "unsupported schema keywords fail compilation with field context",
     "repository lint and tests pass"
   ],
   "commands": [

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -7,6 +7,29 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_SUFFIX = ".schema.json"
+ROOT_KEYWORDS = {
+    "$schema",
+    "title",
+    "description",
+    "type",
+    "required",
+    "properties",
+    "additionalProperties",
+    "allOf",
+}
+PROPERTY_KEYWORDS = {
+    "$ref",
+    "description",
+    "enum",
+    "items",
+    "maximum",
+    "minimum",
+    "minItems",
+    "pattern",
+    "properties",
+    "required",
+    "type",
+}
 
 
 def _model_name(value: str) -> str:
@@ -72,6 +95,108 @@ def _typescript_type(definition: dict[str, Any]) -> str:
     return "unknown"
 
 
+def _python_annotation(definition: dict[str, Any], base_annotation: str | None = None) -> str:
+    annotation = _python_type(definition) if base_annotation is None else base_annotation
+    constraints = []
+    if "minimum" in definition:
+        constraints.append(f"ge={definition['minimum']!r}")
+    if "maximum" in definition:
+        constraints.append(f"le={definition['maximum']!r}")
+    if "minItems" in definition:
+        constraints.append(f"min_length={definition['minItems']!r}")
+    if "pattern" in definition:
+        constraints.append(f"pattern={definition['pattern']!r}")
+    if constraints:
+        return f"Annotated[{annotation}, Field({', '.join(constraints)})]"
+    return annotation
+
+
+def _typescript_constraint_comment(definition: dict[str, Any]) -> str | None:
+    constraints = [
+        f"minimum: {definition['minimum']}" if "minimum" in definition else None,
+        f"maximum: {definition['maximum']}" if "maximum" in definition else None,
+        f"minItems: {definition['minItems']}" if "minItems" in definition else None,
+        f"pattern: {definition['pattern']}" if "pattern" in definition else None,
+    ]
+    present = [constraint for constraint in constraints if constraint]
+    return f"  /** {'; '.join(present)} */" if present else None
+
+
+def _validate_definition(definition: dict[str, Any], location: str) -> None:
+    unsupported = set(definition) - PROPERTY_KEYWORDS
+    if unsupported:
+        raise ValueError(f"unsupported schema keyword(s) at {location}: {sorted(unsupported)}")
+    if "minimum" in definition and not isinstance(definition["minimum"], int | float):
+        raise ValueError(f"minimum must be numeric at {location}")
+    if "maximum" in definition and not isinstance(definition["maximum"], int | float):
+        raise ValueError(f"maximum must be numeric at {location}")
+    if "minItems" in definition and (
+        type(definition["minItems"]) is not int or definition["minItems"] < 0
+    ):
+        raise ValueError(f"minItems must be a non-negative integer at {location}")
+    if "pattern" in definition and not isinstance(definition["pattern"], str):
+        raise ValueError(f"pattern must be a string at {location}")
+    items = definition.get("items")
+    if items is not None:
+        if not isinstance(items, dict):
+            raise ValueError(f"items must be an object at {location}")
+        _validate_definition(items, f"{location}.items")
+    properties = definition.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict):
+            raise ValueError(f"properties must be an object at {location}")
+        for field_name, nested in properties.items():
+            if not isinstance(nested, dict):
+                raise ValueError(f"property definition must be an object: {location}.{field_name}")
+            _validate_definition(nested, f"{location}.{field_name}")
+
+
+def _conditional_validators(schema: dict[str, Any], name: str) -> tuple[list[str], list[dict[str, Any]]]:
+    lines: list[str] = []
+    metadata: list[dict[str, Any]] = []
+    for index, conditional in enumerate(schema.get("allOf", []), start=1):
+        try:
+            condition_properties = conditional["if"]["properties"]
+            then_properties = conditional["then"]["properties"]
+        except (KeyError, TypeError) as exc:
+            raise ValueError(f"unsupported allOf conditional in schema {name} at index {index}") from exc
+        if len(condition_properties) != 1 or len(then_properties) != 1:
+            raise ValueError(f"allOf conditional must target one field in schema {name} at index {index}")
+        condition_field, condition = next(iter(condition_properties.items()))
+        target_field, constraint = next(iter(then_properties.items()))
+        if not isinstance(condition, dict) or set(condition) != {"const"}:
+            raise ValueError(f"allOf condition must use one const in schema {name} at index {index}")
+        if not isinstance(constraint, dict) or set(constraint) - {"minimum", "maximum"}:
+            raise ValueError(f"allOf result must use numeric bounds in schema {name} at index {index}")
+        checks = []
+        if "minimum" in constraint:
+            checks.append(f"self.{target_field} < {constraint['minimum']!r}")
+        if "maximum" in constraint:
+            checks.append(f"self.{target_field} > {constraint['maximum']!r}")
+        if not checks:
+            raise ValueError(f"allOf result has no supported bound in schema {name} at index {index}")
+        error_message = (
+            f"{target_field} violates the {condition_field}={condition['const']!r} constraint"
+        )
+        lines.extend(
+            [
+                "",
+                "    @model_validator(mode=\"after\")",
+                f"    def _validate_conditional_{index}(self):",
+                f"        if self.{condition_field} == {condition['const']!r} and ({' or '.join(checks)}):",
+                f"            raise ValueError({error_message!r})",
+                "        return self",
+            ]
+        )
+        metadata.append(
+            {
+                "if": {condition_field: condition["const"]},
+                "then": {target_field: constraint},
+            }
+        )
+    return lines, metadata
+
+
 class SchemaCompiler:
     """Generate importable Pydantic models and valid TypeScript interfaces."""
 
@@ -89,41 +214,156 @@ class SchemaCompiler:
                 raise ValueError(f"schema root must be an object: {schema_file.name}")
             self.schemas[name] = schema
 
+    def _resolve_ref(self, reference: Any, location: str) -> tuple[str, dict[str, Any]]:
+        if not isinstance(reference, str) or "/" in reference or "\\" in reference:
+            raise ValueError(f"only local schema file references are supported at {location}")
+        name = reference.removesuffix(SCHEMA_SUFFIX)
+        schema = self.schemas.get(name)
+        if schema is None:
+            raise ValueError(f"unknown schema reference {reference!r} at {location}")
+        return _model_name(schema.get("title", name)), schema
+
+    def _python_base_annotation(
+        self,
+        definition: dict[str, Any],
+        suggested_name: str,
+        location: str,
+        class_blocks: list[str],
+        generated: dict[str, dict[str, Any]],
+    ) -> str:
+        if "$ref" in definition:
+            class_name, referenced_schema = self._resolve_ref(definition["$ref"], location)
+            self._append_python_model(class_name, referenced_schema, location, class_blocks, generated)
+            return class_name
+        schema_type = definition.get("type")
+        if schema_type == "array":
+            items = definition.get("items")
+            if not isinstance(items, dict):
+                return "list[Any]"
+            item_annotation = self._python_base_annotation(
+                items,
+                f"{suggested_name}Item",
+                f"{location}.items",
+                class_blocks,
+                generated,
+            )
+            item_annotation = _python_annotation(items, item_annotation)
+            return f"list[{item_annotation}]"
+        if schema_type == "object" and isinstance(definition.get("properties"), dict):
+            self._append_python_model(suggested_name, definition, location, class_blocks, generated)
+            return suggested_name
+        return _python_type(definition)
+
+    def _append_python_model(
+        self,
+        class_name: str,
+        schema: dict[str, Any],
+        location: str,
+        class_blocks: list[str],
+        generated: dict[str, dict[str, Any]],
+    ) -> None:
+        existing = generated.get(class_name)
+        if existing is not None:
+            if existing != schema:
+                raise ValueError(f"generated model name collision for {class_name} at {location}")
+            return
+        generated[class_name] = schema
+
+        unsupported_root = set(schema) - ROOT_KEYWORDS
+        if unsupported_root:
+            raise ValueError(f"unsupported schema keyword(s) at {location}: {sorted(unsupported_root)}")
+        properties = schema.get("properties", {})
+        if schema.get("type") != "object" or not isinstance(properties, dict):
+            raise ValueError(f"schema must describe an object at {location}")
+        required = set(schema.get("required", []))
+        additional_properties = schema.get("additionalProperties", True)
+        if type(additional_properties) is not bool:
+            raise ValueError(f"additionalProperties must be boolean at {location}")
+
+        fields = []
+        for field_name, definition in properties.items():
+            if not isinstance(definition, dict):
+                raise ValueError(f"property definition must be an object: {location}.{field_name}")
+            if not field_name.isidentifier() or keyword.iskeyword(field_name):
+                raise ValueError(f"property cannot produce a Python field: {location}.{field_name}")
+            field_location = f"{location}.{field_name}"
+            _validate_definition(definition, field_location)
+            nested_name = f"{class_name}{_model_name(field_name)}"
+            base_annotation = self._python_base_annotation(
+                definition,
+                nested_name,
+                field_location,
+                class_blocks,
+                generated,
+            )
+            annotation = _python_annotation(definition, base_annotation)
+            optional = field_name not in required
+            if optional and "None" not in annotation.split(" | "):
+                annotation += " | None"
+            fields.append(f"    {field_name}: {annotation}{' = None' if optional else ''}")
+
+        conditional_lines, _ = _conditional_validators(schema, location)
+        if not additional_properties:
+            fields.insert(0, '    model_config = ConfigDict(extra="forbid")')
+        body = "\n".join([*fields, *conditional_lines]) or "    pass"
+        class_blocks.append(f"class {class_name}(BaseModel):\n{body}\n")
+
     def compile_all(self, output_py: Path, output_ts: Path) -> None:
         output_py.mkdir(parents=True, exist_ok=True)
         output_ts.mkdir(parents=True, exist_ok=True)
 
         for name, schema in self.schemas.items():
+            unsupported_root = set(schema) - ROOT_KEYWORDS
+            if unsupported_root:
+                raise ValueError(f"unsupported schema keyword(s) in {name}: {sorted(unsupported_root)}")
             model_name = _model_name(schema.get("title", name))
             properties = schema.get("properties", {})
             if schema.get("type") != "object" or not isinstance(properties, dict):
                 raise ValueError(f"schema must describe an object: {name}")
             required = set(schema.get("required", []))
+            additional_properties = schema.get("additionalProperties", True)
+            if type(additional_properties) is not bool:
+                raise ValueError(f"additionalProperties must be boolean in schema {name}")
 
-            python_fields = []
             typescript_fields = []
+            constraint_metadata: dict[str, Any] = {}
             for field_name, definition in properties.items():
                 if not isinstance(definition, dict):
                     raise ValueError(f"property definition must be an object: {name}.{field_name}")
                 if not field_name.isidentifier() or keyword.iskeyword(field_name):
                     raise ValueError(f"property cannot produce a Python field: {name}.{field_name}")
-                python_annotation = _python_type(definition)
+                _validate_definition(definition, f"{name}.{field_name}")
                 optional = field_name not in required
-                if optional and "None" not in python_annotation.split(" | "):
-                    python_annotation += " | None"
-                default = "" if not optional else " = None"
-                python_fields.append(f"    {field_name}: {python_annotation}{default}")
                 marker = "" if not optional else "?"
+                comment = _typescript_constraint_comment(definition)
+                if comment:
+                    typescript_fields.append(comment)
+                    constraint_metadata[field_name] = {
+                        key: definition[key]
+                        for key in ("minimum", "maximum", "minItems", "pattern")
+                        if key in definition
+                    }
                 typescript_fields.append(f"  {json.dumps(field_name)}{marker}: {_typescript_type(definition)};")
 
-            python_body = "\n".join(python_fields) or "    pass"
+            _, conditional_metadata = _conditional_validators(schema, name)
+            class_blocks: list[str] = []
+            self._append_python_model(model_name, schema, name, class_blocks, {})
             python_code = (
-                "from typing import Any, Literal\n\n"
-                "from pydantic import BaseModel\n\n\n"
-                f"class {model_name}(BaseModel):\n{python_body}\n"
+                "from typing import Annotated, Any, Literal\n\n"
+                "from pydantic import BaseModel, ConfigDict, Field, model_validator\n\n\n"
+                + "\n\n".join(class_blocks)
             )
             typescript_body = "\n".join(typescript_fields)
-            typescript_code = f"export interface {model_name} {{\n{typescript_body}\n}}\n"
+            metadata = {
+                "fields": constraint_metadata,
+                "conditionals": conditional_metadata,
+                "additionalProperties": additional_properties,
+            }
+            typescript_code = (
+                f"export interface {model_name} {{\n{typescript_body}\n}}\n\n"
+                f"export const {model_name}Constraints = {json.dumps(metadata, indent=2)} as const;\n\n"
+                f"export const {model_name}Schema = {json.dumps(schema, indent=2)} as const;\n"
+            )
             (output_py / f"{name}.py").write_text(python_code, encoding="utf-8")
             (output_ts / f"{name}.ts").write_text(typescript_code, encoding="utf-8")
 

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -130,9 +130,7 @@ def _validate_definition(definition: dict[str, Any], location: str) -> None:
         raise ValueError(f"minimum must be numeric at {location}")
     if "maximum" in definition and not isinstance(definition["maximum"], int | float):
         raise ValueError(f"maximum must be numeric at {location}")
-    if "minItems" in definition and (
-        type(definition["minItems"]) is not int or definition["minItems"] < 0
-    ):
+    if "minItems" in definition and (type(definition["minItems"]) is not int or definition["minItems"] < 0):
         raise ValueError(f"minItems must be a non-negative integer at {location}")
     if "pattern" in definition and not isinstance(definition["pattern"], str):
         raise ValueError(f"pattern must be a string at {location}")
@@ -175,13 +173,11 @@ def _conditional_validators(schema: dict[str, Any], name: str) -> tuple[list[str
             checks.append(f"self.{target_field} > {constraint['maximum']!r}")
         if not checks:
             raise ValueError(f"allOf result has no supported bound in schema {name} at index {index}")
-        error_message = (
-            f"{target_field} violates the {condition_field}={condition['const']!r} constraint"
-        )
+        error_message = f"{target_field} violates the {condition_field}={condition['const']!r} constraint"
         lines.extend(
             [
                 "",
-                "    @model_validator(mode=\"after\")",
+                '    @model_validator(mode="after")',
                 f"    def _validate_conditional_{index}(self):",
                 f"        if self.{condition_field} == {condition['const']!r} and ({' or '.join(checks)}):",
                 f"            raise ValueError({error_message!r})",
@@ -350,8 +346,7 @@ class SchemaCompiler:
             self._append_python_model(model_name, schema, name, class_blocks, {})
             python_code = (
                 "from typing import Annotated, Any, Literal\n\n"
-                "from pydantic import BaseModel, ConfigDict, Field, model_validator\n\n\n"
-                + "\n\n".join(class_blocks)
+                "from pydantic import BaseModel, ConfigDict, Field, model_validator\n\n\n" + "\n\n".join(class_blocks)
             )
             typescript_body = "\n".join(typescript_fields)
             metadata = {

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -103,8 +103,7 @@ def test_explicit_extra_forbid_and_unsupported_keywords_fail_closed(tmp_path: Pa
     schema_dir = tmp_path / "schemas"
     schema_dir.mkdir()
     (schema_dir / "strict.schema.json").write_text(
-        '{"title":"Strict","type":"object","additionalProperties":false,'
-        '"properties":{"id":{"type":"string"}}}',
+        '{"title":"Strict","type":"object","additionalProperties":false,' '"properties":{"id":{"type":"string"}}}',
         encoding="utf-8",
     )
     compiler = SchemaCompiler(schema_dir)

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import pytest
 from pydantic import BaseModel
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -30,3 +31,96 @@ def test_generated_models_are_valid_and_typed(tmp_path: Path) -> None:
     assert '"action_id": string;' in typescript
     assert '"error_code"?: number | null;' in typescript
     assert all(compiler.verify_type_compatibility().values())
+
+
+def generated_model(tmp_path: Path, schema_name: str, model_name: str):
+    compiler = SchemaCompiler(ROOT / "interfaces" / "json_schema")
+    compiler.load_schemas()
+    python_dir = tmp_path / "python"
+    compiler.compile_all(python_dir, tmp_path / "typescript")
+    generated = python_dir / f"{schema_name}.py"
+    namespace = {}
+    exec(compile(generated.read_text(encoding="utf-8"), str(generated), "exec"), namespace)
+    return namespace[model_name]
+
+
+def test_generated_models_enforce_repository_constraints(tmp_path: Path) -> None:
+    world_event = generated_model(tmp_path, "world_event", "WorldEvent")
+    with pytest.raises(ValueError):
+        world_event(event_id="e", run_id="r", sequence_no=-1, event_type="fault", occurred_at="t", payload={})
+
+    task_graph = generated_model(tmp_path, "task_graph", "TaskGraph")
+    with pytest.raises(ValueError):
+        task_graph(task_id="t", goal="g", steps=[], planner="p", model_route="template")
+
+    world_state = generated_model(tmp_path, "world_state", "WorldState")
+    with pytest.raises(ValueError):
+        world_state(run_id="r", sequence_no=0, state_hash="short", entities=[], reduced_at="t")
+    with pytest.raises(ValueError):
+        world_state(
+            run_id="r",
+            sequence_no=0,
+            state_hash="0" * 64,
+            entities=[{"entity_id": "x", "entity_type": "block", "belief": "observed", "confidence": 2.0}],
+            reduced_at="t",
+        )
+
+
+def test_generated_models_validate_local_references(tmp_path: Path) -> None:
+    observation = generated_model(tmp_path, "observation", "Observation")
+    valid = {
+        "observation_id": "o",
+        "run_id": "r",
+        "entity_id": "x",
+        "entity_type": "block",
+        "pose": {
+            "frame_id": "world",
+            "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+            "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        },
+        "confidence": 0.9,
+        "observed_at": "t",
+        "source": "camera-1",
+        "evidence_refs": ["frame://1"],
+    }
+    assert observation(**valid)
+    valid["pose"]["position"]["x"] = "not-a-number"
+    with pytest.raises(ValueError):
+        observation(**valid)
+
+
+def test_generated_mcu_model_enforces_conditional_ranges(tmp_path: Path) -> None:
+    mcu_frame = generated_model(tmp_path, "mcu_protocol", "McuFrame")
+    with pytest.raises(ValueError, match="frame_kind"):
+        mcu_frame(frame_id="f", frame_kind="command", command_id=40000, sent_at="t")
+    with pytest.raises(ValueError, match="frame_kind"):
+        mcu_frame(frame_id="f", frame_kind="stop", command_id=10, sent_at="t")
+    assert mcu_frame(frame_id="f", frame_kind="command", command_id=32767, sent_at="t")
+    assert mcu_frame(frame_id="f", frame_kind="stop", command_id=32768, sent_at="t")
+
+
+def test_explicit_extra_forbid_and_unsupported_keywords_fail_closed(tmp_path: Path) -> None:
+    schema_dir = tmp_path / "schemas"
+    schema_dir.mkdir()
+    (schema_dir / "strict.schema.json").write_text(
+        '{"title":"Strict","type":"object","additionalProperties":false,'
+        '"properties":{"id":{"type":"string"}}}',
+        encoding="utf-8",
+    )
+    compiler = SchemaCompiler(schema_dir)
+    compiler.load_schemas()
+    python_dir = tmp_path / "strict-python"
+    compiler.compile_all(python_dir, tmp_path / "strict-typescript")
+    namespace = {}
+    generated = python_dir / "strict.py"
+    exec(compile(generated.read_text(encoding="utf-8"), str(generated), "exec"), namespace)
+    with pytest.raises(ValueError):
+        namespace["Strict"](id="x", unexpected=True)
+
+    (schema_dir / "unsupported.schema.json").write_text(
+        '{"title":"Unsupported","type":"object","properties":{"id":{"type":"string","format":"uuid"}}}',
+        encoding="utf-8",
+    )
+    compiler.load_schemas()
+    with pytest.raises(ValueError, match="unsupported.*format"):
+        compiler.compile_all(tmp_path / "bad-python", tmp_path / "bad-typescript")


### PR DESCRIPTION
## Summary
- generate recursive Pydantic models for inline objects and local references
- enforce numeric bounds, minItems, patterns, and MCU conditional ranges
- expose TypeScript runtime constraint/schema metadata
- fail compilation on unsupported schema keywords

## Verification
- python -m pytest tests/unit/test_kernel_schema_compiler.py libs/kernel/tests/test_k1_k10.py -q
- python -m ruff check libs/kernel/workbench/kernel/schema_compiler.py tests/unit/test_kernel_schema_compiler.py
- python tools/scripts/validate_contracts.py
- python tools/scripts/check_task_packet.py docs/task_packets/kernel-schema-compiler-correctness.json

Closes #100