### PR TITLE
fix(kernel): validate event log integrity

### DIFF
--- a/docs/task_packets/kernel-event-store-checkpoints.json
+++ b/docs/task_packets/kernel-event-store-checkpoints.json
@@ -1,10 +1,12 @@
 {
-  "issue": "kernel-event-store-checkpoints",
+  "issue": "95",
   "human_owner": "Quchaosheng",
-  "objective": "Keep append-only event checkpoints correct across process restarts and reject unsafe replay boundaries.",
+  "objective": "Enforce event identity, run isolation and contiguous sequence integrity across append, replay and checkpoints.",
   "allowed_paths": [
     "libs/kernel/workbench/kernel/event_store.py",
     "libs/kernel/tests/test_k1_k10.py",
+    "libs/kernel/tests/test_k1_k10_extended.py",
+    "libs/kernel/README.md",
     "tests/unit/test_kernel_event_store.py",
     "docs/task_packets/kernel-event-store-checkpoints.json"
   ],
@@ -22,6 +24,8 @@
     "replay from the current checkpoint returns no historical events",
     "negative, boolean, and out-of-range checkpoints are rejected",
     "malformed and non-object log records fail closed",
+    "default append rejects missing fields, duplicate event IDs, mixed runs, sequence gaps and unknown event types",
+    "legacy object logs require an explicit migration-only constructor flag",
     "repository lint and tests pass"
   ],
   "commands": [
@@ -33,6 +37,7 @@
   "evidence": [
     "restart checkpoint regression assertions",
     "corrupt-log failure assertions",
+    "event-contract, identity, run and sequence regression assertions",
     "K1-K10 integration test output",
     "repository test output"
   ],

--- a/libs/kernel/README.md
+++ b/libs/kernel/README.md
@@ -27,7 +27,14 @@ compiler.compile_all(py_output_dir, ts_output_dir)
 
 # Event logging
 store = EventStore(log_file)
-store.append({"event": "data"})
+store.append({
+    "event_id": "event-1",
+    "run_id": "run-1",
+    "sequence_no": 0,
+    "event_type": "observation",
+    "occurred_at": "2026-08-13T00:00:00Z",
+    "payload": {"entity_id": "red_block"},
+})
 checkpoint = store.create_checkpoint()
 replayed_events = store.replay(from_checkpoint=checkpoint)
 
@@ -36,6 +43,9 @@ manager = LifecycleManager()
 node = manager.create_node("kernel")
 manager.startup_sequence()
 ```
+
+The default Event Store accepts one contiguous, contract-shaped run. Open legacy
+object logs with `EventStore(path, legacy_objects=True)` only while migrating them.
 
 ## Tests
 

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -72,7 +72,7 @@ def test_all():
 
         # K6-K7: Event Store
         log = tmp_path / "events.jsonl"
-        store = EventStore(log)
+        store = EventStore(log, legacy_objects=True)
         for i in range(10):
             store.append({"id": i})
         cp = store.create_checkpoint()
@@ -80,7 +80,7 @@ def test_all():
         replayed = store.replay(from_checkpoint=0)
         assert len(replayed) == 10
         assert store.verify_integrity()
-        reopened = EventStore(log)
+        reopened = EventStore(log, legacy_objects=True)
         reopened.append({"id": 10})
         restart_checkpoint = reopened.create_checkpoint()
         assert restart_checkpoint == 11
@@ -179,17 +179,17 @@ def test_event_store_persistence():
     """K6-K7: 事件持久化"""
     with tempfile.TemporaryDirectory() as tmpdir:
         log_file = Path(tmpdir) / "test.jsonl"
-        store1 = EventStore(log_file)
+        store1 = EventStore(log_file, legacy_objects=True)
         store1.append({"data": "test"})
 
-        store2 = EventStore(log_file)
+        store2 = EventStore(log_file, legacy_objects=True)
         assert store2.replay() == [{"data": "test"}]
 
 
 def test_event_store_checkpoint():
     """K6-K7: 事件检查点"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "test.jsonl")
+        store = EventStore(Path(tmpdir) / "test.jsonl", legacy_objects=True)
         for i in range(5):
             store.append({"index": i})
 
@@ -204,7 +204,7 @@ def test_event_store_checkpoint():
 def test_event_store_scale():
     """K6-K7: 大规模事件"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "large.jsonl")
+        store = EventStore(Path(tmpdir) / "large.jsonl", legacy_objects=True)
         for i in range(100):
             store.append({"id": i})
         assert len(store.events) == 100
@@ -255,7 +255,7 @@ def test_perf_event():
     import time
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "perf.jsonl")
+        store = EventStore(Path(tmpdir) / "perf.jsonl", legacy_objects=True)
         start = time.time()
         for i in range(100):
             store.append({"data": i})
@@ -273,7 +273,7 @@ def test_versioned_message_preserves_type():
 def test_event_store_replays_existing_object_shape():
     """事件存储可以重放已持久化的对象事件。"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "compat.jsonl")
+        store = EventStore(Path(tmpdir) / "compat.jsonl", legacy_objects=True)
         for i in range(5):
             store.append({"type": "event", "id": i})
 

--- a/libs/kernel/tests/test_k1_k10_extended.py
+++ b/libs/kernel/tests/test_k1_k10_extended.py
@@ -90,7 +90,7 @@ def test_message_batch():
 def test_event_append():
     """K6-K7: 追加事件"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "events.jsonl")
+        store = EventStore(Path(tmpdir) / "events.jsonl", legacy_objects=True)
         store.append({"action": "start"})
         assert len(store.events) == 1
 
@@ -98,7 +98,7 @@ def test_event_append():
 def test_event_multiple():
     """K6-K7: 多个事件"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "events.jsonl")
+        store = EventStore(Path(tmpdir) / "events.jsonl", legacy_objects=True)
         for i in range(5):
             store.append({"index": i})
         assert len(store.events) == 5
@@ -109,11 +109,11 @@ def test_event_replay():
     with tempfile.TemporaryDirectory() as tmpdir:
         log_file = Path(tmpdir) / "events.jsonl"
 
-        store1 = EventStore(log_file)
+        store1 = EventStore(log_file, legacy_objects=True)
         for i in range(3):
             store1.append({"data": i})
 
-        store2 = EventStore(log_file)
+        store2 = EventStore(log_file, legacy_objects=True)
         replayed = store2.replay()
         assert len(replayed) >= 3
 
@@ -188,7 +188,7 @@ def test_perf_message_creation():
 def test_perf_event_append():
     """性能: 事件追加延迟"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "perf.jsonl")
+        store = EventStore(Path(tmpdir) / "perf.jsonl", legacy_objects=True)
 
         start = time.time()
         for i in range(100):
@@ -224,7 +224,7 @@ def test_versioned_message_format():
 def test_event_object_format_replay():
     """对象事件可以持久化并重放。"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        store = EventStore(Path(tmpdir) / "compat.jsonl")
+        store = EventStore(Path(tmpdir) / "compat.jsonl", legacy_objects=True)
         # 模拟旧格式事件
         store.append({"type": "legacy", "version": "0.9.0"})
 

--- a/libs/kernel/workbench/kernel/event_store.py
+++ b/libs/kernel/workbench/kernel/event_store.py
@@ -5,18 +5,76 @@ import threading
 from pathlib import Path
 from typing import Any
 
+EVENT_TYPES = {
+    "observation",
+    "action_request",
+    "action_result",
+    "verification",
+    "fault",
+    "emotion",
+    "task_accepted",
+    "task_terminal",
+    "task_start",
+    "tool_call",
+    "policy_violation",
+    "recovery_started",
+    "recovery_complete",
+}
+REQUIRED_EVENT_FIELDS = {"event_id", "run_id", "sequence_no", "event_type", "occurred_at", "payload"}
+
 
 class EventStoreError(ValueError):
     """Raised when the persisted event log cannot be replayed safely."""
 
 
 class EventStore:
-    def __init__(self, log_file: Path):
+    def __init__(self, log_file: Path, *, legacy_objects: bool = False):
         self.log_file = log_file
+        self.legacy_objects = legacy_objects
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
         self.events: list[dict[str, Any]] = []
         self.checkpoints: list[int] = []
         self._lock = threading.RLock()
+
+    def _validate_events(self, events: list[dict[str, Any]]) -> None:
+        if self.legacy_objects:
+            return
+        expected_run_id: str | None = None
+        event_ids: set[str] = set()
+        for index, event in enumerate(events):
+            missing = REQUIRED_EVENT_FIELDS - set(event)
+            if missing:
+                raise EventStoreError(f"event at index {index} is missing fields: {sorted(missing)}")
+            event_id = event["event_id"]
+            run_id = event["run_id"]
+            sequence_no = event["sequence_no"]
+            event_type = event["event_type"]
+            occurred_at = event["occurred_at"]
+            payload = event["payload"]
+            evidence_refs = event.get("evidence_refs", [])
+            if not isinstance(event_id, str) or not event_id:
+                raise EventStoreError(f"event at index {index} has an invalid event_id")
+            if event_id in event_ids:
+                raise EventStoreError(f"event log has duplicate event_id {event_id!r}")
+            event_ids.add(event_id)
+            if not isinstance(run_id, str) or not run_id:
+                raise EventStoreError(f"event at index {index} has an invalid run_id")
+            if expected_run_id is None:
+                expected_run_id = run_id
+            elif run_id != expected_run_id:
+                raise EventStoreError(f"event log mixes run_id {expected_run_id!r} and {run_id!r}")
+            if type(sequence_no) is not int or sequence_no != index:
+                raise EventStoreError(
+                    f"event sequence_no must be contiguous from zero; index {index} has {sequence_no!r}"
+                )
+            if not isinstance(event_type, str) or event_type not in EVENT_TYPES:
+                raise EventStoreError(f"event at index {index} has an unknown event_type")
+            if not isinstance(occurred_at, str) or not occurred_at:
+                raise EventStoreError(f"event at index {index} has an invalid occurred_at")
+            if not isinstance(payload, dict):
+                raise EventStoreError(f"event at index {index} payload must be an object")
+            if not isinstance(evidence_refs, list) or any(not isinstance(ref, str) for ref in evidence_refs):
+                raise EventStoreError(f"event at index {index} evidence_refs must be a string list")
 
     def _read_events(self) -> list[dict[str, Any]]:
         if not self.log_file.exists():
@@ -36,15 +94,20 @@ class EventStore:
                     events.append(event)
         except (OSError, UnicodeError) as exc:
             raise EventStoreError(f"event log is unavailable or not UTF-8: {self.log_file}") from exc
+        self._validate_events(events)
         return events
 
     def append(self, event: dict[str, Any]) -> None:
         if not isinstance(event, dict):
             raise TypeError("event must be an object")
-        serialized = json.dumps(event, ensure_ascii=False)
+        try:
+            serialized = json.dumps(event, allow_nan=False, ensure_ascii=False, separators=(",", ":"))
+        except (TypeError, ValueError) as exc:
+            raise EventStoreError("event must contain strict JSON values") from exc
         persisted_event = json.loads(serialized)
         with self._lock:
             events = self._read_events()
+            self._validate_events([*events, persisted_event])
             try:
                 with self.log_file.open("a", encoding="utf-8", newline="\n") as handle:
                     handle.write(serialized + "\n")

--- a/tests/unit/test_kernel_event_store.py
+++ b/tests/unit/test_kernel_event_store.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -9,24 +10,36 @@ sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 from workbench.kernel.event_store import EventStore, EventStoreError
 
 
+def event(event_id: int, *, run_id: str = "run-1", sequence_no: int | None = None) -> dict:
+    return {
+        "event_id": f"event-{event_id}",
+        "run_id": run_id,
+        "sequence_no": event_id if sequence_no is None else sequence_no,
+        "event_type": "observation",
+        "occurred_at": "2026-08-13T00:00:00Z",
+        "payload": {"index": event_id},
+        "evidence_refs": [],
+    }
+
+
 def test_checkpoint_counts_persisted_events_after_restart(tmp_path: Path) -> None:
     log = tmp_path / "events.jsonl"
     first = EventStore(log)
     for event_id in range(3):
-        first.append({"id": event_id})
+        first.append(event(event_id))
 
     reopened = EventStore(log)
-    reopened.append({"id": 3})
+    reopened.append(event(3))
     checkpoint = reopened.create_checkpoint()
 
     assert checkpoint == 4
-    assert reopened.replay(from_checkpoint=3) == [{"id": 3}]
+    assert reopened.replay(from_checkpoint=3) == [event(3)]
     assert reopened.replay(from_checkpoint=checkpoint) == []
 
 
 def test_replay_rejects_invalid_checkpoints(tmp_path: Path) -> None:
     store = EventStore(tmp_path / "events.jsonl")
-    store.append({"id": 0})
+    store.append(event(0))
 
     for checkpoint in (-1, True, 2):
         with pytest.raises(ValueError, match="checkpoint must be between"):
@@ -37,12 +50,12 @@ def test_corrupt_or_non_object_events_fail_integrity_check(tmp_path: Path) -> No
     log = tmp_path / "events.jsonl"
     store = EventStore(log)
 
-    log.write_text('{"id": 0}\n{bad-json}\n', encoding="utf-8")
+    log.write_text(f"{json.dumps(event(0))}\n{{bad-json}}\n", encoding="utf-8")
     assert not store.verify_integrity()
     with pytest.raises(EventStoreError, match="invalid event JSON"):
         store.create_checkpoint()
 
-    log.write_text('{"id": 0}\n["not-an-object"]\n', encoding="utf-8")
+    log.write_text(f'{json.dumps(event(0))}\n["not-an-object"]\n', encoding="utf-8")
     assert not store.verify_integrity()
 
 
@@ -53,3 +66,55 @@ def test_append_rejects_non_object_before_writing(tmp_path: Path) -> None:
     with pytest.raises(TypeError, match="event must be an object"):
         store.append(["not-an-object"])
     assert not log.exists()
+
+
+@pytest.mark.parametrize(
+    "bad_event, message",
+    [
+        ({"garbage": True}, "missing fields"),
+        (event(0, sequence_no=1), "contiguous"),
+        ({**event(0), "event_type": "unknown"}, "unknown event_type"),
+        ({**event(0), "payload": []}, "payload must be an object"),
+        ({**event(0), "evidence_refs": [1]}, "string list"),
+    ],
+)
+def test_append_rejects_invalid_event_contract(tmp_path: Path, bad_event: dict, message: str) -> None:
+    log = tmp_path / "events.jsonl"
+    store = EventStore(log)
+    with pytest.raises(EventStoreError, match=message):
+        store.append(bad_event)
+    assert not log.exists()
+
+
+def test_append_rejects_duplicate_identity_and_mixed_run_before_writing(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    store = EventStore(log)
+    store.append(event(0))
+    before = log.read_bytes()
+
+    with pytest.raises(EventStoreError, match="duplicate event_id"):
+        store.append({**event(1), "event_id": "event-0"})
+    assert log.read_bytes() == before
+
+    with pytest.raises(EventStoreError, match="mixes run_id"):
+        store.append(event(1, run_id="run-2"))
+    assert log.read_bytes() == before
+
+
+def test_integrity_checks_contract_and_strict_json(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    store = EventStore(log)
+    log.write_text('{"garbage":true}\n', encoding="utf-8")
+    assert not store.verify_integrity()
+    with pytest.raises(EventStoreError, match="missing fields"):
+        store.replay()
+
+    with pytest.raises(EventStoreError, match="strict JSON"):
+        EventStore(tmp_path / "nan.jsonl").append({**event(0), "payload": {"confidence": float("nan")}})
+
+
+def test_legacy_object_mode_is_explicit(tmp_path: Path) -> None:
+    store = EventStore(tmp_path / "legacy.jsonl", legacy_objects=True)
+    store.append({"id": 0})
+    assert store.verify_integrity()
+    assert store.replay() == [{"id": 0}]


### PR DESCRIPTION
## Summary
- make contract-shaped events the default Kernel EventStore boundary
- reject duplicate IDs, mixed runs, sequence gaps, unknown types, and malformed payloads before writing
- require an explicit migration-only flag for legacy object logs

## Verification
- python -m pytest tests/unit/test_kernel_event_store.py libs/kernel/tests/test_k1_k10.py libs/kernel/tests/test_k1_k10_extended.py -q
- python -m ruff check libs/kernel/workbench/kernel/event_store.py tests/unit/test_kernel_event_store.py
- python tools/scripts/check_task_packet.py docs/task_packets/kernel-event-store-checkpoints.json

Closes #95