### PR TITLE
fix(kernel): fail closed on missing readiness checks

### DIFF
--- a/docs/task_packets/kernel-startup-config.json
+++ b/docs/task_packets/kernel-startup-config.json
@@ -1,7 +1,7 @@
 {
-  "issue": "kernel-startup-config",
+  "issue": "96",
   "human_owner": "Quchaosheng",
-  "objective": "Load optional kernel bootstrap configuration and make declared startup check failures block bootstrap deterministically.",
+  "objective": "Make production startup fail closed when readiness checks are absent, partial or unmeasured.",
   "allowed_paths": [
     "libs/kernel/workbench/kernel/startup.py",
     "libs/kernel/tests/test_k1_k10.py",
@@ -18,7 +18,9 @@
     "interfaces/**"
   ],
   "acceptance": [
-    "missing bootstrap.json preserves the documented offline defaults",
+    "missing bootstrap.json fails production startup",
+    "offline defaults require an explicit constructor flag and offline mode",
+    "production configuration requires every named boolean check",
     "valid configured failed checks block bootstrap",
     "malformed, incomplete, and unknown-check configurations fail closed",
     "repository lint and tests pass"

--- a/libs/kernel/tests/test_k1_k10.py
+++ b/libs/kernel/tests/test_k1_k10.py
@@ -99,7 +99,7 @@ def test_all():
         print("[PASS] K8 Lifecycle")
 
         # K9-K10: Bootstrap
-        bootstrapper = SystemBootstrapper(tmp_path / "config")
+        bootstrapper = SystemBootstrapper(tmp_path / "config", offline=True)
         assert bootstrapper.bootstrap()
         (tmp_path / "config").mkdir()
         (tmp_path / "config" / "bootstrap.json").write_text(
@@ -108,7 +108,19 @@ def test_all():
                     "schemas": ["action"],
                     "nodes": ["kernel"],
                     "version": "1.0.0",
-                    "checks": {"event_store_ready": False},
+                    "mode": "production",
+                    "checks": {
+                        "schema_compatibility": True,
+                        "version_middleware": True,
+                        "disk_space": True,
+                        "all_nodes_online": True,
+                        "event_store_ready": False,
+                        "lifecycle_configured": True,
+                        "contracts_valid": True,
+                        "dependencies_resolved": True,
+                        "config_loaded": True,
+                        "memory_available": True,
+                    },
                 }
             ),
             encoding="utf-8",

--- a/libs/kernel/workbench/kernel/startup.py
+++ b/libs/kernel/workbench/kernel/startup.py
@@ -17,20 +17,23 @@ CHECK_NAMES = (
     "config_loaded",
     "memory_available",
 )
-REQUIRED_CONFIG_KEYS = ("schemas", "nodes", "version")
+REQUIRED_CONFIG_KEYS = ("schemas", "nodes", "version", "mode", "checks")
 DEFAULT_CONFIG = {
     "schemas": ["action", "state", "result"],
     "nodes": ["kernel", "hardware", "sim"],
     "version": "1.0.0",
+    "mode": "offline",
+    "checks": {name: True for name in CHECK_NAMES},
 }
 
 
 class StartupChecklist:
-    def __init__(self, checks: Mapping[str, bool] | None = None):
-        self.checks = {name: True for name in CHECK_NAMES}
-        if checks is not None:
-            self._validate_checks(checks)
-            self.checks.update(checks)
+    def __init__(self, checks: Mapping[str, bool]):
+        self._validate_checks(checks)
+        if set(checks) != set(CHECK_NAMES):
+            missing = set(CHECK_NAMES) - set(checks)
+            raise ValueError(f"startup checks must be complete; missing: {sorted(missing)}")
+        self.checks = dict(checks)
 
     @staticmethod
     def _validate_checks(checks: Mapping[str, Any]) -> bool:
@@ -41,23 +44,14 @@ class StartupChecklist:
             raise ValueError("startup check values must be boolean")
         return True
 
-    def verify_all(self, config: Mapping[str, Any]) -> bool:
-        if not isinstance(config, Mapping):
-            return False
-        configured_checks = config.get("checks", {})
-        if not isinstance(configured_checks, Mapping):
-            return False
-        try:
-            self._validate_checks(configured_checks)
-        except ValueError:
-            return False
-        effective_checks = {**self.checks, **configured_checks}
-        return all(effective_checks.values())
+    def verify_all(self) -> bool:
+        return all(self.checks.values())
 
 
 class SystemBootstrapper:
-    def __init__(self, config_dir: Path):
+    def __init__(self, config_dir: Path, *, offline: bool = False):
         self.config_dir = Path(config_dir)
+        self.offline = offline
         self.config: dict[str, Any] = {}
 
     @staticmethod
@@ -67,6 +61,15 @@ class SystemBootstrapper:
         if any(key not in config for key in REQUIRED_CONFIG_KEYS):
             return False
         if not isinstance(config["version"], str) or not config["version"]:
+            return False
+        if config["mode"] not in {"production", "offline"}:
+            return False
+        checks = config["checks"]
+        if not isinstance(checks, Mapping):
+            return False
+        try:
+            StartupChecklist(checks)
+        except ValueError:
             return False
         if any(
             not isinstance(config[key], list)
@@ -80,7 +83,9 @@ class SystemBootstrapper:
     def load_config(self) -> bool:
         config_path = self.config_dir / "bootstrap.json"
         if not config_path.exists():
-            self.config = dict(DEFAULT_CONFIG)
+            if not self.offline:
+                return False
+            self.config = {**DEFAULT_CONFIG, "checks": dict(DEFAULT_CONFIG["checks"])}
             return True
         try:
             config = json.loads(config_path.read_text(encoding="utf-8"))
@@ -88,10 +93,12 @@ class SystemBootstrapper:
             return False
         if not self._valid_config(config):
             return False
+        if (config["mode"] == "offline") != self.offline:
+            return False
         self.config = config
         return True
 
     def bootstrap(self) -> bool:
         if not self.load_config():
             return False
-        return StartupChecklist().verify_all(self.config)
+        return StartupChecklist(self.config["checks"]).verify_all()

--- a/tests/unit/test_kernel_startup_config.py
+++ b/tests/unit/test_kernel_startup_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 
-from workbench.kernel.startup import SystemBootstrapper
+from workbench.kernel.startup import CHECK_NAMES, SystemBootstrapper
 
 
 def write_config(root: Path, payload: object) -> None:
@@ -13,23 +13,43 @@ def write_config(root: Path, payload: object) -> None:
     (root / "bootstrap.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
-def test_missing_config_keeps_offline_defaults(tmp_path: Path) -> None:
-    bootstrapper = SystemBootstrapper(tmp_path / "missing")
+def config(*, mode: str = "production", failed: str | None = None) -> dict:
+    checks = {name: name != failed for name in CHECK_NAMES}
+    return {
+        "schemas": ["action"],
+        "nodes": ["kernel"],
+        "version": "1.0.0",
+        "mode": mode,
+        "checks": checks,
+    }
+
+
+def test_missing_config_fails_production_and_requires_explicit_offline_mode(tmp_path: Path) -> None:
+    assert not SystemBootstrapper(tmp_path / "missing").bootstrap()
+
+    bootstrapper = SystemBootstrapper(tmp_path / "missing", offline=True)
     assert bootstrapper.bootstrap()
+    assert bootstrapper.config["mode"] == "offline"
     assert bootstrapper.config["nodes"] == ["kernel", "hardware", "sim"]
 
 
 def test_configured_failed_check_blocks_bootstrap(tmp_path: Path) -> None:
-    write_config(
-        tmp_path,
-        {
-            "schemas": ["action"],
-            "nodes": ["kernel"],
-            "version": "1.0.0",
-            "checks": {"contracts_valid": False},
-        },
-    )
+    write_config(tmp_path, config(failed="contracts_valid"))
     assert not SystemBootstrapper(tmp_path).bootstrap()
+
+
+def test_complete_production_checks_allow_bootstrap(tmp_path: Path) -> None:
+    write_config(tmp_path, config())
+    assert SystemBootstrapper(tmp_path).bootstrap()
+
+
+def test_offline_and_production_modes_cannot_be_confused(tmp_path: Path) -> None:
+    write_config(tmp_path, config(mode="offline"))
+    assert not SystemBootstrapper(tmp_path).bootstrap()
+    assert SystemBootstrapper(tmp_path, offline=True).bootstrap()
+
+    write_config(tmp_path, config(mode="production"))
+    assert not SystemBootstrapper(tmp_path, offline=True).bootstrap()
 
 
 def test_malformed_or_unsafe_config_fails_closed(tmp_path: Path) -> None:
@@ -38,9 +58,20 @@ def test_malformed_or_unsafe_config_fails_closed(tmp_path: Path) -> None:
 
     write_config(
         tmp_path,
-        {"schemas": ["action"], "nodes": ["kernel"], "version": "1.0.0", "checks": {"unknown": True}},
+        {
+            "schemas": ["action"],
+            "nodes": ["kernel"],
+            "version": "1.0.0",
+            "mode": "production",
+            "checks": {**{name: True for name in CHECK_NAMES}, "unknown": True},
+        },
     )
     assert not SystemBootstrapper(tmp_path).bootstrap()
 
-    write_config(tmp_path, {"schemas": [], "nodes": ["kernel"], "version": "1.0.0"})
+    write_config(tmp_path, {**config(), "schemas": []})
+    assert not SystemBootstrapper(tmp_path).bootstrap()
+
+    partial = config()
+    partial["checks"].pop("memory_available")
+    write_config(tmp_path, partial)
     assert not SystemBootstrapper(tmp_path).bootstrap()


### PR DESCRIPTION
## Summary
- require complete measured checks for production startup
- make missing production config fail closed
- isolate built-in defaults behind an explicit offline mode

## Verification
- python -m pytest tests/unit/test_kernel_startup_config.py libs/kernel/tests/test_k1_k10.py -q
- python -m ruff check libs/kernel/workbench/kernel/startup.py tests/unit/test_kernel_startup_config.py
- python tools/scripts/check_task_packet.py docs/task_packets/kernel-startup-config.json

Closes #96