### PR TITLE
fix(kernel): validate broker publications

### DIFF
--- a/docs/task_packets/kernel-broker-validation.json
+++ b/docs/task_packets/kernel-broker-validation.json
@@ -1,0 +1,43 @@
+{
+  "issue": "102",
+  "human_owner": "Quchaosheng",
+  "objective": "Reject unregistered or schema-invalid messages before the kernel broker publication boundary.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/communication.py",
+    "libs/kernel/workbench/kernel/schema_compiler.py",
+    "tests/unit/test_kernel_communication_broker.py",
+    "docs/task_packets/kernel-broker-validation.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "message type and exact version must exist in the configured registry",
+    "payloads satisfy the registered schema before publication",
+    "invalid envelopes and payloads never enter message_log",
+    "registry reopen preserves broker validation behavior",
+    "repository lint and tests pass"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_kernel_communication_broker.py tests/unit/test_kernel_envelope_lifecycle.py -q",
+    "python -m ruff check libs/kernel tests/unit/test_kernel_communication_broker.py",
+    "python -m pytest tests/ -q"
+  ],
+  "evidence": [
+    "unknown type and version rejection assertions",
+    "schema boundary and no-partial-log assertions",
+    "registry reopen assertion",
+    "repository test output"
+  ],
+  "stop_conditions": [
+    "interface schema changes are required",
+    "implicit semantic-version compatibility is required",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/libs/kernel/workbench/kernel/communication.py
+++ b/libs/kernel/workbench/kernel/communication.py
@@ -9,9 +9,15 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any
 
+from .schema_compiler import SchemaValidationError, validate_schema_instance
+
 
 class MessageIntegrityError(ValueError):
     """Raised when a serialized message envelope cannot be trusted."""
+
+
+class BrokerValidationError(ValueError):
+    """Raised when a message cannot cross the broker publication boundary."""
 
 
 def _freeze_json(value: Any, ancestors: set[int] | None = None) -> Any:
@@ -69,6 +75,9 @@ class Message:
     def __post_init__(self) -> None:
         if not isinstance(self.payload, Mapping):
             raise TypeError("message payload must be an object")
+        reserved = [key for key in self.payload if isinstance(key, str) and key.startswith("_")]
+        if reserved:
+            raise ValueError(f"message payload contains reserved fields: {sorted(reserved)}")
         object.__setattr__(self, "payload", _freeze_json(self.payload))
         object.__setattr__(self, "message_type", _require_text(self.message_type, "message_type"))
         object.__setattr__(self, "version", _require_text(self.version, "version"))
@@ -144,9 +153,24 @@ class VersionValidator:
 class CommunicationBroker:
     def __init__(self, version_registry):
         self.version_registry = version_registry
-        self.message_log = []
+        self.message_log: list[Message] = []
 
     def publish(self, payload, message_type, version, actor):
-        msg = Message(payload, message_type, version, actor)
-        self.message_log.append(msg)
-        return msg
+        try:
+            message = Message(payload, message_type, version, actor)
+        except (TypeError, ValueError) as exc:
+            raise BrokerValidationError(f"invalid message envelope: {exc}") from exc
+        versions = self.version_registry.versions.get(message.message_type)
+        if not isinstance(versions, dict):
+            raise BrokerValidationError(f"message type {message.message_type!r} is not registered")
+        schema = versions.get(message.version)
+        if not isinstance(schema, dict):
+            raise BrokerValidationError(
+                f"message version {message.version!r} is not registered for type {message.message_type!r}"
+            )
+        try:
+            validate_schema_instance(_thaw_json(message.payload), schema)
+        except SchemaValidationError as exc:
+            raise BrokerValidationError(f"message payload does not satisfy the registered schema: {exc}") from exc
+        self.message_log.append(message)
+        return message

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -2,6 +2,7 @@
 
 import json
 import keyword
+import math
 import re
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,120 @@ PROPERTY_KEYWORDS = {
     "required",
     "type",
 }
+
+
+class SchemaValidationError(ValueError):
+    """Raised when a value does not satisfy the supported schema subset."""
+
+
+def _matches_json_type(value: Any, schema_type: str) -> bool:
+    if schema_type == "null":
+        return value is None
+    if schema_type == "boolean":
+        return type(value) is bool
+    if schema_type == "integer":
+        return type(value) is int
+    if schema_type == "number":
+        return type(value) in {int, float} and math.isfinite(value)
+    if schema_type == "string":
+        return isinstance(value, str)
+    if schema_type == "array":
+        return isinstance(value, list)
+    if schema_type == "object":
+        return isinstance(value, dict)
+    raise SchemaValidationError(f"unsupported schema type {schema_type!r}")
+
+
+def _enum_contains(enum: list[Any], value: Any) -> bool:
+    return any(type(candidate) is type(value) and candidate == value for candidate in enum)
+
+
+def validate_schema_instance(
+    value: Any,
+    schema: dict[str, Any],
+    *,
+    references: dict[str, dict[str, Any]] | None = None,
+    location: str = "$",
+) -> None:
+    """Validate one value against the JSON Schema subset the compiler supports."""
+    if not isinstance(schema, dict):
+        raise SchemaValidationError(f"schema at {location} must be an object")
+    if "$ref" in schema:
+        reference = schema["$ref"]
+        referenced = (references or {}).get(reference)
+        if referenced is None:
+            raise SchemaValidationError(f"unresolved schema reference {reference!r} at {location}")
+        validate_schema_instance(value, referenced, references=references, location=location)
+        return
+
+    if "enum" in schema:
+        enum = schema["enum"]
+        if not isinstance(enum, list) or not _enum_contains(enum, value):
+            raise SchemaValidationError(f"value at {location} is not in the allowed enum")
+
+    schema_types = schema.get("type")
+    if schema_types is not None:
+        allowed_types = schema_types if isinstance(schema_types, list) else [schema_types]
+        if not all(isinstance(schema_type, str) for schema_type in allowed_types):
+            raise SchemaValidationError(f"schema type at {location} must be a string or string list")
+        if not any(_matches_json_type(value, schema_type) for schema_type in allowed_types):
+            raise SchemaValidationError(f"value at {location} does not match type {schema_types!r}")
+
+    if "minimum" in schema and (type(value) not in {int, float} or value < schema["minimum"]):
+        raise SchemaValidationError(f"value at {location} is below minimum {schema['minimum']!r}")
+    if "maximum" in schema and (type(value) not in {int, float} or value > schema["maximum"]):
+        raise SchemaValidationError(f"value at {location} is above maximum {schema['maximum']!r}")
+    if "pattern" in schema and (not isinstance(value, str) or re.search(schema["pattern"], value) is None):
+        raise SchemaValidationError(f"value at {location} does not match pattern {schema['pattern']!r}")
+    if "minItems" in schema and (not isinstance(value, list) or len(value) < schema["minItems"]):
+        raise SchemaValidationError(f"array at {location} has fewer than {schema['minItems']} items")
+
+    if isinstance(value, list) and "items" in schema:
+        for index, item in enumerate(value):
+            validate_schema_instance(
+                item,
+                schema["items"],
+                references=references,
+                location=f"{location}[{index}]",
+            )
+
+    if isinstance(value, dict):
+        properties = schema.get("properties", {})
+        required = schema.get("required", [])
+        if not isinstance(properties, dict) or not isinstance(required, list):
+            raise SchemaValidationError(f"object schema at {location} has invalid properties or required fields")
+        missing = set(required) - set(value)
+        if missing:
+            raise SchemaValidationError(f"object at {location} is missing fields: {sorted(missing)}")
+        if schema.get("additionalProperties", True) is False:
+            extra = set(value) - set(properties)
+            if extra:
+                raise SchemaValidationError(f"object at {location} has extra fields: {sorted(extra)}")
+        for field_name, definition in properties.items():
+            if field_name in value:
+                validate_schema_instance(
+                    value[field_name],
+                    definition,
+                    references=references,
+                    location=f"{location}.{field_name}",
+                )
+
+    for conditional in schema.get("allOf", []):
+        condition_properties = conditional.get("if", {}).get("properties", {})
+        condition_matches = (
+            all(
+                field_name in value
+                and isinstance(definition, dict)
+                and "const" in definition
+                and type(value[field_name]) is type(definition["const"])
+                and value[field_name] == definition["const"]
+                for field_name, definition in condition_properties.items()
+            )
+            if isinstance(value, dict)
+            else False
+        )
+        if condition_matches:
+            validate_schema_instance(value, conditional.get("then", {}), references=references, location=location)
 
 
 def _model_name(value: str) -> str:

--- a/tests/unit/test_kernel_communication_broker.py
+++ b/tests/unit/test_kernel_communication_broker.py
@@ -1,0 +1,84 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "kernel"))
+
+from workbench.kernel.communication import BrokerValidationError, CommunicationBroker
+from workbench.kernel.version_registry import VersionRegistry
+
+ACTION_SCHEMA = {
+    "type": "object",
+    "required": ["target", "speed"],
+    "additionalProperties": False,
+    "properties": {
+        "target": {"type": "string", "pattern": "^[a-z_]+$"},
+        "speed": {"type": "number", "minimum": 0, "maximum": 1},
+    },
+}
+
+
+def broker(tmp_path: Path) -> CommunicationBroker:
+    registry = VersionRegistry(tmp_path / "versions.json")
+    registry.register_schema("action", "1.0.0", ACTION_SCHEMA)
+    return CommunicationBroker(registry)
+
+
+def test_broker_publishes_only_registered_schema_valid_messages(tmp_path: Path) -> None:
+    boundary = broker(tmp_path)
+    message = boundary.publish({"target": "red_block", "speed": 0.5}, "action", "1.0.0", "planner")
+    assert boundary.message_log == [message]
+    assert message.payload["target"] == "red_block"
+
+
+@pytest.mark.parametrize(
+    "message_type, version, error",
+    [
+        ("unknown", "1.0.0", "type.*not registered"),
+        ("action", "2.0.0", "version.*not registered"),
+    ],
+)
+def test_broker_rejects_unknown_type_or_exact_version(
+    tmp_path: Path, message_type: str, version: str, error: str
+) -> None:
+    boundary = broker(tmp_path)
+    with pytest.raises(BrokerValidationError, match=error):
+        boundary.publish({"target": "red_block", "speed": 0.5}, message_type, version, "planner")
+    assert boundary.message_log == []
+
+
+@pytest.mark.parametrize(
+    "payload, error",
+    [
+        ({"target": "red_block"}, "missing fields"),
+        ({"target": "Red Block", "speed": 0.5}, "pattern"),
+        ({"target": "red_block", "speed": 2.0}, "maximum"),
+        ({"target": "red_block", "speed": 0.5, "raw_joint": 1}, "extra fields"),
+        ({"target": "red_block", "speed": True}, "does not match type"),
+        ({"_actor": "forged", "target": "red_block", "speed": 0.5}, "reserved"),
+    ],
+)
+def test_broker_rejects_invalid_payload_without_partial_log(tmp_path: Path, payload: dict, error: str) -> None:
+    boundary = broker(tmp_path)
+    with pytest.raises(BrokerValidationError, match=error):
+        boundary.publish(payload, "action", "1.0.0", "planner")
+    assert boundary.message_log == []
+
+
+def test_broker_uses_registry_state_after_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "versions.json"
+    registry = VersionRegistry(path)
+    registry.register_schema("action", "1.0.0", ACTION_SCHEMA)
+    reopened = CommunicationBroker(VersionRegistry(path))
+    assert reopened.publish({"target": "red_block", "speed": 1}, "action", "1.0.0", "planner")
+
+
+def test_broker_rejects_registered_content_that_is_not_a_schema(tmp_path: Path) -> None:
+    registry = VersionRegistry(tmp_path / "versions.json")
+    registry.register_schema("action", "1.0.0", "not-a-schema")
+    boundary = CommunicationBroker(registry)
+    with pytest.raises(BrokerValidationError, match="version.*not registered"):
+        boundary.publish({}, "action", "1.0.0", "planner")
+    assert boundary.message_log == []


### PR DESCRIPTION
## Summary
- require exact registered message type and version before publish
- validate payloads with the same supported schema subset as generated contracts
- reject reserved payload fields and keep invalid messages out of message_log

## Verification
- python -m pytest tests/unit/test_kernel_communication_broker.py tests/unit/test_kernel_envelope_lifecycle.py tests/unit/test_kernel_schema_compiler.py tests/unit/test_kernel_version_registry.py libs/kernel/tests/test_k1_k10.py -q
- python -m ruff check libs/kernel/workbench/kernel/communication.py libs/kernel/workbench/kernel/schema_compiler.py tests/unit/test_kernel_communication_broker.py
- python tools/scripts/validate_contracts.py
- python tools/scripts/check_task_packet.py docs/task_packets/kernel-broker-validation.json

Closes #102