### PR TITLE
feat(motion): add joint limits and ros2_control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ node_modules/
 coverage.xml
 /site/
 
+# colcon / ament build artifacts generated at repository root.
+/install/
+/log/
+
 # AI tooling working directories — must stay out of history.
 # Once committed, removing these requires rewriting history and a force-push.
 # NOTE: docs/task_packets/ is deliberately NOT ignored. A task packet is a

--- a/docs/task_packets/motion-002-limits-control.json
+++ b/docs/task_packets/motion-002-limits-control.json
@@ -1,0 +1,70 @@
+{
+  "issue": 116,
+  "human_owner": "cyathea152-bit",
+  "objective": "Motion phase 2: joint limits (three distinct sources) + ros2_control + controllers for the UR5e + Robotiq 2F-85 composition, plus the pure-logic over-limit trajectory validator. Deliver a gz_ros2_control block behind a sim_gz xacro arg (phase-1 zero regression), controllers.yaml (arm JointTrajectoryController + GripperActionController [package gripper_controllers, plugin type position_controllers/GripperActionController - historical namespace] + joint_state_broadcaster) with names sourced from arm.yaml, a config-only hw_override safety layer (structure only; content stays empty for P0 sim per ADR-0001), a reproducible sim_control.launch.py, and workbench_motion/joint_limits.py whose check_trajectory is a PURE JUDGMENT (returns Violation|None, no side effects, never clamps) that accepts current joint state to check the current->first-point segment (prevents single-point-large-jump bypass), AND is a CONSERVATIVE PRE-FILTER (no JTC spline-peak or hard acceleration check). Per docs/context/CONSTRAINTS.yaml the end-to-end zero-motion enforcement - event emission, zero-dispatch, EvidenceSink closure, sole trajectory gate, anti-bypass, namespace isolation, AND the real spline-extremum/runtime-monitoring needed to actually guarantee zero-over-limit - is phase 4's release-line responsibility, not phase 2. Phase 2 delivers the pure validator kernel + a phase2_probe tool that empirically records the controller's actual over-limit behavior as one of SIX classes (rejected/aborted/clamped/executed_over_limit/timeout/unclassified; last four fail the gate), the TF chain, and the gripper mimic ratios (computed as delta-follower/delta-driver, not absolute position ratio). PLAN.md phase-2 acceptance was updated on 2026-08-10 to move end-to-end rejection to phase 4, so the two build docs agree. No ActionResult/interfaces changes. C13/C14 real-hardware safety and C5/C6 recovery/safe-stop are out of scope (phase 3/4/6). Launch/package.xml/setup.py changes require Linux Owner review per AGENTS.md:18.",
+  "allowed_paths": [
+    "robot/control/**",
+    "docs/task_packets/motion-002-limits-control.json",
+    "docs/evaluation/phase2-controllers.json",
+    ".gitignore"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "robot/description/**",
+    "docs/context/**",
+    "docs/architecture/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "services/**",
+    "interfaces/**",
+    "robot/description/**"
+  ],
+  "acceptance": [
+    "xacro <install-or-source>/config/arm_on_workbench.urdf.xacro sim_gz:=true > /tmp/wb_ctrl.urdf expands to a single connected tree (check_urdf passes) containing the gz_ros2_control/GazeboSimSystem hardware plugin, position command_interfaces for all 6 arm joints + the gripper driver joint, and the gz_ros2_control-system gazebo plugin whose <parameters> points at controllers.yaml",
+    "sim_gz:=false (default) is unchanged: move_group launch and the phase-1 reachability gate still pass (phase-1 zero regression)",
+    "ros2 control list_controllers shows joint_state_broadcaster, arm_trajectory_controller and gripper_controller all active (C2-derived acceptance per 05-机械臂资产.md:13, NOT a README Metrics row; requires gz_ros2_control + controllers apt install, run locally)",
+    "TF is complete (C2 explicitly lists URDF/TF/controllers/limits): /tf and /tf_static resolve the chain world->base_link->...->tool0->grasp_tcp with no missing frames",
+    "a legal FollowJointTrajectory reaches the goal in Gazebo; no-penetration is evidenced by MoveIt /check_state_validity (moveit_msgs/GetStateValidity) - the single pinned path (repo has no Gazebo contact sensor/bridge; merged URDF is MoveIt's collision authority). Since /check_state_validity validates ONE state, the path is checked at each observed /joint_states sample AND at trajectory points densified to a fixed joint step collision_check_resolution_rad (default 0.05) - endpoint-valid does not prove path-collision-free; /joint_states before/after recorded",
+    "sim_control.launch.py does NOT include phase-1 move_group.launch.py (which starts a static joint_state_publisher and hardcodes use_sim_time=false at line 91,113); it builds a separate move_group Node via a shared param-assembly helper (workbench_motion/launch_utils.py) with use_sim_time=true, a single robot_state_publisher, NO joint_state_publisher, and /joint_states sourced only from joint_state_broadcaster",
+    "controller names, update_rate, arm joint list and gripper driver joint are read from config/arm.yaml (arm.vendor_description_pkg/arm.ur_type for hard limits path, controllers: section for names) by runtime Python via workbench_motion.arm_config, not hard-coded; controllers.yaml <-> arm.yaml consistency is regression-guarded in test/test_controllers_config.py",
+    "workbench_motion/joint_limits.py loads hard limits from vendor ur5e joint_limits.yaml via arm.yaml arm.vendor_description_pkg/arm.ur_type (custom !degrees tag), enforces override subset-of-hard fail-closed (empty/missing/looser/unknown-joint/bad-unit), and check_trajectory(traj, current_joint_positions) is a PURE JUDGMENT (input trajectory + current state -> Violation|None, NO event/dispatch/EvidenceSink side effects) covering position/velocity/effort/NaN-Inf/negative-or-non-strictly-increasing-time_from_start/optional-velocities-accelerations-effort-length-must-be-0-or-njoints/current-to-first-point-segment-velocity (first.time_from_start<0 rejects; ==0 requires first.positions match current within epsilon; >0 checks |first-current|/t segment velocity; prevents single-point-large-jump bypass)/segment-mean-velocity-under-linear-interpolation/missing-empty-duplicate-unknown-partial joint_names, with limit_epsilon that only tightens (never widens a hard limit outward), WITHOUT clamping; all covered by attack-style tests under uv run pytest with no ROS. It validates hard-limits intersect hw_override (NOT planning limits - those are MoveIt's planning-time constraint). It is a CONSERVATIVE PRE-FILTER (no JTC spline peak, no hard acceleration check) - not a sole guarantee of zero-over-limit; event emission, zero-dispatch and EvidenceSink closure are phase 4",
+    "the controller's ACTUAL over-limit behavior (raw FollowJointTrajectory to JTC) is observed via /joint_states before/after + action result and classified into SIX classes: rejected / aborted / clamped / executed_over_limit / timeout / unclassified; clamped + executed_over_limit + timeout + unclassified all FAIL the gate (executed_over_limit directly violates collision_or_limit_violation=0); clamped and executed_over_limit are registered as bypass risks phase 4 must eliminate; only rejected/aborted (confirmed no over-limit) count as controller-side protection",
+    "the Robotiq 2F-85 mimic linkage is validated by a minimal spike: after open->close, all five follower joints satisfy their multiplier ratio (computed as delta-follower / delta-driver, NOT absolute position ratio) to the driver joint within tolerance_abs=0.02 (NOT just controller active); if the driver-joint-only macro does not drive the followers under gz_ros2_control, fall back to explicitly declaring the five follower joints + multipliers (per vendor macro) and record it",
+    "phase2_probe is one console command that emits docs/evaluation/phase2-controllers.json (atomic replace on success; failure exits nonzero and does not publish a new artifact; consumers validate exit status, commit, git_dirty and config hashes); it depends on control_msgs/trajectory_msgs/controller_manager_msgs/tf2_ros/moveit_msgs/sensor_msgs (declared in package.xml); before sending any over-limit trajectory it fail-closed confirms the hardware plugin is gz_ros2_control/GazeboSimSystem and aborts otherwise; missing/timed-out endpoints (ListControllers/action/GetStateValidity/TF) yield a non-zero exit and no empty-passing JSON; stale TF/JointState (beyond staleness_s) is flagged not silently used",
+    "test/test_phase2_probe.py covers (with mocked ROS IO, under uv run pytest) the six-class over-limit classification (rejected/aborted/clamped/executed_over_limit/timeout/unclassified) with the last four failing the gate, timeouts, stale TF/JointState, missing topic/action/service -> non-zero exit without empty JSON, JSON schema, mimic ratio delta-based computation, and the non-GazeboSimSystem -> refuse-to-send fail-closed path",
+    "docs/evaluation/phase2-controllers.json records commit, software versions, controller states, the TF chain check, the gripper mimic ratios, the legal trajectory + its collision evidence, the observed controller over-limit behavior, and the validator Violation (no event_id at phase 2 - events are phase 4), plus /joint_states before/after",
+    "colcon build --packages-select workbench_motion passes; root make lint/test/contract/scenario-check/context-check stay green (no interfaces change)"
+  ],
+  "commands": [
+    "make task-check PACKET=docs/task_packets/motion-002-limits-control.json",
+    "uv run --directory robot/control pytest",
+    "source /opt/ros/jazzy/setup.bash && colcon build --packages-select workbench_motion && source install/setup.bash",
+    "source /opt/ros/jazzy/setup.bash && source install/setup.bash && xacro $(ros2 pkg prefix workbench_motion)/share/workbench_motion/config/arm_on_workbench.urdf.xacro sim_gz:=true > /tmp/wb_ctrl.urdf && check_urdf /tmp/wb_ctrl.urdf",
+    "source /opt/ros/jazzy/setup.bash && source install/setup.bash && ros2 launch workbench_motion sim_control.launch.py",
+    "source /opt/ros/jazzy/setup.bash && source install/setup.bash && ros2 control list_controllers",
+    "source /opt/ros/jazzy/setup.bash && source install/setup.bash && ros2 control list_controller_types | grep -i gripper",
+    "source /opt/ros/jazzy/setup.bash && source install/setup.bash && ros2 run workbench_motion phase2_probe",
+    "make lint && make test && make contract && make scenario-check && make context-check"
+  ],
+  "evidence": [
+    "check_urdf output on the sim_gz:=true expansion + grep of the gz_ros2_control plugin and command_interfaces",
+    "ros2 control list_controllers output (three controllers active)",
+    "docs/evaluation/phase2-controllers.json (generated by phase2_probe) with controller states, TF chain check, gripper mimic ratios, legal trajectory + collision evidence, observed over-limit behavior, validator Violation, and /joint_states before/after",
+    "joint_limits + controllers-config unit test output under uv run pytest",
+    "RViz/Gazebo screenshot of the arm executing a legal trajectory (aux)"
+  ],
+  "stop_conditions": [
+    "Linux Owner rejects the proposed launch/package.xml/setup.py changes (requires their approval per AGENTS.md:18 before merge)",
+    "gz_ros2_control / controllers not installable under Jazzy/Harmonic (record blocker; pure-logic tests still deliverable)",
+    "fallback (explicit follower joints + multipliers per vendor macro) also fails to drive the gripper under gz_ros2_control after the minimal spike confirmed driver-joint-only does not work",
+    "any change would require touching a forbidden path or interfaces/",
+    "phase2_probe cannot confirm the hardware plugin is gz_ros2_control/GazeboSimSystem (abort before sending any over-limit trajectory; never risk sending to a real-hardware controller)",
+    "neither MoveIt /check_state_validity nor a controller-manager/action/TF endpoint the probe needs is available (record unavailable + non-zero exit; do not emit an empty-but-passing JSON)"
+  ],
+  "risks_and_fallbacks": [
+    "gz_ros2_control may not drive Robotiq follower joints from driver-joint-only <mimic>: fall back to explicitly declaring the five follower joints + multipliers per vendor macro; record in docs/evaluation/phase2-controllers.json",
+    "chosen gripper controller plugin may not load: switch to the actually-loadable type (self-decidable); update controllers.yaml + package.xml"
+  ]
+}

--- a/robot/control/PHASE2.md
+++ b/robot/control/PHASE2.md
@@ -1,0 +1,458 @@
+# 阶段 2 详细实现文档 — 关节限位 + ros2_control + 控制器
+
+> 配套 `PLAN.md §阶段 2`。本文件是阶段 2 的施工图：判定现状、锚定官方标准、列清可复用资产、给出高内聚低耦合的落地方案、逐文件清单、验收映射、攻击性测试规则。与 PLAN.md 同为本地工作文档。
+>
+> **契约不变**：ActionResult（outcome/dispatch_state/device_state）以 main 冻结版为准；阶段 2 不产 ActionResult（阶段 4/5/6 才产），只交付「限位 + 控制器 + 越限校验内核」的地基。
+
+## 0. 官方标准锚点（验收措辞一律挂到这里，不自造）
+
+阶段性标准的三个权威源，本文件所有验收都引用其具体条目，不含糊说"阶段 2 零运动"：
+
+- **`docs/context/CONSTRAINTS.yaml`**（`make context-check` 强制存在，`tools/scripts/check_context.py` 门控）——唯一被工具校验的约束：
+  - `safety.agent_may_emit_joint_commands: false`
+  - `release.collision_or_limit_violation_must_equal_zero: true`
+  - `release.false_completion_must_equal_zero: true`
+- **README「Metrics」表**——官方验收数字；标 **0** 的三条 Safety 是 release blocker：False completion=0、Collisions/joint limit violations=0、Model emitting raw joint control=0。**注意：该表没有"controllers active"行**——控制器 active、TF 帧链是 **C2** 验收（项目派生），别挂到 README Metrics（§7 已据此更正）。
+- **`05-机械臂资产.md` / `06-抓取与恢复.md` 的 C 系列分期 + `ADR-0001`**——任务归属哪个 P（月）、什么出 v0.1 范围（P0 = 纯仿真固定桌面单臂）。
+
+**关键定性（决定阶段 2 交付边界，见 §5）**：`collision_or_limit_violation_must_equal_zero` 与 `agent_may_emit_joint_commands: false` 是 **v0.1 发布线**，不是"阶段 2 门"。官方无任何条目要求"阶段 2 必须是唯一 trajectory gate"。越限=0 的**端到端 ROS 闭合**天然落在阶段 4（适配器唯一接口 + 防绕过 + 命名空间隔离，PLAN §阶段 4）。阶段 2 交付其**纯逻辑校验内核**并记录反面证据。
+
+## 1. Scope Matrix（本阶段做/不做，防误读）
+
+按 C 系列官方分期显式划界，避免阶段 2 完成后被误解为已覆盖真机安全或抓取恢复：
+
+| 能力 | 官方任务 | 期 | 阶段 2 |
+|---|---|---|---|
+| 仿真标称硬限位（position/velocity/effort）接入 URDF/ros2_control | C2 | P1 | ✅ 做（复用厂商已注入的 `<limit>`） |
+| MoveIt 规划层限位 | C2 | P1 | 已存在（阶段 1 交付），本阶段不动 |
+| ros2_control + 控制器 + 控制器 active | C2 | P1 | ✅ 做 |
+| 越限**校验纯逻辑内核** + 反面证据 | C6/C12 前置 | — | ✅ 做（判定，不 clamp） |
+| 越限**端到端 ROS 零运动闭合**（唯一 gate / 防绕过 / 命名空间隔离） | — | — | ❌ **归阶段 4**（PLAN §阶段 4） |
+| 真机关节限位 + 安全参数、"仿真参数不能直接用真机" | C13/C14 | **P3** | ❌ 只建结构，内容留空（见 §4） |
+| 力控柔顺、工作空间显式拒绝不可达 | C10/C12 | P2 | ❌ 后续 |
+| 抓取失败/取消/重执行恢复、有界安全停车 | C5/C6 | P1(#6) | ❌ 阶段 4/6，非本阶段 |
+
+## 2. 现状判定（可直接复用的阶段 1 资产）
+
+阶段 1 已提交（`feat/motion-phase1-arm`），阶段 2 直接复用、不重造：
+
+| 资产 | 位置 | 阶段 2 怎么用 |
+|---|---|---|
+| 合并 URDF（臂+世界） | `config/arm_on_workbench.urdf.xacro` | 同一份 xacro 内加 `<ros2_control>` + Gazebo 插件（`sim_gz` arg 门控），不新开描述文件 |
+| 换臂唯一入口 | `config/arm.yaml` | 新增 `controllers:` 段作控制器命名唯一源；`gripper.driver_joint` 已在，复用 |
+| arm.yaml 读取路径 | `workbench_motion/arm_config.py` | 扩 `ArmConfig` 加控制器字段 + `driver_joint`；生成器/校验器复用 |
+| MoveIt 规划层限位 | `config/moveit/joint_limits.yaml` | 三路限位中的「规划路」已存在，本阶段不改 |
+| SRDF / group 定义 | `config/moveit/workbench_arm.srdf` | 控制器控的关节名基准；一致性单测比对 |
+| 证据事件 + Sink | `workbench_motion/evidence.py` | **阶段 4 用**（越限拒绝产 `ExecutionEvent` + `event_id`）；**阶段 2 的 `check_trajectory` 纯判定不碰它**（§5.5） |
+| 统一日志 | `workbench_motion/logging_setup.py` | 拒绝/降级按 WARNING/ERROR，带 run_id |
+| move_group 启动 + 路径解析 | `launch/move_group.launch.py` | share 解析、xacro→robot_description、`_require()` 抽公共，供新 sim launch 复用 |
+| 纯逻辑 + ROS-free 单测范式 | `reachability.py` / `test_*` | 限位校验器同范式：纯 Python、uv 可测、无 rclpy |
+
+**厂商已带可复用 ros2_control 宏，不要自拼 `<joint>` 接口：**
+- `ur_description/urdf/inc/ur_joint_control.xacro` → 宏 `ur_joint_control_description`，给 6 臂关节 position/velocity/effort 接口。
+- `robotiq_description/urdf/robotiq_gripper.ros2_control.xacro` → 宏 `robotiq_gripper_ros2_control`。**其仿真分支绑死 `ign_ros2_control/IgnitionSystem`（旧 Ignition 名），Jazzy/Harmonic 要 `gz_ros2_control/GazeboSimSystem`**——所以只借关节接口描述，插件由我们顶层 `<ros2_control>` 指定（§5.1）。
+
+## 3. 环境前置（真正的卡点，先说清）
+
+PLAN.md 说「阶段 2 无外部**模块**依赖」，指不等别的 Owner 交代码；但**运行时 apt 包本机未装齐**，是阶段 2 跑起来的硬前置，别和"模块依赖"混。另有 **Linux Owner 治理审批依赖**（launch/package.xml/setup.py 变更需 Linux Owner review，AGENTS.md:18）——无代码依赖，但有治理门槛。
+
+本机现状（已核实 2026-08-10）：`gz-sim`(Harmonic)、`gz_ros2_control`、`controller_manager`、`joint_trajectory_controller`、`joint_state_broadcaster`、`ur_simulation_gz`、`robotiq_controllers` **均未安装**；apt 源有候选，可装。纯 Python 单测不受此阻，先行。
+
+开工前补装（写进 `package.xml` 交 rosdep）：
+
+```bash
+sudo apt-get install -y \
+  ros-jazzy-gz-ros2-control \
+  ros-jazzy-controller-manager \
+  ros-jazzy-joint-trajectory-controller \
+  ros-jazzy-joint-state-broadcaster \
+  ros-jazzy-gripper-controllers \
+  ros-jazzy-ros-gz-sim \
+  ros-jazzy-ros-gz-bridge \
+  ros-jazzy-ros2controlcli
+# Gazebo Harmonic 由 Jazzy gz vendor 依赖链提供，无需单独的 gz-harmonic 包。
+```
+
+夹爪控制器见 §5.3。**包与插件命名空间不一致，别混**（已按 Jazzy `ros-jazzy-gripper-controllers` 4.40.1 的 `ros_control_plugins.xml` 核实）：`GripperActionController` 由**包 `gripper_controllers`** 提供，但注册的**插件类型是 `position_controllers/GripperActionController`**（历史命名空间）。所以：装 `ros-jazzy-gripper-controllers` + `<exec_depend>gripper_controllers`，但 controllers.yaml 的 `type` 写 `position_controllers/GripperActionController`。另：`robotiq-controllers` 是**真机** Robotiq 激活控制器（C13/P3），与仿真夹爪 action 控制器无关。冻结前仍以 `ros2 control list_controller_types` 实测为准。
+
+## 4. 三路限位，别混（FRAMES.md：限位归 `robot/control/`，不进 description）
+
+| 路 | 层 | 来源文件 | 谁消费 | 松紧 |
+|---|---|---|---|---|
+| ① 硬限位 | 物理/驱动 | 厂商 `ur_description/config/ur5e/joint_limits.yaml`，经 `ur_macro` 已注入合并 URDF 的 `<limit>` | URDF / gz_ros2_control / 校验器基准 | 标称，最松 |
+| ② 规划限位 | 规划 | `config/moveit/joint_limits.yaml`（**已存在**） | MoveIt 规划 | ≤ ①（见下「单位」） |
+| ③ 真机安全覆盖 | 安全 | **新增** `config/joint_limits.hw_override.yaml`（C13/P3，阶段 2 只建结构） | 真机/校验器叠加 | 只能 ≤ ①，更严 |
+
+**单位与"更保守"的精确定义（回应 review P2）**：
+- ② 比 ① 保守体现在**两层**（回应 review：并非"数值与厂商 nominal 相同、只靠 scaling"）：(i) **数值本身已主动收紧**——如 shoulder_pan/lift 的 `max_velocity` 写 120°/s，而厂商 `ur_description` 3.5.1 是 180°/s；(ii) 再叠 `default_velocity_scaling_factor=0.1` / `acceleration_scaling_factor=0.1`。所以"② 比 ① 保守"比的是**规划时运行 scaling 后的有效限位**（`planning_value × scaling`），不是 YAML nominal。**规划层自己采用 scaling（MoveIt 消费），安全校验器不消费它**——校验器只检查 ① 硬限位 ∩ ③ 真机覆盖，不叠加 ② 的规划缩放。阶段 1 的 `joint_limits.yaml` 里"UR5e nominal"注释不实，本阶段改注释如实记录（见 §6）。
+- 硬限位**不重写**——UR 的 `<limit>` 已在合并 URDF（`ur_macro` 从厂商 yaml 读入）。只**引用**作校验基准，不抄数字（抄=双源漂移）。
+
+**③ `hw_override.yaml` 的失败语义（回应 review P2，全部 fail closed）**：
+- 文件**为空 / 无 `joint_limits` 段**：合法，等价"不覆盖"（P0 纯仿真下正常，ADR-0001）。
+- 某关节**缺失**：合法，该关节不叠加（不覆盖 ≠ 违规）。
+- 某关节**比硬限更松**（`override.max_velocity > hard` 或 pos 区间更宽）：**fail closed**，加载即报错退出。安全层只能更严。
+- **未知关节名**（不在 arm.yaml `joints`）：**fail closed**，报错——防止手滑写错关节名却静默无效。
+- **单位/类型错误**（非数值、min>max）：**fail closed**。
+
+## 5. 架构（高内聚低耦合）
+
+三块解耦：**描述层**（xacro：ros2_control + Gazebo 插件）、**控制器配置层**（controllers.yaml）、**启动/校验层**（launch + 纯 Python 校验器）。描述层不知控制器 YAML 长相；校验器不 import 任何 ROS 消息类型（延续 PLAN §阶段 4「Runtime 包不 import MoveIt/ros2_control 消息」防绕过线）。
+
+### 5.0 控制器命名 schema（冻结，回应 review P0-2）
+
+**权威唯一源 = `config/arm.yaml` 新增 `controllers:` 段**。运行时 Python 经 `arm_config.load_arm_config()` 读取，不写死；controllers.yaml 里的名字与之一致由单测强制。冻结命名（统一用 `arm_trajectory_controller`，废弃早前草稿里混用的 `arm_controller`）：
+
+`config/arm.yaml` 追加（不改已有字段；**不新增顶层 vendor: 段**——arm.vendor_description_pkg / arm.ur_type 已存在于 line 11-14）：
+```yaml
+# 控制器命名 + controller_manager 参数：ros2_control 层的唯一命名源。
+# controllers.yaml 的键必须与此处一致（test_controllers_config.py 强制）。
+controllers:
+  update_rate_hz: 500                     # controller_manager 更新率，冻结入配置
+  joint_state_broadcaster: joint_state_broadcaster
+  arm_trajectory_controller: arm_trajectory_controller
+  gripper_controller: gripper_controller
+```
+
+`ArmConfig`（`arm_config.py`）扩字段（保持 `frozen=True` dataclass 风格）。**注意：`vendor_description_pkg` / `ur_type` 的 YAML 字段虽已存在于 `arm.yaml:13-14`，但当前 `ArmConfig` dataclass（`arm_config.py:30`）并未解析它们**——阶段 2 需向 `ArmConfig` **新增**这两个字段并由 `parse_arm_config()` 解析：
+```python
+vendor_description_pkg: str       # 新增，来自 arm.vendor_description_pkg（YAML 已有，dataclass 未解析）
+ur_type: str                      # 新增，来自 arm.ur_type（YAML 已有，dataclass 未解析）
+driver_joint: str                 # 来自 gripper.driver_joint
+update_rate_hz: int               # controllers.update_rate_hz
+arm_trajectory_controller: str    # controllers.arm_trajectory_controller
+gripper_controller: str           # controllers.gripper_controller
+joint_state_broadcaster: str      # controllers.joint_state_broadcaster
+```
+`parse_arm_config()` 对应解析；缺 `controllers`/`gripper.driver_joint` 段时给显式错误（不静默默认）——命名与路径是安全相关配置，fail closed。测试：`test_arm_config.py` 加断言 `vendor_description_pkg == "ur_description"`、`ur_type == "ur5e"`、`driver_joint == "robotiq_85_left_knuckle_joint"`、控制器名齐全。
+
+### 5.1 描述层：ros2_control 块 + Gazebo 插件
+
+**在合并 URDF 里加，不新开描述文件。** `sim_gz` xacro arg 门控（默认 `false`）：
+- `false`（阶段 1 现状）：纯几何，move_group/可达性不受影响，**阶段 1 零回归**。
+- `true`：注入 `<ros2_control>` + `gz_ros2_control` 插件，供 Gazebo 起控制器。
+
+**xacro 方案决策（回应 review P1）：采用「xacro 参数传入」，不采用构建时生成。** 关节名、tf_prefix、controllers.yaml 路径都作 xacro `params`/`arg` 传入宏；关节接口用厂商宏展开。理由：xacro 本就是参数化模板，运行期一次展开即定；构建时生成会引入"生成步骤+生成物入库"的额外维护面，与"合并 URDF 单一来源"相悖。
+
+新增 `config/ros2_control.xacro`（本包宏，复用厂商关节接口）：
+```xml
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:include filename="$(find ur_description)/urdf/inc/ur_joint_control.xacro"/>
+
+  <!-- 夹爪控制接口：见 5.2，本包自定义以避免厂商仿真分支的 Ignition 插件 -->
+  <xacro:macro name="workbench_gripper_control" params="tf_prefix driver_joint">
+    <joint name="${tf_prefix}${driver_joint}">
+      <command_interface name="position"/>
+      <state_interface name="position"><param name="initial_value">0.0</param></state_interface>
+      <state_interface name="velocity"/>
+    </joint>
+  </xacro:macro>
+
+  <xacro:macro name="workbench_ros2_control" params="tf_prefix driver_joint controllers_yaml">
+    <ros2_control name="workbench_arm_system" type="system">
+      <hardware>
+        <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      </hardware>
+      <xacro:ur_joint_control_description tf_prefix="${tf_prefix}"/>   <!-- 6 臂关节 -->
+      <xacro:workbench_gripper_control tf_prefix="${tf_prefix}" driver_joint="${driver_joint}"/>
+    </ros2_control>
+
+    <gazebo>
+      <plugin filename="gz_ros2_control-system"
+              name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+        <parameters>${controllers_yaml}</parameters>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+</robot>
+```
+
+`arm_on_workbench.urdf.xacro` 顶部加 arg + 条件 include：
+```xml
+<xacro:arg name="sim_gz"          default="false"/>
+<xacro:arg name="driver_joint"    default="robotiq_85_left_knuckle_joint"/>  <!-- 镜像 arm.yaml gripper.driver_joint -->
+<xacro:arg name="controllers_yaml" default="$(find workbench_motion)/config/controllers.yaml"/>
+...
+<xacro:if value="$(arg sim_gz)">
+  <xacro:include filename="$(find workbench_motion)/config/ros2_control.xacro"/>
+  <xacro:workbench_ros2_control tf_prefix="$(arg tf_prefix)"
+      driver_joint="$(arg driver_joint)" controllers_yaml="$(arg controllers_yaml)"/>
+</xacro:if>
+```
+
+**"从 arm.yaml 读取"的落地方式（回应 review P1）**：xacro **不能**直接读 YAML。约定：`driver_joint` 既是 xacro `arg`（默认值）**也**是 arm.yaml 字段，二者一致由 `test_arm_config.py` 断言守护（延用阶段 1「arg 默认值↔arm.yaml」一致性做法）；launch 层（Python，能读 YAML）用 `load_arm_config().driver_joint` 显式传 `xacro ... driver_joint:=<值>`，运行期以 arm.yaml 为准。这样"唯一源是 arm.yaml"落到运行期，xacro 默认值只是可离线展开的兜底。
+
+**臂+夹爪合一个 system**：gz_ros2_control 一个插件实例管一棵树全部关节即可，不必拆两个 system。
+
+### 5.2 夹爪关节接口（宏来源明确，回应 review P1）
+
+`workbench_gripper_control` 宏在 §5.1 给出，随 `config/ros2_control.xacro` 交付、经 setup.py `glob("config/*.xacro")` 装入 share。最小 spike 的 Gazebo 日志确认 driver-only system 只导出驱动关节，`joint_state_broadcaster` 无法观测五个从动关节，因此已启用预定 fallback：驱动关节声明 position command+state 接口，五个从动关节按厂商列表和 multiplier 显式声明为 state-only 接口。
+
+**mimic 完整性是未验证假设，先做最小 spike（回应 review 阻塞项）**：厂商仿真宏（`robotiq_gripper.ros2_control.xacro:38+`）在 `<ros2_control>` 里把**五个从动关节**（`right_knuckle` / `left_inner_knuckle` / `right_inner_knuckle` / `left_finger_tip` / `right_finger_tip`，各带 multiplier ±1）**逐个显式声明**，而非只靠 URDF `<mimic>`。这说明"只声明驱动关节 + 靠 gz_ros2_control 处理 `<mimic>`"能否让 2F-85 在 Harmonic 下正确联动**尚未证实**。开工**第一步做最小 spike**：起 gz + 只声明驱动关节的 system，发一个夹爪目标，订阅 `/joint_states` 看五个从动关节是否按比例动。
+- spike **通过**（gz_ros2_control 正确解析 URDF `<mimic>`）：保留最小宏。
+- spike **不通过**：回退到"在 system 里显式声明五个从动关节 + multiplier"（照厂商宏的关节列表，但插件换 `gz_ros2_control/GazeboSimSystem`）。
+
+**验收加一条（不能只看 controller active）**：夹爪 open→close 后，采 `/joint_states`，断言**五个 mimic 关节都满足对驱动关节的比例关系**（multiplier ±1，容差内），结果入 `phase2-controllers.json`。
+
+不复用厂商 `robotiq_gripper_ros2_control` 整宏：它绑死 `ign_ros2_control/IgnitionSystem`（旧 Ignition），Harmonic 不适用（§2）；但**其从动关节列表 + multiplier 是 spike 失败时的权威参照**。
+
+**验收纳入 xacro 展开结果**（回应 review P1）：`xacro arm_on_workbench.urdf.xacro sim_gz:=true > /tmp/wb_ctrl.urdf` 后断言 —— 展开物含 `<plugin>gz_ros2_control/GazeboSimSystem</plugin>`、含 6 臂关节 + 驱动关节的 `<command_interface name="position">`、含 gz_ros2_control-system gazebo 插件且 `<parameters>` 指向 controllers.yaml；`check_urdf /tmp/wb_ctrl.urdf` 单树无错。
+
+### 5.3 控制器配置层：`config/controllers.yaml`
+
+命名全部引用 §5.0 的 arm.yaml `controllers:` 段（此处示例值即冻结值）：
+
+```yaml
+controller_manager:
+  ros__parameters:
+    update_rate: 500                      # = arm.yaml controllers.update_rate_hz
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    arm_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+    gripper_controller:
+      # 插件类型命名空间是 position_controllers/，但由包 gripper_controllers 提供（见下）
+      type: position_controllers/GripperActionController
+
+arm_trajectory_controller:
+  ros__parameters:
+    joints:                               # 必须 == arm.yaml arm.joints（单测强制）
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
+    command_interfaces: [position]
+    state_interfaces: [position, velocity]
+    constraints:
+      stopped_velocity_tolerance: 0.01    # 执行期跟踪容差，非入口越限判定
+      goal_time: 0.5
+      shoulder_pan_joint: {goal: 0.02}
+      shoulder_lift_joint: {goal: 0.02}
+      elbow_joint: {goal: 0.02}
+      wrist_1_joint: {goal: 0.02}
+      wrist_2_joint: {goal: 0.02}
+      wrist_3_joint: {goal: 0.02}
+
+gripper_controller:
+  ros__parameters:
+    joint: robotiq_85_left_knuckle_joint  # = arm.yaml gripper.driver_joint
+```
+
+每关节 goal tolerance 必须显式非零；否则 JTC 会把 Gazebo 硬限位夹到边界的越限目标也报告为 succeeded，probe 分类为 `clamped` 并触发失败门。上述配置让该路径实测为 `aborted`。
+
+**夹爪控制器类型冻结（回应 review P1，已核实 Jazzy deb）**：`GripperActionController`（阶段 5 抓放要 GripperCommand action，MoveIt simple controller manager 也按此对接）——
+- **包**：`gripper_controllers`（`<exec_depend>gripper_controllers`、`sudo apt install ros-jazzy-gripper-controllers`）。
+- **插件类型（写进 controllers.yaml `type`）**：`position_controllers/GripperActionController`。这是 `ros-jazzy-gripper-controllers` 4.40.1 的 `ros_control_plugins.xml` 实际注册的命名空间（历史遗留，包名≠命名空间）。**不是**说它归 `position_controllers` 包。
+
+**冻结前仍在 Jazzy/Harmonic 实机确认**：
+```bash
+ros2 control list_controller_types | grep -i gripper   # 期望见 position_controllers/GripperActionController
+```
+**三个易混项区分**：包 `gripper_controllers`=提供 GripperActionController（本阶段用，插件在 position_controllers/ 命名空间）；包 `position_controllers`=通用 position forward 控制器（另一回事）；`robotiq-controllers`=**真机** Robotiq 激活/驱动控制器（C13/P3 才用，阶段 2 不依赖）——README 阶段 2 段落会写清。
+
+**双写守护**：controllers.yaml 的 `joints` 列表与 `arm.yaml arm.joints` 必然重复（ros2_control 要求列关节名）。用 `test_controllers_config.py` 断言二者逐项相等、夹爪 `joint == arm.yaml gripper.driver_joint`、三个控制器名 == arm.yaml `controllers:` 段——把双写钉成"被测试守护的一致性"，非散落魔数（延用阶段 1 arm.yaml↔SRDF 一致性做法）。
+
+### 5.4 启动层：`launch/sim_control.launch.py`（可复现设计，回应 review P1）
+
+目标：任何人照抄能稳定得到"3 控制器 active"。明确每一步：
+
+1. **共享逻辑抽取——但绝不 include 阶段 1 的 `move_group.launch.py`（回应 review）**：那个 launch 会额外起 `robot_state_publisher` + **静态 `joint_state_publisher`**、且硬编码 `use_sim_time=False`（`move_group.launch.py:91,113`）——在仿真里会与 gz 时钟冲突、JSP 会与 `joint_state_broadcaster` 抢发 `/joint_states`。正确做法：把「构造 move_group Node 所需的参数装配」（SRDF/kinematics/OMPL/joint_limits 读取、`robot_description_semantic` 等）抽成 `launch_utils.py` 的**返回参数字典/Node 工厂的 helper**，`sim_control.launch.py` 用它自建一个 move_group Node，参数改为 `use_sim_time=true`；**只起一个 RSP（`use_sim_time=true`），不起 JSP**；`/joint_states` 唯一来源是 `joint_state_broadcaster`。`move_group.launch.py` 改为调用同一 helper（其行为不变：仍 `use_sim_time=False` + JSP，因为它是无控制器的纯 IK/可达性用途）。helper 只共享「参数装配」，不共享「起哪些节点/时钟源」。
+2. **robot_description**：`Command(["xacro ", arm_xacro, " sim_gz:=true", " driver_joint:=", <arm.yaml driver_joint>, " controllers_yaml:=", <path>])`，`driver_joint` 由 `load_arm_config()` 注入（运行期以 arm.yaml 为准，§5.1）。
+3. **world/SDF**：起 `ros_gz_sim` 的 `gz_sim.launch.py`，server-only `gz_args:="-s -r -v 3 empty.sdf"`（P0 空世界自测，不依赖外部 bringup，PLAN §阶段 1 精神），并用 `ros_gz_bridge parameter_bridge` 单向桥接 `/clock`，供所有 `use_sim_time=true` 节点使用。世界几何来自 URDF spawn，不另建 SDF 世界物体。
+4. **robot_state_publisher**：起，喂 `robot_description` + `use_sim_time:=true`。
+5. **spawn 机器人**：`ros_gz_sim` 的 `create` 节点，`-topic robot_description -name workbench_arm`。
+6. **控制器 spawn 顺序（用事件串，不靠 sleep）**：`joint_state_broadcaster` → `arm_trajectory_controller` → `gripper_controller`，每个是 `controller_manager` 的 `spawner` 节点，后一个由前一个的 `RegisterEventHandler(OnProcessExit)` 触发。**注意 `OnProcessExit` 在 spawner 成功和失败时都会触发**——handler 里必须判 `event.returncode == 0` 才 spawn 下一个；非 0 则发 `Shutdown`（携带失败控制器名），不得在前一个失败时继续往下 spawn（否则串起半截控制器还报 active 假象）。`spawner` 自带对 `~/list_controllers` 服务的等待，避免竞态。
+7. **use_sim_time**：所有节点显式 `use_sim_time:=true`（gz 时钟）。
+8. **失败退出**：`spawner` 失败即非零退出，launch 传播；文档给出排障顺序（gz 起没起 → controller_manager 插件加载没有 → 控制器类型插件缺失）。
+
+9. **move_group（本阶段随 sim 一起起，为 probe 的碰撞检查供 `/check_state_validity`）**：复用阶段 1 的 move_group 配置（SRDF/kinematics/OMPL/joint_limits），与控制器同一 launch 起来。**"无穿模"证据路径定为 MoveIt `/check_state_validity`**（见 §5.5 说明），不接 Gazebo contact sensor——仓库当前无 contact sensor/bridge，且合并 URDF 已是 MoveIt 的碰撞权威（PLAN §阶段 3）。
+
+产物：`ros2 control list_controllers` 三个均 `active` 即达标（**C2 派生验收**，非 README Metrics——见 §0/§7）。
+
+### 5.5 越限校验：保守前置筛查纯内核（P0-1 按"降级为纯逻辑权威"收口）
+
+**边界定性（对齐 §0）**：`collision_or_limit_violation=0` 是 v0.1 发布线，其 ROS 端到端闭合（唯一 gate + 防绕过 + 命名空间隔离）归阶段 4。阶段 2 **不**建 action proxy、**不**做命名空间隔离——那会提前实现本属阶段 4 的机制、与冻结的 PLAN 阶段划分冲突、且可能在阶段 4 重构。阶段 2 交付：
+
+**(a) 纯逻辑校验内核** `workbench_motion/joint_limits.py`（**无 rclpy**，uv 可测）。**职责边界（回应 review 阻塞项）：阶段 2 只交付纯判定——输入轨迹、输出 `Violation | None`，不产事件、不下发、不碰 EvidenceSink。** 事件生成、零下发、EvidenceSink 闭合全部归阶段 4 的适配器（它有 ROS 上下文、run_id/action_id、唯一入口）。阶段 4 复用**同一个** `check_trajectory`，不重写。
+- `load_hard_limits(vendor_description_pkg, ur_type)`：读厂商 `{vendor_description_pkg}/config/{ur_type}/joint_limits.yaml`。含自定义 `!degrees` YAML tag，加 constructor 转弧度。路径参数来自 `arm.yaml` 的 `arm.vendor_description_pkg` / `arm.ur_type`（已存在字段），不写死。得每关节 `(min_pos, max_pos, max_vel, max_eff)`。
+- `load_override(path)`：读 `hw_override.yaml`，按 §4 失败语义（空/缺/更松/未知关节/单位错）fail closed。
+- `effective_limits(hard, override)`：`hard ∩ override` 取最严。**不接收 scaling 参数**——MoveIt 规划期缩放只留在规划层（路②），不进入这个安全校验器（回应 review 语义冲突问题）。
+- `check_trajectory(traj, current_joint_positions: dict[str, float]) -> Violation | None`：**纯判定，绝不 clamp、绝不产生副作用**。接收当前关节状态，构造虚拟"段 0"（`current → points[0]`）检查启动瞬时速度，防单点大跳跃绕过。
+
+**(a′) 校验口径明确（回应 review 阻塞项）**：`check_trajectory` 执行 **① 硬限位 ∩ ③ 真机覆盖**（二者取最严），**不叠加 ② 规划限位**——② 归 MoveIt 规划期，阶段 2 校验器不越界。阶段 4 要保证「发布线收到的轨迹已经过 MoveIt 规划且满足 ②」，但那是调用链保证（只从 MoveIt 接轨迹），非校验器职责。校验内核是**保守前置筛查（pre-filter）**：只查 position/velocity/effort 点值 + 段平均速度（线性口径），**不复现 JTC 的 cubic/quintic 样条区间峰值、不硬检加速度**，能挡住明显越限，但**不足以单独保证「零越限」**。阶段 4 若要据它保证发布线的越限=0，**必须二选一**：① 冻结控制器插值方法并按真实样条计算区间极值再判定；或 ② 补执行期监控（订阅 `/joint_states` 实时查速度/位置越限并触发停机）。此约束写进阶段 4 的待办，PLAN §阶段 4 已承接。
+
+**(b) 实测控制器越限行为（回应 review，不预设结论，六分类）**：直发一条越限 `FollowJointTrajectory` 到 JTC，**观测 `/joint_states` 前后 + action result**，分六类（**不止 clamp/reject/abort**）：
+| 分类 | 含义 | gate |
+|---|---|---|
+| `rejected` | 控制器拒收目标（goal rejected），关节零运动 | 安全 |
+| `aborted` | 收下但执行中 abort，未越界 | 安全 |
+| `clamped` | 收下、执行，但把越限值**静默截断**到边界（关节停在 bound 内） | **登记为阶段 4 必须消除的绕过风险** |
+| `executed_over_limit` | 控制器接受目标且关节**实际越界**（最严重、完全可能） | **fail gate**——发布线 `collision_or_limit_violation=0` 被直接违反，阶段 4 必须消除 |
+| `timeout` | action 超时或无 result | **fail gate** |
+| `unclassified` | 行为无法归入上述五类（防御性兜底） | **fail gate**——不得当"安全"记 |
+
+实测结果（版本号、分类、`/joint_states` 前后、越界关节与幅度）写进 `docs/evaluation/phase2-controllers.json`（§7）。`clamped` / `executed_over_limit` / `timeout` / `unclassified` 都**不能**被记成"控制器已提供防护"；只有 `rejected` / `aborted`（且确认未越界）才算控制器侧有一层防护，且**无论哪类**，越限=0 的保证都在阶段 4（唯一入口 + 校验内核 + 真实极值/执行期监控），不依赖控制器行为。
+
+**(c) 段平均速度背后的线性插值假设（回应 review 小修项）**：JTC 实际沿 cubic/quintic 样条插值，区间峰值速度 > 段平均；阶段 2 校验器只按线性 `Δpos/Δt` 检查——**能挡住大部分越限，但留缺口（真实样条可能峰值越限）**。缺口由阶段 4 闭合（①冻结插值法+真实极值计算 或 ②执行期监控），PLAN 已承接。
+
+**`check_trajectory` 完整安全语义（回应 review P1，"每点合法≠整条合法"）**，逐条 fail closed，各配攻击性单测：
+| 规则 | 判定 |
+|---|---|
+| `joint_names` 缺失/为空 | 拒 |
+| `joint_names` 有重复 | 拒 |
+| `joint_names` 含未知关节（不在 arm.yaml joints） | 拒 |
+| **partial goal**（只给部分关节） | 拒（阶段 2 要求全关节；宁可拒不可漏检） |
+| `points` 为空 | 拒 |
+| 某点 `positions` 长度 ≠ `joint_names` | 拒 |
+| 可选 `velocities`/`accelerations`/`effort` 长度既非 0 也非关节数 | 拒（要么整条不给，要么与关节一一对应；半截数组模糊对应） |
+| **当前状态边界条件（回应 review P0）**：`current_joint_positions` 缺关节/含未知关节/NaN·Inf/自身已越限 | 拒（fail closed：不对有毒当前状态做检查） |
+| **当前 → 首点段速度**（防瞬移）：`first.time_from_start < 0` | 拒（时间不能倒退） |
+| `first.time_from_start == 0` | 首点 `positions` 必须与 `current_joint_positions` 在 `limit_epsilon` 内一致，否则拒（t=0 意味"立即是当前状态"） |
+| `first.time_from_start > 0` | 检查虚拟段 0：`\|first.pos - current.pos\| / first.time_from_start` 越 effective `max_vel` → 拒（单点短时大跳跃会绕过相邻点段平均检查） |
+| 位置越 effective `[min,max]`（任一点、任一关节） | 拒，指明关节/值/界 |
+| 速度 `|velocity|` 越 effective `max_vel` | 拒 |
+| effort 越 `max_eff`（若给） | 拒 |
+| 含 NaN/Inf（pos/vel/acc/eff 任一） | 拒（复用 evidence.py 已有的有限性拒绝思路） |
+| `time_from_start` 有负值（除首点已检查） | 拒（时间不能倒退到起点之前） |
+| `time_from_start` 非**严格**递增（含相邻相等 Δt=0） | 拒（Δt=0 会让段速度除零/无穷，且时序无意义） |
+| 相邻点**段平均速度** `Δpos/Δt` 越 `max_vel`（线性插值假设，见下） | 拒（点上 `velocity` 合法但段位移过大——整条轨迹级检查，非逐点） |
+| 边界容差 | 用配置化 `limit_epsilon`（默认 1e-6）**只向内收，绝不向外放宽硬限位**。明确公式：`effective_max = max - epsilon`、`effective_min = min + epsilon`、`effective_max_vel = max_vel - epsilon`；判越限用 `value > effective_max` / `value < effective_min`。即 epsilon 把可接受区间**缩小**（更严），绝不写成 `value > max + epsilon`（那是放宽）。速度/effort 同理向内收 |
+| 加速度 | 阶段 2 记录字段并可选检查（`max_acceleration` 厂商未公开，②里是保守选值）；不作硬门，注明留阶段 6 |
+
+**段速度检查的插值口径（回应 review 语义不一致）**：阶段 2 **只保证线性插值口径**，检查相邻点的**段平均速度** `Δpos/Δt`，不是 JTC 实际的 cubic/quintic spline 区间真实速度峰值。理由：`check_trajectory` 是 ROS-free 纯逻辑内核，不复现 JTC 的样条插值器；线性段平均速度是**保守下界**（样条峰值 ≥ 线性平均值时才更严，但至少能抓住"两点间位移/时间已超 max_vel"这类整条轨迹级越限）。**明确不声称"段峰值"**——那需要按 JTC 样条算真实峰值，留待后续阶段若接入 JTC 插值器再做。文档、表格、Task Packet 统一用「段平均速度（线性口径）」措辞，不用「segment-peak」。
+
+拒绝路径（**在阶段 4 的适配器里闭合，非阶段 2**）：越限 → 不下发任何指令（零运动来自"根本没发"）→ WARNING 日志（带 run_id）+ 产 `ExecutionEvent`（`event_type="trajectory_rejected"`，payload 含结构化违规）→ `EvidenceSink.append()` 拿稳定 `event_id`。阶段 2 只交付返回 `Violation` 的纯判定内核；上述副作用链归阶段 4（它才有 ROS 上下文与 run_id/action_id）——延用 evidence.py 既定分工。
+
+## 6. 逐文件清单
+
+新增：
+- `config/ros2_control.xacro` — ros2_control 宏（复用厂商臂关节接口 + 本包夹爪宏 + Harmonic 插件）+ gz_ros2_control gazebo 插件（§5.1 已给全定义）。
+- `config/controllers.yaml` — controller_manager + 臂 JTC + 夹爪 + joint_state_broadcaster（§5.3）。
+- `config/joint_limits.hw_override.yaml` — 真机安全覆盖（第③路，C13/P3）；阶段 2 结构在、内容空，含头注说明失败语义。
+- `workbench_motion/joint_limits.py` — 纯逻辑：**硬限位 + override 两路加载与合成**（不叠加规划 scaling）、`!degrees` 解析、fail-closed override、`check_trajectory`（§5.5）。无 rclpy。
+- `workbench_motion/launch_utils.py` — 从 move_group.launch.py 抽的共享 xacro/路径逻辑。
+- `launch/sim_control.launch.py` — Gazebo + spawn + 控制器顺序 spawn + **move_group**（为 probe 供 `/check_state_validity`，复用阶段 1 MoveIt 配置）（§5.4）。
+- `test/test_joint_limits.py` — `!degrees`、硬限位加载、override fail-closed 全分支、`check_trajectory` 全规则攻击性用例、"校验器不改输入点"。
+- `test/test_controllers_config.py` — controllers.yaml↔arm.yaml 关节/夹爪/控制器名一致。
+- `test/test_phase2_probe.py` — probe 的**纯逻辑部分**单测（把 ROS IO 抽成可注入接口，用假响应喂）：越限行为**六分类**（rejected/aborted/clamped/executed_over_limit/timeout/unclassified）判定 + 后四类 fail gate、各类超时、TF/JointState 陈旧（stale）判定、缺 topic/action/service 时非零退出且不产空 JSON、JSON 生成 schema 正确、非 GazeboSimSystem 时拒发越限轨迹（fail-closed）、mimic 比例按增量计算。ROS 依赖用 mock，纯逻辑在 uv 下可测。
+- `workbench_motion/phase2_probe.py` + console_scripts 入口 `phase2_probe` — **一条命令产全套证据**（回应 review 工具缺口）。范式同阶段 1 `reachability_check`（ROS 控制台脚本产 JSON）。实现要点（写死路径，不留"可能没数据源"的空洞）：
+  - **步骤**：① `controller_manager_msgs/ListControllers` 采三控制器 state；② `tf2_ros.Buffer` 查 `world→base_link→…→tool0→grasp_tcp` 每段 `lookup_transform`，缺段记 `missing`；③ 发**合法** `FollowJointTrajectory`（`control_msgs`），用 **MoveIt `/check_state_validity`（`moveit_msgs/GetStateValidity`）** 判无碰撞（**碰撞证据唯一路径 = MoveIt，不接 Gazebo contact**——仓库无 contact sensor/bridge，合并 URDF 已是 MoveIt 碰撞权威）。`/check_state_validity` **一次只验一个状态**，故必须定义"沿途"分辨率：对每个**实测到的 `/joint_states` 采样**逐个验（执行期实时验），**且**对规划轨迹按固定关节步长 `collision_check_resolution_rad`（默认 0.05 rad）线性加密后逐点验——终点合法≠路径无碰撞，两者都记；任一状态 invalid 即判该轨迹穿模。④ 发**越限** `FollowJointTrajectory`，采 `/joint_states` 前后 + action result **实测**控制器行为，按 §5.5(b) **六分类**（rejected/aborted/clamped/executed_over_limit/timeout/unclassified），后四类 fail gate；⑤ 本地跑 `check_trajectory` 记 `Violation`（无 event_id）；⑥ 夹爪 open→close（`GripperCommand`），采 `/joint_states` 验五从动关节 multiplier 比例（Δfollower/Δdriver）。
+  - **fail-closed 安全（回应 review）**：probe 会主动发越限轨迹，**执行前必须确认 hardware 插件是 `gz_ros2_control/GazeboSimSystem`**（查 `robot_description` 里的 `<plugin>` 或 controller_manager 参数）；**不是 GazeboSimSystem 就立即中止、绝不发送**——防止误连未来真机控制器把越限指令打到真臂。
+  - **健壮性**：`ListControllers`/action server/`/check_state_validity`/TF 任一超时或缺失 → 记 `unavailable` 并**非零退出**，不写"看似成功"的空 JSON；TF/JointState 时间戳过期（超 `staleness_s`）判 stale 而非静默采旧值。
+- `docs/task_packets/motion-002-limits-control.json` — 阶段 2 Task Packet（已随本次落盘，`make task-check` 过）。
+- `docs/evaluation/phase2-controllers.json` — 机器可读证据（由 `phase2_probe` 生成，§7）。
+
+修改：
+- `config/arm.yaml` — 加 `controllers:` 段（§5.0）；`gripper.driver_joint` 已在，复用。
+- `workbench_motion/arm_config.py` — `ArmConfig` 加 `driver_joint`/`update_rate_hz`/三控制器名字段，`parse_arm_config` 解析 + 缺失 fail closed（§5.0）。
+- `config/arm_on_workbench.urdf.xacro` — 加 `sim_gz`/`driver_joint`/`controllers_yaml` arg + 条件 include（默认 false，阶段 1 零回归）。
+- `launch/move_group.launch.py` — 改用 `launch_utils.py`（仅去重）。
+- `package.xml` — 加 exec_depend：
+  - 控制/仿真运行时：`gz_ros2_control`、`controller_manager`、`joint_trajectory_controller`、`joint_state_broadcaster`、`gripper_controllers`、`ros_gz_sim`、`ros_gz_bridge`（仅桥 `/clock`）。
+  - **`phase2_probe` 用到的消息/客户端库**（回应 review：先前漏列）：`control_msgs`（FollowJointTrajectory / GripperCommand action）、`trajectory_msgs`（JointTrajectory）、`controller_manager_msgs`（ListControllers 服务）、`tf2_ros`（帧链查询）、`moveit_msgs`（GetStateValidity 服务，已在阶段 1 依赖）、`sensor_msgs`（JointState，已在）。**不引 Gazebo contact bridge**——碰撞证据走 MoveIt（见下）；`ros_gz_bridge` 仅用于 `/clock`。
+- `test/test_arm_config.py` — 断言新增控制器/driver_joint 字段。
+- `README.md` — 阶段 2 段落：apt 前置、`sim_control` 起法、`list_controllers` 验证、夹爪控制器类型澄清（vs robotiq-controllers）、越限校验复现命令；换臂清单加 controllers.yaml 关节列表 + hw_override 两项。
+- `setup.py` — data_files 现有 glob 已覆盖新 `.xacro`/`.yaml`/`launch`；`console_scripts` 加 `phase2_probe = workbench_motion.phase2_probe:main`。
+- `config/moveit/joint_limits.yaml`（阶段 1 交付物，本阶段仅**改注释**不改值）— 现注释 `# UR5e nominal` **不实**：厂商 `ur_description` 3.5.1 的 shoulder_pan/lift 是 **180°/s**，我们写 120°/s 是**主动收紧**。改注释为"主动收紧值（厂商 nominal 180°/s，规划层保守取 120°/s），来源与理由见此注 + `arm.yaml`"，如实记录。
+
+## 7. 验收映射（挂官方标准）+ 机器可读证据
+
+| 验收 | 官方锚点 | 本方案 | 证据（稳定，非"日志行"） |
+|---|---|---|---|
+| 3 控制器 `active` | **C2（项目派生，非 README Metrics）** | §5.3+§5.4 | `phase2-controllers.json`.controllers[] state |
+| **TF 帧链完整**（C2 明列 URDF/**TF**/控制器/限位） | **C2** | §5.4 rsp + spawn | `/tf` + `/tf_static` 采样，断言 `world→base_link→…→tool0→grasp_tcp` 链完整入 json |
+| 合法 `FollowJointTrajectory` 平滑到位、**无穿模** | CONSTRAINTS `collision_or_limit_violation=0` | §5.1 gz system + JTC | 关节前后状态 + **MoveIt `/check_state_validity` 结果（唯一路径，逐采样+加密点）**，不只靠无 warning，入 json |
+| **校验内核（保守前置筛查）**判定越限（不 clamp）+ 实测控制器越限行为 | 同上（发布线，端到端 + 真实极值/监控归阶段 4） | §5.5 `check_trajectory` | 单测输出 + `Violation` + **六分类实测(rejected/aborted/clamped/executed_over_limit/timeout/unclassified)**，后四类 fail gate，入 json |
+| xacro 展开含正确插件/接口、单树 | C2 | §5.2 展开断言 | `check_urdf` 输出 |
+| **夹爪 mimic 比例关系**（open→close 后五从动关节按 multiplier 联动） | C2/C3 前置 | §5.2 spike + 验收 | `phase2-controllers.json`.gripper_mimic |
+| override ⊆ hard、命名一致 | — | §4/§5.0/§5.3 单测 | 单测输出 |
+| `sim_gz=false` 回归 | 阶段 1 门 | §5.1 门控 | 可达性 gate 仍过 |
+
+> **关于官方锚点的诚实标注（回应 review）**：README「Metrics」表**只有三条 Safety（False completion / Collisions·joint-limit-violations / raw joint control 均=0）+ Task/Evidence/System**，**没有"controllers active"这一行**。"3 控制器 active"和"TF 帧链"是 **C2**（`05-机械臂资产.md:13`「URDF/TF/控制器/关节限位独立 launch 能加载」）的验收，属**项目派生**，不冒充 README 指标。
+
+**`docs/evaluation/phase2-controllers.json`（回应 review P1「日志不是稳定证据」）** 至少记录（镜像 phase1-reachability.json 风格）：
+```
+generated_at, commit(git rev-parse HEAD), versions{ros_distro, gz, gz_ros2_control, jtc, gripper_controllers},
+arm(=arm.yaml arm_label), controllers[{name,type,state}],
+tf_chain{expected: ["world","base_link",…,"tool0","grasp_tcp"], present: bool, missing: []},  # C2 的 TF 验收
+gripper_mimic{
+    tolerance_abs: 0.02,                                    # |observed_ratio - nominal| ≤ tol 判 ok
+    driver_joint, 
+    followers[{
+        joint, 
+        nominal_multiplier,                                 # 来自 URDF <mimic multiplier="...">
+        observed_ratio,                                     # Δfollower / Δdriver（开→关增量比，非绝对位置比）
+        ok: bool                                            # |observed - nominal| ≤ tolerance_abs
+    }]},
+legal_trajectory{
+    tracking_tolerance_rad: 0.05,                           # |final - target| ≤ tol 判 tracking_ok
+    joint_states_before, joint_states_after, tracking_ok,
+    collision{
+        source: "moveit",                                   # 唯一路径: /check_state_validity
+        resolution_rad: 0.05,                               # 固定（冻结）：线性插值加密到 ≤0.05 rad 关节步
+        states_checked: N,                                  # 轨迹点加密后数量 + 实测 /joint_states 采样数
+        all_valid: bool, 
+        first_invalid: {...}|null
+    }},
+observed_controller_over_limit_behavior{                   # 实测六分类，不预设
+    kind: "rejected"|"aborted"|"clamped"|"executed_over_limit"|"timeout"|"unclassified",
+    joint_states_before, joint_states_after, over_limit_joints: [{joint, value, bound}],
+    gate: "safe"|"fail",                                   # clamped/executed_over_limit/timeout/unclassified => fail
+    is_phase4_bypass_risk: bool},                          # clamped/executed_over_limit 时 true
+validator_violation{joint, kind, value, bound}             # check_trajectory 返回的纯 Violation（无 event_id：事件归阶段 4）
+```
+关节前后状态从 `/joint_states` 采。**无穿模证据路径唯一定为 MoveIt `/check_state_validity`**（仓库无 Gazebo contact sensor/bridge，合并 URDF 是 MoveIt 碰撞权威）——`/joint_states` + 无 warning 不足以证明无穿模（review 小修项）。**一条命令产全套证据**：见 §6 的 `phase2_probe` 控制台脚本。
+
+**probe 健壮性（回应 review）**：
+- JSON 原子写：先写临时文件，校验 schema 通过后 `os.replace()` 覆盖目标。**注意**：`os.replace()` 只保证原子覆盖，**不会**在新运行失败时清除旧证据——失败路径直接非零退出，不产任何 JSON，调用方依据退出码判定失败（不因空 JSON 或旧 JSON 被误导为通过）。
+- 记录 git 状态：`"git_dirty": bool`（`git status --porcelain` 非空时 true；`git diff-index` 不含未跟踪文件，不够全）。
+- 记录关键配置 hash：`"config_hashes": {"arm.yaml": "sha256:...", "controllers.yaml": "sha256:..."}`（防配置漂移后误用旧证据）。
+- 碰撞检查插值口径冻结为 0.05 rad 关节步（线性插值加密轨迹点；若后续需匹配 JTC 样条真实路径，留阶段 4/6 升级）。
+
+## 8. 测试清单（随阶段交付，AGENTS.md:7）
+
+纯 Python（`uv run pytest`，无 ROS）：
+- `!degrees` tag：360°→2π。
+- 硬限位加载：6 关节齐全，pos/vel/eff 边界对得上厂商表。
+- override fail-closed **全分支**：空文件→放行；缺关节→放行该关节；更松→报错；未知关节→报错；min>max/非数值→报错。
+- `check_trajectory` 全规则（§5.5 表逐行）：合法→None；**当前→首点段速度越限→拒**；越 pos/vel/eff→违规且定位；缺/空/重复/未知/partial joint_names→拒；空 points；positions 长度不匹配；**可选 velocities/accelerations/effort 长度非 0 且非关节数→拒**；NaN/Inf；**`time_from_start` 负值 / 非严格递增（含 Δt=0）→拒**；**段平均速度（线性口径）`Δpos/Δt` 越 max_vel**；**`limit_epsilon` 不向外放宽硬限位**（越 bound 的值不因 epsilon 被判合法）；**断言不修改输入点（不 clamp）**。
+- controllers.yaml ↔ arm.yaml：关节列表、夹爪关节、三控制器名一致。
+- arm_config：新字段解析（vendor/controllers）+ 缺失 fail closed。
+- `phase2_probe` 纯逻辑（mock ROS IO）：越限六分类（rejected/aborted/clamped/executed_over_limit/timeout/unclassified）+ 后四类 fail gate、超时、TF/JointState stale、缺 topic/action/service→非零退出不产空 JSON、JSON schema、非 GazeboSimSystem→拒发越限（fail-closed）、mimic 比例按增量计算。
+
+ROS/仿真（需 §3 apt 装齐；PR 附本地日志 + phase2-controllers.json，同阶段 1 可达性门做法）：
+- `colcon build` 通过。
+- xacro `sim_gz:=true` 展开断言（§5.2）+ `check_urdf`。
+- `list_controllers` 三个 active。
+- 合法 `FollowJointTrajectory` 到位（`/joint_states` 前后）；无穿模由 **MoveIt `/check_state_validity`** 佐证（唯一路径）。
+- 越限行为实测（**六分类**，不预设）：`rejected`/`aborted`/`clamped`/`executed_over_limit`/`timeout`/`unclassified`，后四类 fail gate。
+- 直发越限轨迹 → **实测并记录**控制器行为（六分类，不预设；后四类 fail gate）；经校验内核 → 返回 `Violation`（**阶段 2 无 event_id——事件归阶段 4**）。
+- `sim_gz=false`：move_group + 可达性 gate 仍过（阶段 1 零回归）。
+- 根 `make lint/test/contract/scenario-check/context-check` 全绿（AGENTS.md 四项检查齐 + lint）。
+
+## 9. 卡点与风险
+
+- **apt 未装齐（§3）**：真阻塞，先补装。纯逻辑单测先行不受阻。
+- **gz_ros2_control mimic 支持**：2F-85 靠 mimic 联动，需确认 Harmonic 下 gz_ros2_control 正确处理 `<mimic>`。开工第一步做 §5.2 的最小 spike。**不通过则回退到"在 `<ros2_control>` 里显式声明五个从动关节 + multiplier"（照厂商宏关节列表，插件换 GazeboSimSystem），与 §5.2 fallback 一致**——不是"只控驱动关节"。记入 PR。
+- **夹爪控制器插件全名**：§5.3 —— 包 `gripper_controllers`，插件类型 `position_controllers/GripperActionController`（命名空间历史遗留，已核 Jazzy deb）；**冻结前仍须 pluginlib 实际加载确认**，以真实可加载名落定 controllers.yaml + package.xml。
+- **update_rate 500Hz**：需与 gz 物理步长匹配，值冻结入 controllers.yaml，实测可调（不留裸魔数）。
+- **越限=0 归属**：阶段 2 只交校验内核 + 反面证据；端到端唯一入口/防绕过/命名空间隔离归阶段 4，复用**同一** `check_trajectory`，不重写（§0/§5.5）。
+
+## 10. Task Packet
+
+`docs/task_packets/motion-002-limits-control.json`（已随本文件落盘）：
+- issue 5、human_owner `cyathea152-bit`（沿用 motion-001）。
+- allowed_paths：`robot/control/**`、`docs/task_packets/motion-002-limits-control.json`、`docs/evaluation/phase2-controllers.json`。
+- read_only：`interfaces/**`、`robot/description/**`、`docs/context/**`、`AGENTS.md`。
+- forbidden：`firmware/**`、`services/**`、`interfaces/**`、`robot/description/**`。
+- acceptance/commands/evidence/stop_conditions 照 §7/§8/§9 填。
+- 校验：`make task-check PACKET=docs/task_packets/motion-002-limits-control.json` 通过。
+
+## 11. 分支 / PR 策略（回应 review git 卫生项）
+
+现状：仍在 `feat/motion-phase1-arm`，阶段 1 PR **未合并**，`PHASE2.md` + `motion-002-*.json` 两个文件当前 untracked。**不要把阶段 2 代码堆进阶段 1 的 PR**（污染 review、放大 diff）。二选一：
+- **推荐：等阶段 1 PR 合并后，从更新的 `main` 新开 `feat/motion-phase2-limits-control`。** 阶段 2 依赖阶段 1 的合并 URDF/arm.yaml/arm_config，从合并后的 main 起最干净。
+- **次选：stacked PR。** 若阶段 1 短期不合并且阶段 2 要并行，`feat/motion-phase2-limits-control` 从 `feat/motion-phase1-arm` 切出，PR 显式声明 base 为阶段 1 分支（不是 main），阶段 1 合并后 rebase 到 main。
+
+无论哪种，本轮这两个规划文档（PHASE2.md / Task Packet）属**规划产物**：可先随阶段 1 分支带上，或单独一个 docs-only commit——但阶段 2 的**代码**（xacro/yaml/py）必须落在阶段 2 分支，不混进阶段 1。

--- a/robot/control/README.md
+++ b/robot/control/README.md
@@ -147,3 +147,65 @@ override for ad-hoc probing, but with no flags the values come from arm.yaml
 macro instantiation are still hand-edited per arm — that is the "config edit",
 not a Python edit. Acceptance: the swap touches no `.py` files under
 `workbench_motion/workbench_motion/`.
+
+## Phase 2: limits + ros2_control
+
+Install the Jazzy/Harmonic runtime packages (apt/rosdep, not uv):
+
+```bash
+sudo apt-get install -y \
+  ros-jazzy-gz-ros2-control \
+  ros-jazzy-controller-manager \
+  ros-jazzy-joint-trajectory-controller \
+  ros-jazzy-joint-state-broadcaster \
+  ros-jazzy-gripper-controllers \
+  ros-jazzy-ros-gz-sim \
+  ros-jazzy-ros-gz-bridge \
+  ros-jazzy-ros2controlcli
+```
+
+On ROS 2 Jazzy/Noble, these packages pull Gazebo Harmonic through the
+`ros-jazzy-gz-*-vendor` dependency chain. A separate `gz-harmonic` package is
+not required and may not exist in a ROS-only apt configuration.
+`ros_gz_bridge` is used only for the Gazebo-to-ROS `/clock` bridge required by
+nodes running with `use_sim_time=true`; collision evidence remains exclusively
+MoveIt's `/check_state_validity`, with no Gazebo contact bridge.
+
+The gripper package is `gripper_controllers`, while its Jazzy plugin type is
+the historical `position_controllers/GripperActionController`. It is not the
+real-hardware `robotiq_controllers` plugin.
+
+The arm JTC has an explicit `0.02 rad` goal tolerance per joint and a `0.5 s`
+goal-time allowance. This makes an unreachable, hard-limit-clamped target end
+as an aborted action instead of being reported as a successful clamped goal.
+
+Build and validate the opt-in control expansion:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+colcon build --packages-select workbench_motion
+source install/setup.bash
+xacro $(ros2 pkg prefix workbench_motion)/share/workbench_motion/config/arm_on_workbench.urdf.xacro \
+  sim_gz:=true > /tmp/wb_ctrl.urdf
+check_urdf /tmp/wb_ctrl.urdf
+ros2 launch workbench_motion sim_control.launch.py
+```
+
+In a second sourced shell, verify the controller types/states and run the
+single evidence probe:
+
+```bash
+ros2 control list_controller_types | grep -i gripper
+ros2 control list_controllers
+ros2 run workbench_motion phase2_probe
+```
+
+`phase2_probe` refuses to send its over-limit test unless robot_description
+contains `gz_ros2_control/GazeboSimSystem`. On a fully passing run it atomically
+publishes `docs/evaluation/phase2-controllers.json`; endpoint, stale-data,
+collision, mimic, or unsafe controller behavior failures exit nonzero without
+publishing a new artifact.
+
+An arm swap must additionally update the joint list and names in
+`config/controllers.yaml`, review `config/joint_limits.hw_override.yaml`, and
+rerun this probe. Vendor hard limits remain dynamic; never copy them here.

--- a/robot/control/workbench_motion/config/arm.yaml
+++ b/robot/control/workbench_motion/config/arm.yaml
@@ -54,3 +54,12 @@ gripper:
   planning_group: gripper
   # tool0 -> grasp_tcp offset along tool0 +z (arm_on_workbench.urdf.xacro arg tcp_z).
   tcp_offset_z: 0.16
+
+# Controller names and controller-manager settings are safety-relevant runtime
+# configuration. Consumers must read them through ArmConfig and fail closed if
+# this section is absent.
+controllers:
+  update_rate_hz: 500
+  joint_state_broadcaster: joint_state_broadcaster
+  arm_trajectory_controller: arm_trajectory_controller
+  gripper_controller: gripper_controller

--- a/robot/control/workbench_motion/config/arm_on_workbench.urdf.xacro
+++ b/robot/control/workbench_motion/config/arm_on_workbench.urdf.xacro
@@ -14,9 +14,8 @@
     defaults mirrored in config/arm.yaml. Swapping the arm is a config edit, never
     an adapter-logic edit (phase-1 acceptance gate + README swap checklist).
 
-  Phase boundary: this file is description only. ros2_control / controllers land
-  in phase 2; grasp/attach logic in phase 5. `include_ros2_control` on the gripper
-  is therefore false here.
+  ros2_control is opt-in through sim_gz:=true. The default remains false so the
+  phase-1 MoveIt/reachability expansion is byte-for-byte free of control plugins.
 
   Validate:
     xacro robot/control/config/arm_on_workbench.urdf.xacro > /tmp/wb_arm.urdf
@@ -29,6 +28,9 @@
        swap touches. -->
   <xacro:arg name="ur_type"        default="ur5e"/>
   <xacro:arg name="tf_prefix"      default=""/>
+  <xacro:arg name="sim_gz"         default="false"/>
+  <xacro:arg name="driver_joint"   default="robotiq_85_left_knuckle_joint"/>
+  <xacro:arg name="controllers_yaml" default="$(find workbench_motion)/config/controllers.yaml"/>
 
   <!-- Arm base placement in the workbench `world` frame. The arm mounts on the
        table surface (world z = table_height = 0.75), offset toward -y and yawed
@@ -98,5 +100,14 @@
     <child  link="$(arg tf_prefix)grasp_tcp"/>
     <origin xyz="0 0 $(arg tcp_z)" rpy="0 0 0"/>
   </joint>
+
+  <!-- ==================================================== simulation control -->
+  <xacro:if value="$(arg sim_gz)">
+    <xacro:include filename="$(find workbench_motion)/config/ros2_control.xacro"/>
+    <xacro:workbench_ros2_control
+      tf_prefix="$(arg tf_prefix)"
+      driver_joint="$(arg driver_joint)"
+      controllers_yaml="$(arg controllers_yaml)"/>
+  </xacro:if>
 
 </robot>

--- a/robot/control/workbench_motion/config/controllers.yaml
+++ b/robot/control/workbench_motion/config/controllers.yaml
@@ -1,0 +1,35 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 500
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    arm_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+    gripper_controller:
+      # Provided by gripper_controllers; the plugin keeps its historical namespace.
+      type: position_controllers/GripperActionController
+
+arm_trajectory_controller:
+  ros__parameters:
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
+    command_interfaces: [position]
+    state_interfaces: [position, velocity]
+    constraints:
+      stopped_velocity_tolerance: 0.01
+      goal_time: 0.5
+      shoulder_pan_joint: {goal: 0.02}
+      shoulder_lift_joint: {goal: 0.02}
+      elbow_joint: {goal: 0.02}
+      wrist_1_joint: {goal: 0.02}
+      wrist_2_joint: {goal: 0.02}
+      wrist_3_joint: {goal: 0.02}
+
+gripper_controller:
+  ros__parameters:
+    joint: robotiq_85_left_knuckle_joint

--- a/robot/control/workbench_motion/config/joint_limits.hw_override.yaml
+++ b/robot/control/workbench_motion/config/joint_limits.hw_override.yaml
@@ -1,0 +1,5 @@
+# Real-hardware safety overrides (C13/P3). P0 simulation intentionally has no
+# overrides. Missing joints mean "use the vendor hard limit". Any future entry
+# must be strictly within the vendor interval/magnitudes; unknown joints,
+# malformed values, or looser limits fail closed in load_hw_override().
+joint_limits: {}

--- a/robot/control/workbench_motion/config/moveit/joint_limits.yaml
+++ b/robot/control/workbench_motion/config/moveit/joint_limits.yaml
@@ -6,16 +6,16 @@
 # other layers land in phase 2 (config/controllers.yaml, joint_limits.hw_override).
 # Do not confuse the three sources.
 #
-# Velocity limits mirror ur_description nominal UR5e values; accelerations are a
-# conservative planning choice (not published by the vendor, so chosen here and
-# recorded rather than left as magic numbers).
+# Shoulder pan/lift are deliberately tightened to 120 deg/s from the vendor's
+# 180 deg/s nominal hard limit. The other nominal values and the 0.1 scaling are
+# planning-layer choices; this file is not consumed by the safety validator.
 default_velocity_scaling_factor: 0.1
 default_acceleration_scaling_factor: 0.1
 
 joint_limits:
   shoulder_pan_joint:
     has_velocity_limits: true
-    max_velocity: 2.0943951    # rad/s (120 deg/s), UR5e nominal
+    max_velocity: 2.0943951    # rad/s (120 deg/s), tightened from vendor 180 deg/s
     has_acceleration_limits: true
     max_acceleration: 5.0
   shoulder_lift_joint:

--- a/robot/control/workbench_motion/config/ros2_control.xacro
+++ b/robot/control/workbench_motion/config/ros2_control.xacro
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!-- Reuse the vendor's six-arm-joint interface declaration. Hard limits stay
+       in the UR macro/URDF; this file does not duplicate their values. -->
+  <xacro:include filename="$(find ur_description)/urdf/inc/ur_joint_control.xacro"/>
+
+  <!-- The Robotiq vendor simulation macro is tied to ign_ros2_control. Reuse
+       its follower list and multipliers so joint_state_broadcaster exposes the
+       complete linkage under gz_ros2_control; only the driver is commanded. -->
+  <xacro:macro name="workbench_gripper_control" params="tf_prefix driver_joint">
+    <joint name="${tf_prefix}${driver_joint}">
+      <command_interface name="position"/>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="${tf_prefix}robotiq_85_right_knuckle_joint">
+      <param name="mimic">${tf_prefix}${driver_joint}</param>
+      <param name="multiplier">-1</param>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="${tf_prefix}robotiq_85_left_inner_knuckle_joint">
+      <param name="mimic">${tf_prefix}${driver_joint}</param>
+      <param name="multiplier">1</param>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="${tf_prefix}robotiq_85_right_inner_knuckle_joint">
+      <param name="mimic">${tf_prefix}${driver_joint}</param>
+      <param name="multiplier">-1</param>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="${tf_prefix}robotiq_85_left_finger_tip_joint">
+      <param name="mimic">${tf_prefix}${driver_joint}</param>
+      <param name="multiplier">-1</param>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="${tf_prefix}robotiq_85_right_finger_tip_joint">
+      <param name="mimic">${tf_prefix}${driver_joint}</param>
+      <param name="multiplier">1</param>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </xacro:macro>
+
+  <xacro:macro name="workbench_ros2_control" params="tf_prefix driver_joint controllers_yaml">
+    <ros2_control name="workbench_arm_system" type="system">
+      <hardware>
+        <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      </hardware>
+      <xacro:ur_joint_control_description tf_prefix="${tf_prefix}"/>
+      <xacro:workbench_gripper_control tf_prefix="${tf_prefix}" driver_joint="${driver_joint}"/>
+    </ros2_control>
+
+    <gazebo>
+      <plugin filename="gz_ros2_control-system"
+              name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+        <parameters>${controllers_yaml}</parameters>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/robot/control/workbench_motion/launch/move_group.launch.py
+++ b/robot/control/workbench_motion/launch/move_group.launch.py
@@ -25,88 +25,35 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import Command, LaunchConfiguration
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros.parameter_descriptions import ParameterValue
+from workbench_motion.launch_utils import move_group_parameters, require_file, robot_description
 
 _SHARE = Path(get_package_share_directory("workbench_motion"))
 _CONFIG_DIR = _SHARE / "config"
-_MOVEIT_DIR = _CONFIG_DIR / "moveit"
-
 _DEFAULT_ARM_XACRO = str(_CONFIG_DIR / "arm_on_workbench.urdf.xacro")
-
-
-def _load_yaml(path: Path) -> dict:
-    return yaml.safe_load(path.read_text(encoding="utf-8"))
-
-
-def _require(path: Path, what: str) -> Path:
-    if not path.is_file():
-        raise FileNotFoundError(
-            f"{what} not found at {path}. Did you `colcon build --packages-select "
-            f"workbench_motion` and `source install/setup.bash`?"
-        )
-    return path
 
 
 def _setup(context, *_args, **_kwargs) -> list[Node]:
     arm_xacro = Path(LaunchConfiguration("arm_xacro").perform(context))
-    _require(arm_xacro, "arm xacro")
-    srdf = _require(_MOVEIT_DIR / "workbench_arm.srdf", "SRDF")
-    kin = _require(_MOVEIT_DIR / "kinematics.yaml", "kinematics.yaml")
-    jl = _require(_MOVEIT_DIR / "joint_limits.yaml", "joint_limits.yaml")
-    ompl_path = _require(_MOVEIT_DIR / "ompl_planning.yaml", "ompl_planning.yaml")
-
-    # The composed xacro finds the vendored world via $(find workbench_motion);
-    # no workbench path needs to be threaded in here.
-    robot_description = {
-        "robot_description": ParameterValue(
-            Command(["xacro ", str(arm_xacro)]),
-            value_type=str,
-        )
-    }
-    robot_description_semantic = {
-        "robot_description_semantic": ParameterValue(
-            srdf.read_text(encoding="utf-8"),
-            value_type=str,
-        )
-    }
-    kinematics = {"robot_description_kinematics": _load_yaml(kin)}
-    joint_limits = {"robot_description_planning": _load_yaml(jl)}
-
-    # Jazzy move_group requires the pipeline to be selected at the root and the
-    # OMPL params nested under the pipeline's own namespace (`ompl`). Passing the
-    # OMPL config as root params leaves planning_plugins undefined -> SIGABRT
-    # ("Planning plugin name is empty or not defined in namespace 'move_group'").
-    planning = {
-        "planning_pipelines": ["ompl"],
-        "default_planning_pipeline": "ompl",
-        "ompl": _load_yaml(ompl_path),
-    }
+    require_file(arm_xacro, "arm xacro")
+    description = robot_description(arm_xacro)
+    moveit_params = move_group_parameters(_SHARE, description, use_sim_time=False)
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
-            robot_description,
-            robot_description_semantic,
-            kinematics,
-            joint_limits,
-            planning,
-            {"publish_robot_description_semantic": True},
-            {"use_sim_time": False},
-        ],
+        parameters=moveit_params,
     )
     rsp = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[robot_description, {"use_sim_time": False}],
+        parameters=[description, {"use_sim_time": False}],
     )
     # Static joint states so TF is complete for IK/collision (no controllers yet;
     # ros2_control lands in phase 2).

--- a/robot/control/workbench_motion/launch/sim_control.launch.py
+++ b/robot/control/workbench_motion/launch/sim_control.launch.py
@@ -1,0 +1,106 @@
+"""Gazebo Harmonic + ros2_control + MoveIt bringup for phase-2 evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, OpaqueFunction, RegisterEventHandler, Shutdown
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+from workbench_motion.arm_config import load_arm_config
+from workbench_motion.launch_utils import move_group_parameters, require_file, robot_description
+
+
+def _next_if_success(failed_process: str, next_action=None):
+    def handler(event, _context):
+        if event.returncode == 0:
+            return [next_action] if next_action is not None else []
+        return [Shutdown(reason=f"{failed_process} failed with return code {event.returncode}")]
+
+    return handler
+
+
+def _setup(_context, *_args, **_kwargs):
+    share = Path(get_package_share_directory("workbench_motion"))
+    ros_gz_share = Path(get_package_share_directory("ros_gz_sim"))
+    xacro = require_file(share / "config" / "arm_on_workbench.urdf.xacro", "arm xacro")
+    controllers = require_file(share / "config" / "controllers.yaml", "controllers.yaml")
+    arm = load_arm_config(share / "config" / "arm.yaml")
+    description = robot_description(
+        xacro,
+        {
+            "sim_gz": "true",
+            "driver_joint": arm.driver_joint,
+            "controllers_yaml": str(controllers),
+        },
+    )
+    common_time = {"use_sim_time": True}
+
+    gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(str(ros_gz_share / "launch" / "gz_sim.launch.py")),
+        launch_arguments={"gz_args": "-s -r -v 3 empty.sdf"}.items(),
+    )
+    clock_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        output="screen",
+        arguments=["/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock"],
+    )
+    rsp = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="screen",
+        parameters=[description, common_time],
+    )
+    spawn = Node(
+        package="ros_gz_sim",
+        executable="create",
+        output="screen",
+        arguments=["-topic", "robot_description", "-name", "workbench_arm", "-allow_renaming", "false"],
+    )
+    move_group = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=move_group_parameters(share, description, use_sim_time=True),
+    )
+
+    def spawner(name: str) -> Node:
+        return Node(
+            package="controller_manager",
+            executable="spawner",
+            output="screen",
+            arguments=[name, "--controller-manager", "/controller_manager", "--controller-manager-timeout", "60"],
+        )
+
+    jsb = spawner(arm.joint_state_broadcaster)
+    arm_controller = spawner(arm.arm_trajectory_controller)
+    gripper = spawner(arm.gripper_controller)
+    return [
+        clock_bridge,
+        gazebo,
+        rsp,
+        spawn,
+        move_group,
+        RegisterEventHandler(OnProcessExit(target_action=spawn, on_exit=_next_if_success("robot spawn", jsb))),
+        RegisterEventHandler(
+            OnProcessExit(
+                target_action=jsb,
+                on_exit=_next_if_success(arm.joint_state_broadcaster, arm_controller),
+            )
+        ),
+        RegisterEventHandler(
+            OnProcessExit(
+                target_action=arm_controller,
+                on_exit=_next_if_success(arm.arm_trajectory_controller, gripper),
+            )
+        ),
+        RegisterEventHandler(OnProcessExit(target_action=gripper, on_exit=_next_if_success(arm.gripper_controller))),
+    ]
+
+
+def generate_launch_description() -> LaunchDescription:
+    return LaunchDescription([OpaqueFunction(function=_setup)])

--- a/robot/control/workbench_motion/package.xml
+++ b/robot/control/workbench_motion/package.xml
@@ -6,8 +6,8 @@
   <description>
     Motion (robot/control) semantic-action adapter package: entry validation,
     grasp/place/stop execution over a replaceable backend, and ActionResult
-    production. Phase 0 delivers the package skeleton, unified logging, and the
-    EvidenceSink interface only.
+    production. Phase 2 adds the Gazebo Harmonic ros2_control foundation,
+    controller bringup, and a ROS-free joint-limit pre-filter.
   </description>
   <maintainer email="motion-owner@workbench-1.invalid">Motion Owner</maintainer>
   <license>Apache-2.0</license>
@@ -34,6 +34,18 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>gripper_controllers</exec_depend>
+  <exec_depend>control_msgs</exec_depend>
+  <exec_depend>action_msgs</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>controller_manager_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/robot/control/workbench_motion/setup.py
+++ b/robot/control/workbench_motion/setup.py
@@ -32,6 +32,7 @@ setup(
         "console_scripts": [
             "scaffold_node = workbench_motion.scaffold_node:main",
             "reachability_check = workbench_motion.reachability_check:main",
+            "phase2_probe = workbench_motion.phase2_probe:main",
         ],
     },
 )

--- a/robot/control/workbench_motion/test/test_arm_config.py
+++ b/robot/control/workbench_motion/test/test_arm_config.py
@@ -28,12 +28,19 @@ def test_shipped_arm_yaml_loads():
     cfg = load_arm_config(_ARM_YAML)
     assert isinstance(cfg, ArmConfig)
     assert cfg.model == "ur5e"
+    assert cfg.vendor_description_pkg == "ur_description"
+    assert cfg.ur_type == "ur5e"
     assert cfg.planning_group == "ur_manipulator"
     assert cfg.ik_tip_link == "grasp_tcp"
     assert cfg.base_frame == "world"
     assert cfg.dof == 6
     assert cfg.joints[0] == "shoulder_pan_joint"
     assert cfg.gripper_model == "robotiq_2f_85"
+    assert cfg.driver_joint == "robotiq_85_left_knuckle_joint"
+    assert cfg.update_rate_hz == 500
+    assert cfg.joint_state_broadcaster == "joint_state_broadcaster"
+    assert cfg.arm_trajectory_controller == "arm_trajectory_controller"
+    assert cfg.gripper_controller == "gripper_controller"
     assert cfg.arm_label == "ur5e+robotiq_2f_85"
 
 
@@ -90,12 +97,21 @@ def test_parse_rejects_empty_joints():
             {
                 "arm": {
                     "model": "x",
+                    "vendor_description_pkg": "vendor",
+                    "ur_type": "x",
                     "planning_group": "g",
                     "base_link": "b",
                     "ee_link": "e",
                     "ik_tip_link": "t",
                     "joints": [],
-                }
+                },
+                "gripper": {"model": "g", "planning_group": "gripper", "driver_joint": "finger"},
+                "controllers": {
+                    "update_rate_hz": 100,
+                    "joint_state_broadcaster": "jsb",
+                    "arm_trajectory_controller": "arm",
+                    "gripper_controller": "gripper",
+                },
             }
         )
 
@@ -105,16 +121,128 @@ def test_parse_defaults_base_frame_to_world_when_absent():
         {
             "arm": {
                 "model": "ur5e",
+                "vendor_description_pkg": "ur_description",
+                "ur_type": "ur5e",
                 "planning_group": "ur_manipulator",
                 "base_link": "base_link",
                 "ee_link": "tool0",
                 "ik_tip_link": "grasp_tcp",
                 "joints": ["a"],
-            }
+            },
+            "gripper": {"model": "g", "planning_group": "gripper", "driver_joint": "finger"},
+            "controllers": {
+                "update_rate_hz": 100,
+                "joint_state_broadcaster": "jsb",
+                "arm_trajectory_controller": "arm",
+                "gripper_controller": "gripper",
+            },
         }
     )
     assert cfg.base_frame == "world"
-    assert cfg.gripper_model == "none"
+    assert cfg.gripper_model == "g"
+
+
+@pytest.mark.parametrize("missing", ["gripper", "controllers"])
+def test_parse_rejects_missing_safety_sections(missing):
+    data = {
+        "arm": {
+            "model": "ur5e",
+            "vendor_description_pkg": "ur_description",
+            "ur_type": "ur5e",
+            "planning_group": "arm",
+            "base_link": "base",
+            "ee_link": "tool",
+            "ik_tip_link": "tip",
+            "joints": ["joint"],
+        },
+        "gripper": {"model": "g", "planning_group": "gripper", "driver_joint": "finger"},
+        "controllers": {
+            "update_rate_hz": 100,
+            "joint_state_broadcaster": "jsb",
+            "arm_trajectory_controller": "arm",
+            "gripper_controller": "gripper",
+        },
+    }
+    del data[missing]
+    with pytest.raises(ValueError, match="missing required"):
+        parse_arm_config(data)
+
+
+def test_parse_rejects_missing_arm_section_as_value_error():
+    with pytest.raises(ValueError, match="missing required arm configuration section: arm"):
+        parse_arm_config({"gripper": {}, "controllers": {}})
+
+
+def test_parse_rejects_required_identity_field_as_value_error():
+    data = {
+        "arm": {
+            "vendor_description_pkg": "ur_description",
+            "ur_type": "ur5e",
+            "planning_group": "arm",
+            "base_link": "base",
+            "ee_link": "tool",
+            "ik_tip_link": "tip",
+            "joints": ["joint"],
+        },
+        "gripper": {"model": "g", "planning_group": "gripper", "driver_joint": "finger"},
+        "controllers": {
+            "update_rate_hz": 100,
+            "joint_state_broadcaster": "jsb",
+            "arm_trajectory_controller": "arm",
+            "gripper_controller": "gripper",
+        },
+    }
+    with pytest.raises(ValueError, match="required arm configuration field: model"):
+        parse_arm_config(data)
+
+
+def test_parse_rejects_missing_driver_joint():
+    data = {
+        "arm": {
+            "model": "ur5e",
+            "vendor_description_pkg": "ur_description",
+            "ur_type": "ur5e",
+            "planning_group": "arm",
+            "base_link": "base",
+            "ee_link": "tool",
+            "ik_tip_link": "tip",
+            "joints": ["joint"],
+        },
+        "gripper": {"model": "g", "planning_group": "gripper"},
+        "controllers": {
+            "update_rate_hz": 100,
+            "joint_state_broadcaster": "jsb",
+            "arm_trajectory_controller": "arm",
+            "gripper_controller": "gripper",
+        },
+    }
+    with pytest.raises(ValueError, match="driver_joint"):
+        parse_arm_config(data)
+
+
+@pytest.mark.parametrize("rate", [0, -1, 100.5, True])
+def test_parse_rejects_invalid_controller_update_rate(rate):
+    data = {
+        "arm": {
+            "model": "ur5e",
+            "vendor_description_pkg": "ur_description",
+            "ur_type": "ur5e",
+            "planning_group": "arm",
+            "base_link": "base",
+            "ee_link": "tool",
+            "ik_tip_link": "tip",
+            "joints": ["joint"],
+        },
+        "gripper": {"model": "g", "planning_group": "gripper", "driver_joint": "finger"},
+        "controllers": {
+            "update_rate_hz": rate,
+            "joint_state_broadcaster": "jsb",
+            "arm_trajectory_controller": "arm",
+            "gripper_controller": "gripper",
+        },
+    }
+    with pytest.raises(ValueError, match="positive integer"):
+        parse_arm_config(data)
 
 
 def test_reachability_check_defaults_come_from_arm_yaml():

--- a/robot/control/workbench_motion/test/test_controllers_config.py
+++ b/robot/control/workbench_motion/test/test_controllers_config.py
@@ -1,0 +1,90 @@
+"""Structural consistency checks for phase-2 control configuration."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import yaml
+from workbench_motion.arm_config import load_arm_config
+
+CONFIG = Path(__file__).resolve().parent.parent / "config"
+LAUNCH = Path(__file__).resolve().parent.parent / "launch"
+
+
+def test_controller_names_joints_and_rate_match_arm_yaml():
+    arm = load_arm_config(CONFIG / "arm.yaml")
+    controllers = yaml.safe_load((CONFIG / "controllers.yaml").read_text(encoding="utf-8"))
+    manager = controllers["controller_manager"]["ros__parameters"]
+    assert manager["update_rate"] == arm.update_rate_hz
+    assert manager[arm.joint_state_broadcaster]["type"] == "joint_state_broadcaster/JointStateBroadcaster"
+    assert manager[arm.arm_trajectory_controller]["type"] == "joint_trajectory_controller/JointTrajectoryController"
+    assert manager[arm.gripper_controller]["type"] == "position_controllers/GripperActionController"
+    assert tuple(controllers[arm.arm_trajectory_controller]["ros__parameters"]["joints"]) == arm.joints
+    assert controllers[arm.gripper_controller]["ros__parameters"]["joint"] == arm.driver_joint
+    constraints = controllers[arm.arm_trajectory_controller]["ros__parameters"]["constraints"]
+    assert constraints["goal_time"] > 0
+    for joint in arm.joints:
+        assert 0 < constraints[joint]["goal"] <= 0.05
+
+
+def test_xacro_control_is_opt_in_and_reuses_vendor_macro():
+    composed = (CONFIG / "arm_on_workbench.urdf.xacro").read_text(encoding="utf-8")
+    control = (CONFIG / "ros2_control.xacro").read_text(encoding="utf-8")
+    assert re.search(r'<xacro:arg name="sim_gz"\s+default="false"', composed)
+    assert "ur_joint_control_description" in control
+    assert "gz_ros2_control/GazeboSimSystem" in control
+    assert "<plugin>ign_ros2_control/" not in control
+    assert "joint_limits" not in control
+
+
+def test_gripper_control_declares_vendor_mimic_followers_as_state_only():
+    control = (CONFIG / "ros2_control.xacro").read_text(encoding="utf-8")
+    followers = {
+        "robotiq_85_right_knuckle_joint": "-1",
+        "robotiq_85_left_inner_knuckle_joint": "1",
+        "robotiq_85_right_inner_knuckle_joint": "-1",
+        "robotiq_85_left_finger_tip_joint": "-1",
+        "robotiq_85_right_finger_tip_joint": "1",
+    }
+    for joint, multiplier in followers.items():
+        block = re.search(rf'<joint name="\$\{{tf_prefix\}}{joint}">(.*?)</joint>', control, re.DOTALL)
+        assert block is not None
+        assert '<param name="mimic">${tf_prefix}${driver_joint}</param>' in block.group(1)
+        assert f'<param name="multiplier">{multiplier}</param>' in block.group(1)
+        assert '<state_interface name="position"/>' in block.group(1)
+        assert '<state_interface name="velocity"/>' in block.group(1)
+        assert "command_interface" not in block.group(1)
+
+
+def test_xacro_defaults_match_arm_config():
+    arm = load_arm_config(CONFIG / "arm.yaml")
+    root = ET.fromstring((CONFIG / "arm_on_workbench.urdf.xacro").read_text(encoding="utf-8"))
+    ns = {"xacro": "http://www.ros.org/wiki/xacro"}
+    defaults = {arg.attrib["name"]: arg.attrib["default"] for arg in root.findall("xacro:arg", ns)}
+    assert defaults["ur_type"] == arm.ur_type
+    assert defaults["driver_joint"] == arm.driver_joint
+
+
+def test_sim_launch_is_headless_and_does_not_start_joint_state_publisher():
+    launch = (LAUNCH / "sim_control.launch.py").read_text(encoding="utf-8")
+    assert '"gz_args": "-s -r -v 3 empty.sdf"' in launch
+    assert 'package="robot_state_publisher"' in launch
+    assert 'package="joint_state_publisher"' not in launch
+    assert "use_sim_time=True" in launch
+
+
+def test_sim_launch_bridges_clock_only():
+    launch = (LAUNCH / "sim_control.launch.py").read_text(encoding="utf-8")
+    assert 'package="ros_gz_bridge"' in launch
+    assert '"/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock"' in launch
+    assert "/contacts" not in launch
+
+
+def test_sim_launch_shutdown_reason_names_each_failed_controller():
+    launch = (LAUNCH / "sim_control.launch.py").read_text(encoding="utf-8")
+    assert "failed_process: str" in launch
+    assert "_next_if_success(arm.joint_state_broadcaster, arm_controller)" in launch
+    assert "_next_if_success(arm.arm_trajectory_controller, gripper)" in launch
+    assert "_next_if_success(arm.gripper_controller)" in launch

--- a/robot/control/workbench_motion/test/test_joint_limits.py
+++ b/robot/control/workbench_motion/test/test_joint_limits.py
@@ -1,0 +1,179 @@
+"""Attack-style tests for the ROS-free phase-2 joint-limit validator."""
+
+from __future__ import annotations
+
+import copy
+import math
+from typing import ClassVar
+
+import pytest
+from workbench_motion.joint_limits import (
+    JointLimit,
+    check_trajectory,
+    effective_limits,
+    load_hard_limits,
+    load_hw_override,
+)
+
+JOINTS = ("j1", "j2")
+LIMITS = {
+    "j1": JointLimit(-2.0, 2.0, 1.0, 10.0),
+    "j2": JointLimit(-3.0, 3.0, 2.0, 20.0),
+}
+CURRENT = {"j1": 0.0, "j2": 0.0}
+
+
+def trajectory(*points, names=JOINTS):
+    return {"joint_names": list(names), "points": list(points)}
+
+
+def point(t, positions=(0.0, 0.0), velocities=(), accelerations=(), effort=()):
+    return {
+        "positions": list(positions),
+        "velocities": list(velocities),
+        "accelerations": list(accelerations),
+        "effort": list(effort),
+        "time_from_start": t,
+    }
+
+
+def check(traj, current=CURRENT, *, epsilon=1e-6):
+    return check_trajectory(traj, current, LIMITS, limit_epsilon=epsilon)
+
+
+def test_loads_real_vendor_degrees_and_all_six_joints():
+    limits = load_hard_limits("ur_description", "ur5e")
+    assert len(limits) == 6
+    assert math.isclose(limits["shoulder_pan_joint"].max_position, 2 * math.pi)
+    assert math.isclose(limits["shoulder_pan_joint"].max_velocity, math.pi)
+    assert limits["wrist_1_joint"].max_effort == 28.0
+
+
+def test_hw_override_empty_and_missing_joint_are_allowed(tmp_path):
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("", encoding="utf-8")
+    assert load_hw_override(empty, hard_limits=LIMITS) == {}
+    partial = tmp_path / "partial.yaml"
+    partial.write_text("joint_limits:\n  j1:\n    max_velocity: 0.5\n", encoding="utf-8")
+    loaded = load_hw_override(partial, hard_limits=LIMITS)
+    assert loaded["j1"].max_velocity == 0.5
+    assert "j2" not in loaded
+
+
+def test_shipped_default_hw_override_is_empty_and_loadable():
+    hard = load_hard_limits("ur_description", "ur5e")
+    assert load_hw_override(hard_limits=hard) == {}
+
+
+@pytest.mark.parametrize(
+    "yaml_text,match",
+    [
+        ("joint_limits:\n  typo:\n    max_velocity: 0.5\n", "unknown joint"),
+        ("joint_limits:\n  j1:\n    max_velocity: 1.1\n", "looser"),
+        ("joint_limits:\n  j1:\n    min_position: -2.1\n", "looser"),
+        ("joint_limits:\n  j1:\n    max_position: 2.1\n", "looser"),
+        ("joint_limits:\n  j1:\n    max_effort: 11\n", "looser"),
+        ("joint_limits:\n  j1:\n    min_position: 1\n    max_position: 0\n", "min_position"),
+        ("joint_limits:\n  j1:\n    max_velocity: fast\n", "finite number"),
+        ("joint_limits:\n  j1:\n    degrees: 90\n", "unknown fields"),
+    ],
+)
+def test_hw_override_fails_closed(yaml_text, match, tmp_path):
+    path = tmp_path / "override.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+    with pytest.raises(ValueError, match=match):
+        load_hw_override(path, hard_limits=LIMITS)
+
+
+def test_effective_limits_intersects_without_planning_scaling():
+    override = {"j1": JointLimit(-1.0, 1.5, 0.4, 8.0)}
+    result = effective_limits(LIMITS, override)
+    assert result["j1"] == override["j1"]
+    assert result["j2"] == LIMITS["j2"]
+
+
+def test_legal_trajectory_passes_and_input_is_not_mutated():
+    traj = trajectory(point(0.0), point(1.0, (0.5, 1.0), velocities=(0.5, 1.0), effort=(1.0, 2.0)))
+    before = copy.deepcopy(traj)
+    assert check(traj) is None
+    assert traj == before
+
+
+@pytest.mark.parametrize(
+    "traj,current,kind",
+    [
+        ({"points": [point(0.0)]}, CURRENT, "joint_names"),
+        (trajectory(point(0.0), names=()), CURRENT, "joint_names"),
+        (trajectory(point(0.0), names=("j1", "j1")), CURRENT, "joint_names"),
+        (trajectory(point(0.0), names=("j1", "unknown")), CURRENT, "joint_names"),
+        (trajectory({"positions": [0.0], "time_from_start": 0.0}, names=("j1",)), CURRENT, "joint_names"),
+        (trajectory(), CURRENT, "points"),
+        (trajectory(point(0.0, positions=(0.0,))), CURRENT, "array_length"),
+        (trajectory(point(0.0, velocities=(0.0,))), CURRENT, "array_length"),
+        (trajectory(point(0.0, accelerations=(0.0,))), CURRENT, "array_length"),
+        (trajectory(point(0.0, effort=(0.0,))), CURRENT, "array_length"),
+        (trajectory(point(0.0)), {"j1": 0.0}, "current_state"),
+        (trajectory(point(0.0)), {"j1": 0.0, "j2": 0.0, "x": 0.0}, "current_state"),
+        (trajectory(point(0.0)), {"j1": math.nan, "j2": 0.0}, "non_finite"),
+        (trajectory(point(0.0)), {"j1": 2.0, "j2": 0.0}, "current_position"),
+        (trajectory(point(-0.1)), CURRENT, "time"),
+        (trajectory(point(0.0), point(0.0)), CURRENT, "time"),
+        (trajectory(point(0.0, positions=(math.nan, 0.0))), CURRENT, "non_finite"),
+    ],
+)
+def test_malformed_or_unsafe_trajectory_fails_closed(traj, current, kind):
+    assert check(traj, current).kind == kind
+
+
+@pytest.mark.parametrize(
+    "candidate,kind,joint",
+    [
+        (trajectory(point(1.0, positions=(2.0, 0.0))), "position", "j1"),
+        (trajectory(point(1.0, velocities=(1.0, 0.0))), "velocity", "j1"),
+        (trajectory(point(1.0, effort=(10.0, 0.0))), "effort", "j1"),
+        (trajectory(point(0.0, positions=(0.01, 0.0))), "initial_position", "j1"),
+        (trajectory(point(0.1, positions=(0.2, 0.0))), "segment_velocity", "j1"),
+        (trajectory(point(0.0), point(0.1, positions=(0.2, 0.0))), "segment_velocity", "j1"),
+    ],
+)
+def test_limit_attacks_are_rejected(candidate, kind, joint):
+    violation = check(candidate)
+    assert violation is not None
+    assert (violation.kind, violation.joint) == (kind, joint)
+
+
+def test_t0_zero_accepts_current_within_epsilon():
+    assert check(trajectory(point(0.0, positions=(5e-7, 0.0)))) is None
+
+
+def test_epsilon_tightens_instead_of_widening_hard_bound():
+    violation = check(trajectory(point(3.0, positions=(1.9999995, 0.0))), epsilon=1e-6)
+    assert violation is not None and violation.kind == "position"
+
+
+@pytest.mark.parametrize("epsilon", [-1.0, math.inf, math.nan])
+def test_invalid_epsilon_is_rejected(epsilon):
+    with pytest.raises(ValueError, match="limit_epsilon"):
+        check(trajectory(point(0.0)), epsilon=epsilon)
+
+
+class Duration:
+    sec = 1
+    nanosec = 500_000_000
+
+
+class Point:
+    positions: ClassVar[list[float]] = [0.5, 1.0]
+    velocities: ClassVar[list[float]] = []
+    accelerations: ClassVar[list[float]] = []
+    effort: ClassVar[list[float]] = []
+    time_from_start = Duration()
+
+
+class RosLikeTrajectory:
+    joint_names: ClassVar[list[str]] = list(JOINTS)
+    points: ClassVar[list[Point]] = [Point()]
+
+
+def test_accepts_ros_message_shaped_objects_without_importing_ros():
+    assert check(RosLikeTrajectory()) is None

--- a/robot/control/workbench_motion/test/test_phase2_probe.py
+++ b/robot/control/workbench_motion/test/test_phase2_probe.py
@@ -1,0 +1,371 @@
+"""ROS-free tests for phase2_probe orchestration and evidence math."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import math
+from itertools import pairwise
+from types import SimpleNamespace
+
+import pytest
+from workbench_motion.arm_config import load_arm_config
+from workbench_motion.joint_limits import JointLimit
+from workbench_motion.phase2_probe import (
+    FAIL_BEHAVIORS,
+    FOLLOWERS,
+    ActionObservation,
+    JointSnapshot,
+    RosProbeIO,
+    atomic_write_report,
+    behavior_gate,
+    classify_over_limit,
+    densify_joint_path,
+    hardware_is_gazebo,
+    is_stale,
+    mimic_ratios,
+    run_probe,
+    smoothness_report,
+    snapshot_is_complete,
+)
+
+CONFIG = __import__("pathlib").Path(__file__).resolve().parent.parent / "config"
+ARM = load_arm_config(CONFIG / "arm.yaml")
+LIMITS = {joint: JointLimit(-2.0, 2.0, 1.0, 10.0) for joint in ARM.joints}
+BASE = {joint: 0.0 for joint in ARM.joints}
+
+
+class AvailableEndpoint:
+    def wait_for_service(self, timeout_sec):
+        return timeout_sec > 0
+
+    def wait_for_server(self, timeout_sec):
+        return timeout_sec > 0
+
+
+class AvailableParameterEndpoints:
+    def wait_for_services(self, timeout_sec):
+        return timeout_sec > 0
+
+
+def snapshot(**updates):
+    values = dict(BASE)
+    values.update(updates)
+    return JointSnapshot(values, 10.0)
+
+
+def test_endpoint_status_uses_jazzy_parameter_client_api():
+    probe = object.__new__(RosProbeIO)
+    probe.timeout_s = 1.0
+    probe.list_client = AvailableEndpoint()
+    probe.state_client = AvailableEndpoint()
+    probe.arm_action = AvailableEndpoint()
+    probe.gripper_action = AvailableEndpoint()
+    probe.parameter_client = AvailableParameterEndpoints()
+
+    assert all(probe.endpoint_status().values())
+
+
+def test_tf_lookup_spins_the_probe_node_without_a_competing_executor():
+    init_source = inspect.getsource(RosProbeIO.__init__)
+    assert "spin_thread=True" not in init_source
+    assert 'Parameter("use_sim_time", Parameter.Type.BOOL, True)' in init_source
+    assert "self.rclpy.spin_once" in inspect.getsource(RosProbeIO.tf_chain)
+
+
+@pytest.mark.parametrize(
+    "observation,expected",
+    [
+        (ActionObservation(False, "rejected", False, {ARM.joints[0]: 2.1}, snapshot(), snapshot()), "rejected"),
+        (ActionObservation(True, "aborted", False, {ARM.joints[0]: 2.1}, snapshot(), snapshot()), "aborted"),
+        (
+            ActionObservation(
+                True,
+                "aborted",
+                False,
+                {ARM.joints[0]: 2.1},
+                snapshot(**{ARM.joints[0]: 0.05}),
+                snapshot(**{ARM.joints[0]: 2.0}),
+            ),
+            "clamped",
+        ),
+        (
+            ActionObservation(
+                True, "aborted", False, {ARM.joints[0]: 2.1}, snapshot(), snapshot(**{ARM.joints[0]: 0.5})
+            ),
+            "unclassified",
+        ),
+        (
+            ActionObservation(
+                True, "succeeded", False, {ARM.joints[0]: 2.1}, snapshot(), snapshot(**{ARM.joints[0]: 2.0})
+            ),
+            "clamped",
+        ),
+        (
+            ActionObservation(
+                True, "succeeded", False, {ARM.joints[0]: 2.1}, snapshot(), snapshot(**{ARM.joints[0]: 2.05})
+            ),
+            "executed_over_limit",
+        ),
+        (ActionObservation(True, "unknown", True, {ARM.joints[0]: 2.1}, snapshot(), snapshot()), "timeout"),
+        (
+            ActionObservation(
+                True, "succeeded", False, {ARM.joints[0]: 2.1}, snapshot(), snapshot(**{ARM.joints[0]: 0.5})
+            ),
+            "unclassified",
+        ),
+    ],
+)
+def test_six_class_over_limit_behavior(observation, expected):
+    assert classify_over_limit(observation, LIMITS) == expected
+    assert behavior_gate(expected) == ("safe" if expected in {"rejected", "aborted"} else "fail")
+
+
+def test_last_four_classes_fail_gate():
+    assert FAIL_BEHAVIORS == {"clamped", "executed_over_limit", "timeout", "unclassified"}
+
+
+def test_executed_over_limit_in_an_intermediate_sample_is_not_hidden_by_final_state():
+    observation = ActionObservation(
+        True,
+        "aborted",
+        False,
+        {ARM.joints[0]: 2.1},
+        snapshot(),
+        snapshot(),
+        (snapshot(**{ARM.joints[0]: 2.05}),),
+    )
+    assert classify_over_limit(observation, LIMITS) == "executed_over_limit"
+
+
+@pytest.mark.parametrize(
+    "positions",
+    [
+        {ARM.joints[0]: 0.0},
+        {**BASE, ARM.joints[1]: math.nan},
+        {**BASE, ARM.joints[1]: math.inf},
+    ],
+)
+def test_incomplete_or_nonfinite_snapshots_are_not_safe(positions):
+    before = snapshot()
+    after = JointSnapshot(dict(positions), 10.1)
+    observation = ActionObservation(True, "aborted", False, {ARM.joints[0]: 2.1}, before, after)
+    assert not snapshot_is_complete(after, ARM.joints)
+    assert classify_over_limit(observation, LIMITS) == "unclassified"
+
+
+def test_smoothness_report_rejects_velocity_jump_and_overshoot():
+    samples = [
+        snapshot(),
+        JointSnapshot({**BASE, ARM.joints[0]: 0.2}, 10.1),
+        JointSnapshot({**BASE, ARM.joints[0]: 0.21}, 10.1001),
+    ]
+    report = smoothness_report(samples, {**BASE, ARM.joints[0]: 0.2})
+    assert not report["valid"]
+    assert not report["velocity_continuous"]
+
+
+def test_smoothness_report_accepts_monotonic_samples():
+    target = {**BASE, ARM.joints[0]: 0.2}
+    samples = [snapshot(), JointSnapshot({**BASE, ARM.joints[0]: 0.1}, 10.5), JointSnapshot(target, 11.0)]
+    assert smoothness_report(samples, target)["valid"]
+
+
+@pytest.mark.parametrize(
+    "names,positions",
+    [
+        (ARM.joints[:-1], [0.0] * (len(ARM.joints) - 1)),
+        (ARM.joints, [0.0] * (len(ARM.joints) - 1)),
+        (ARM.joints, [0.0, math.nan, 0.0, 0.0, 0.0, 0.0]),
+        (ARM.joints, [0.0, math.inf, 0.0, 0.0, 0.0, 0.0]),
+    ],
+)
+def test_ros_callback_drops_incomplete_or_nonfinite_joint_states(names, positions):
+    probe = object.__new__(RosProbeIO)
+    probe.arm = ARM
+    probe.latest = None
+    probe.history = []
+    message = SimpleNamespace(
+        name=list(names),
+        position=list(positions),
+        header=SimpleNamespace(stamp=SimpleNamespace(sec=10, nanosec=0)),
+    )
+    probe._on_joint_state(message)
+    assert probe.latest is None
+    assert probe.history == []
+
+
+def test_mimic_ratio_uses_deltas_not_absolute_positions():
+    before = {ARM.driver_joint: 0.1, **{joint: 0.2 for joint in FOLLOWERS}}
+    after = {ARM.driver_joint: 0.6}
+    after.update({joint: before[joint] + nominal * 0.5 for joint, nominal in FOLLOWERS.items()})
+    result = mimic_ratios(before, after, ARM.driver_joint)
+    assert result["all_ok"]
+    assert result["control_declaration"] == "explicit_followers_with_vendor_multipliers"
+    assert [entry["observed_ratio"] for entry in result["followers"]] == pytest.approx(list(FOLLOWERS.values()))
+
+
+def test_mimic_ratio_rejects_zero_driver_delta():
+    values = {ARM.driver_joint: 0.1, **{joint: 0.2 for joint in FOLLOWERS}}
+    with pytest.raises(ValueError, match="did not move"):
+        mimic_ratios(values, values, ARM.driver_joint)
+
+
+def test_staleness_and_hardware_fail_closed_helpers():
+    assert is_stale(8.0, 10.0, 1.0)
+    assert is_stale(math.nan, 10.0, 1.0)
+    assert not is_stale(9.5, 10.0, 1.0)
+    assert hardware_is_gazebo("<plugin>gz_ros2_control/GazeboSimSystem</plugin>")
+    assert not hardware_is_gazebo("<plugin>ur_robot_driver/URPositionHardwareInterface</plugin>")
+
+
+def test_densify_uses_fixed_max_joint_step():
+    states = densify_joint_path([{"a": 0.0, "b": 0.0}, {"a": 0.11, "b": 0.02}], 0.05)
+    assert len(states) == 4
+    assert states[-1] == {"a": 0.11, "b": 0.02}
+    assert all(abs(b["a"] - a["a"]) <= 0.05 for a, b in pairwise(states))
+
+
+def valid_report():
+    return {
+        "generated_at": "now",
+        "commit": "abc",
+        "git_dirty": False,
+        "config_hashes": {},
+        "versions": {},
+        "arm": ARM.arm_label,
+        "controllers": [],
+        "tf_chain": {},
+        "gripper_mimic": {},
+        "legal_trajectory": {"smoothness": {"valid": True}},
+        "observed_controller_over_limit_behavior": {"kind": "rejected"},
+        "validator_violation": {"kind": "position"},
+        "all_passed": True,
+    }
+
+
+def test_atomic_report_schema_and_replace(tmp_path):
+    output = tmp_path / "report.json"
+    atomic_write_report(output, valid_report())
+    assert json.loads(output.read_text(encoding="utf-8"))["all_passed"] is True
+    broken = valid_report()
+    del broken["tf_chain"]
+    with pytest.raises(ValueError, match="missing fields"):
+        atomic_write_report(output, broken)
+    assert json.loads(output.read_text(encoding="utf-8"))["all_passed"] is True
+
+
+class FakeIO:
+    def __init__(self, *, endpoints=True, gazebo=True, over_kind="rejected", tf_present=True, joint_error=False):
+        self.endpoints = endpoints
+        self.gazebo = gazebo
+        self.over_kind = over_kind
+        self.tf_present = tf_present
+        self.joint_error = joint_error
+        self.arm_calls = 0
+        positions = dict(BASE)
+        positions[ARM.driver_joint] = 0.0
+        positions.update({joint: 0.0 for joint in FOLLOWERS})
+        self.now = JointSnapshot(positions, 10.0)
+
+    def endpoint_status(self):
+        return {
+            "list": self.endpoints,
+            "action": self.endpoints,
+            "state_validity": self.endpoints,
+            "tf": self.endpoints,
+        }
+
+    def robot_description(self):
+        return "<plugin>gz_ros2_control/GazeboSimSystem</plugin>" if self.gazebo else "<plugin>real_hardware</plugin>"
+
+    def controller_states(self):
+        return [
+            {"name": ARM.joint_state_broadcaster, "type": "jsb", "state": "active"},
+            {"name": ARM.arm_trajectory_controller, "type": "jtc", "state": "active"},
+            {"name": ARM.gripper_controller, "type": "gripper", "state": "active"},
+        ]
+
+    def tf_chain(self, frames, staleness_s):
+        return {
+            "expected": list(frames),
+            "present": self.tf_present,
+            "missing": [],
+            "stale": [] if self.tf_present else ["world->base_link"],
+        }
+
+    def joint_snapshot(self, staleness_s):
+        if self.joint_error:
+            raise RuntimeError("stale joint state")
+        return self.now
+
+    def execute_arm(self, target, duration_s, staleness_s):
+        self.arm_calls += 1
+        before = self.now
+        if self.arm_calls == 1:
+            after_positions = dict(self.now.positions)
+            after_positions.update(target)
+            self.now = JointSnapshot(after_positions, 10.1)
+            return ActionObservation(True, "succeeded", False, dict(target), before, self.now, (self.now,))
+        if self.over_kind == "rejected":
+            return ActionObservation(False, "rejected", False, dict(target), before, before)
+        raise AssertionError("unused fake behavior")
+
+    def collision_check(self, states):
+        return {
+            "source": "moveit",
+            "resolution_rad": 0.05,
+            "states_checked": len(states),
+            "all_valid": True,
+            "first_invalid": None,
+        }
+
+    def execute_gripper(self, position, staleness_s):
+        before = self.now
+        after_positions = dict(before.positions)
+        driver_delta = position - before.positions[ARM.driver_joint]
+        after_positions[ARM.driver_joint] = position
+        for joint, nominal in FOLLOWERS.items():
+            after_positions[joint] = before.positions[joint] + nominal * driver_delta
+        self.now = JointSnapshot(after_positions, 10.2)
+        return ActionObservation(True, "succeeded", False, {ARM.driver_joint: position}, before, self.now)
+
+    def versions(self):
+        return {"ros_distro": "jazzy", "gz": "harmonic"}
+
+
+def test_run_probe_refuses_non_gazebo_before_sending_any_trajectory(tmp_path):
+    io = FakeIO(gazebo=False)
+    output = tmp_path / "report.json"
+    assert run_probe(io, arm=ARM, limits=LIMITS, output=output, repo=tmp_path, config_dir=CONFIG) == 2
+    assert io.arm_calls == 0
+    assert not output.exists()
+
+
+def test_missing_endpoint_exits_nonzero_without_publishing(tmp_path, capsys):
+    output = tmp_path / "report.json"
+    assert (
+        run_probe(FakeIO(endpoints=False), arm=ARM, limits=LIMITS, output=output, repo=tmp_path, config_dir=CONFIG) == 2
+    )
+    assert not output.exists()
+    assert "required endpoints unavailable" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("io", [FakeIO(tf_present=False), FakeIO(joint_error=True)])
+def test_stale_tf_or_joint_state_exits_nonzero_without_publishing(io, tmp_path):
+    output = tmp_path / "report.json"
+    assert run_probe(io, arm=ARM, limits=LIMITS, output=output, repo=tmp_path, config_dir=CONFIG) == 2
+    assert not output.exists()
+
+
+def test_successful_mock_probe_publishes_complete_json(tmp_path, monkeypatch):
+    from workbench_motion import phase2_probe
+
+    monkeypatch.setattr(phase2_probe, "_git_metadata", lambda repo: ("abc123", True))
+    output = tmp_path / "phase2.json"
+    rc = run_probe(FakeIO(), arm=ARM, limits=LIMITS, output=output, repo=tmp_path, config_dir=CONFIG)
+    assert rc == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["observed_controller_over_limit_behavior"]["kind"] == "rejected"
+    assert report["gripper_mimic"]["all_ok"]
+    assert report["tf_chain"]["present"]

--- a/robot/control/workbench_motion/workbench_motion/arm_config.py
+++ b/robot/control/workbench_motion/workbench_motion/arm_config.py
@@ -32,6 +32,8 @@ class ArmConfig:
     """Typed view over arm.yaml. Attribute access, not dict rummaging."""
 
     model: str
+    vendor_description_pkg: str
+    ur_type: str
     planning_group: str
     base_link: str
     ee_link: str
@@ -40,6 +42,11 @@ class ArmConfig:
     base_frame: str
     gripper_model: str
     gripper_group: str
+    driver_joint: str
+    update_rate_hz: int
+    joint_state_broadcaster: str
+    arm_trajectory_controller: str
+    gripper_controller: str
 
     @property
     def dof(self) -> int:
@@ -79,23 +86,65 @@ def parse_arm_config(data: dict[str, Any]) -> ArmConfig:
     Kept separate from file IO so the unit tests can exercise the mapping->object
     contract on a literal dict without touching the filesystem or ROS.
     """
-    arm = data["arm"]
-    gripper = data.get("gripper", {})
+    try:
+        arm = data["arm"]
+        gripper = data["gripper"]
+        controllers = data["controllers"]
+    except KeyError as exc:
+        raise ValueError(f"missing required arm configuration section: {exc.args[0]}") from exc
     placement = data.get("base_placement", {})
-    joints = tuple(arm["joints"])
+    try:
+        model = arm["model"]
+        joints = tuple(arm["joints"])
+        vendor_description_pkg = arm["vendor_description_pkg"]
+        ur_type = arm["ur_type"]
+        planning_group = arm["planning_group"]
+        base_link = arm["base_link"]
+        ee_link = arm["ee_link"]
+        ik_tip_link = arm["ik_tip_link"]
+        gripper_model = gripper["model"]
+        gripper_group = gripper["planning_group"]
+        driver_joint = gripper["driver_joint"]
+        update_rate_hz = controllers["update_rate_hz"]
+        joint_state_broadcaster = controllers["joint_state_broadcaster"]
+        arm_trajectory_controller = controllers["arm_trajectory_controller"]
+        gripper_controller = controllers["gripper_controller"]
+    except (KeyError, TypeError) as exc:
+        missing = exc.args[0] if isinstance(exc, KeyError) else "invalid mapping"
+        raise ValueError(f"missing or invalid required arm configuration field: {missing}") from exc
     if not joints:
         raise ValueError("arm.joints must be non-empty")
+    text_fields = {
+        "arm.vendor_description_pkg": vendor_description_pkg,
+        "arm.ur_type": ur_type,
+        "gripper.driver_joint": driver_joint,
+        "controllers.joint_state_broadcaster": joint_state_broadcaster,
+        "controllers.arm_trajectory_controller": arm_trajectory_controller,
+        "controllers.gripper_controller": gripper_controller,
+    }
+    for label, value in text_fields.items():
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{label} must be a non-empty string")
+    if isinstance(update_rate_hz, bool) or not isinstance(update_rate_hz, int) or update_rate_hz <= 0:
+        raise ValueError("controllers.update_rate_hz must be a positive integer")
     return ArmConfig(
-        model=arm["model"],
-        planning_group=arm["planning_group"],
-        base_link=arm["base_link"],
-        ee_link=arm["ee_link"],
-        ik_tip_link=arm["ik_tip_link"],
+        model=model,
+        vendor_description_pkg=vendor_description_pkg,
+        ur_type=ur_type,
+        planning_group=planning_group,
+        base_link=base_link,
+        ee_link=ee_link,
+        ik_tip_link=ik_tip_link,
         joints=joints,
         # The IK/planning frame is the workbench world root the base is fixed to.
         base_frame=placement.get("frame", "world"),
-        gripper_model=gripper.get("model", "none"),
-        gripper_group=gripper.get("planning_group", "gripper"),
+        gripper_model=gripper_model,
+        gripper_group=gripper_group,
+        driver_joint=driver_joint,
+        update_rate_hz=update_rate_hz,
+        joint_state_broadcaster=joint_state_broadcaster,
+        arm_trajectory_controller=arm_trajectory_controller,
+        gripper_controller=gripper_controller,
     )
 
 

--- a/robot/control/workbench_motion/workbench_motion/joint_limits.py
+++ b/robot/control/workbench_motion/workbench_motion/joint_limits.py
@@ -1,0 +1,375 @@
+"""ROS-free hard-limit loading and conservative trajectory validation.
+
+The validator deliberately checks only vendor hard limits intersected with the
+optional hardware override. MoveIt's planning limits and scaling remain in the
+planning layer. This module judges; it never clamps, dispatches, or emits events.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from workbench_motion.arm_config import load_arm_config
+
+DEFAULT_LIMIT_EPSILON = 1e-6
+_SOURCE_CONFIG = Path(__file__).resolve().parent.parent / "config"
+
+
+@dataclass(frozen=True)
+class JointLimit:
+    min_position: float
+    max_position: float
+    max_velocity: float
+    max_effort: float
+
+
+@dataclass(frozen=True)
+class Violation:
+    kind: str
+    message: str
+    joint: str | None = None
+    value: float | None = None
+    bound: float | None = None
+    point_index: int | None = None
+
+
+class _LimitsLoader(yaml.SafeLoader):
+    pass
+
+
+def _degrees(loader: yaml.SafeLoader, node: yaml.Node) -> float:
+    return math.radians(float(loader.construct_scalar(node)))
+
+
+_LimitsLoader.add_constructor("!degrees", _degrees)
+
+
+def _package_share(package: str) -> Path:
+    try:
+        from ament_index_python.packages import get_package_share_directory
+
+        return Path(get_package_share_directory(package))
+    except (ImportError, LookupError):
+        fallback = Path("/opt/ros/jazzy/share") / package
+        if fallback.is_dir():
+            return fallback
+        raise FileNotFoundError(f"could not locate ROS package share for {package!r}") from None
+
+
+def _number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{label} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{label} must be a finite number")
+    return result
+
+
+def load_hard_limits(vendor_description_pkg: str, ur_type: str) -> dict[str, JointLimit]:
+    """Load vendor limits dynamically, including UR's custom ``!degrees`` tag."""
+    path = _package_share(vendor_description_pkg) / "config" / ur_type / "joint_limits.yaml"
+    if not path.is_file():
+        raise FileNotFoundError(f"vendor joint limits not found: {path}")
+    data = yaml.load(path.read_text(encoding="utf-8"), Loader=_LimitsLoader) or {}
+    raw_limits = data.get("joint_limits")
+    if not isinstance(raw_limits, Mapping) or not raw_limits:
+        raise ValueError(f"{path}: joint_limits must be a non-empty mapping")
+    result: dict[str, JointLimit] = {}
+    for joint, raw in raw_limits.items():
+        if not isinstance(joint, str) or not isinstance(raw, Mapping):
+            raise ValueError(f"{path}: malformed joint limit entry {joint!r}")
+        required_flags = ("has_position_limits", "has_velocity_limits", "has_effort_limits")
+        if any(raw.get(flag) is not True for flag in required_flags):
+            raise ValueError(f"{path}: {joint} must declare position, velocity and effort limits")
+        limit = JointLimit(
+            min_position=_number(raw.get("min_position"), f"{joint}.min_position"),
+            max_position=_number(raw.get("max_position"), f"{joint}.max_position"),
+            max_velocity=_number(raw.get("max_velocity"), f"{joint}.max_velocity"),
+            max_effort=_number(raw.get("max_effort"), f"{joint}.max_effort"),
+        )
+        if limit.min_position > limit.max_position or limit.max_velocity < 0 or limit.max_effort < 0:
+            raise ValueError(f"{path}: invalid bounds for {joint}")
+        result[joint] = limit
+    return result
+
+
+def _default_hard_limits() -> dict[str, JointLimit]:
+    arm = load_arm_config()
+    return load_hard_limits(arm.vendor_description_pkg, arm.ur_type)
+
+
+def _default_override_path() -> Path:
+    try:
+        installed = _package_share("workbench_motion") / "config" / "joint_limits.hw_override.yaml"
+        if installed.is_file():
+            return installed
+    except FileNotFoundError:
+        pass
+    return _SOURCE_CONFIG / "joint_limits.hw_override.yaml"
+
+
+def load_hw_override(
+    path: Path | str | None = None,
+    *,
+    hard_limits: Mapping[str, JointLimit] | None = None,
+) -> dict[str, JointLimit]:
+    """Load real-hardware overrides and reject anything not strictly within hard limits.
+
+    An empty file or absent ``joint_limits`` mapping means no override. Missing
+    joints are allowed; unknown joints, malformed values, and looser bounds are
+    rejected fail-closed.
+    """
+    hard = dict(hard_limits or _default_hard_limits())
+    override_path = Path(path) if path is not None else _default_override_path()
+    if not override_path.is_file():
+        raise FileNotFoundError(f"hardware override not found: {override_path}")
+    data = yaml.safe_load(override_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, Mapping):
+        raise ValueError("hardware override root must be a mapping")
+    raw_limits = data.get("joint_limits")
+    if raw_limits is None:
+        return {}
+    if not isinstance(raw_limits, Mapping):
+        raise ValueError("hardware override joint_limits must be a mapping")
+    result: dict[str, JointLimit] = {}
+    allowed = {"min_position", "max_position", "max_velocity", "max_effort"}
+    for joint, raw in raw_limits.items():
+        if joint not in hard:
+            raise ValueError(f"hardware override contains unknown joint {joint!r}")
+        if not isinstance(raw, Mapping) or not raw:
+            raise ValueError(f"hardware override for {joint} must be a non-empty mapping")
+        unknown_keys = set(raw) - allowed
+        if unknown_keys:
+            raise ValueError(f"hardware override for {joint} has unknown fields: {sorted(unknown_keys)}")
+        base = hard[joint]
+        values = {
+            "min_position": base.min_position,
+            "max_position": base.max_position,
+            "max_velocity": base.max_velocity,
+            "max_effort": base.max_effort,
+        }
+        for key, value in raw.items():
+            values[key] = _number(value, f"{joint}.{key}")
+        candidate = JointLimit(**values)
+        if candidate.min_position > candidate.max_position:
+            raise ValueError(f"hardware override for {joint} has min_position > max_position")
+        if candidate.max_velocity < 0 or candidate.max_effort < 0:
+            raise ValueError(f"hardware override for {joint} has a negative magnitude")
+        if (
+            candidate.min_position < base.min_position
+            or candidate.max_position > base.max_position
+            or candidate.max_velocity > base.max_velocity
+            or candidate.max_effort > base.max_effort
+        ):
+            raise ValueError(f"hardware override for {joint} is looser than the vendor hard limit")
+        result[joint] = candidate
+    return result
+
+
+load_override = load_hw_override
+
+
+def effective_limits(hard: Mapping[str, JointLimit], override: Mapping[str, JointLimit]) -> dict[str, JointLimit]:
+    """Intersect hard and override limits, independently taking the tighter bound."""
+    unknown = set(override) - set(hard)
+    if unknown:
+        raise ValueError(f"override contains unknown joints: {sorted(unknown)}")
+    return {
+        joint: JointLimit(
+            min_position=max(base.min_position, override.get(joint, base).min_position),
+            max_position=min(base.max_position, override.get(joint, base).max_position),
+            max_velocity=min(base.max_velocity, override.get(joint, base).max_velocity),
+            max_effort=min(base.max_effort, override.get(joint, base).max_effort),
+        )
+        for joint, base in hard.items()
+    }
+
+
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _seconds(value: Any) -> float:
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, Mapping):
+        return float(value.get("sec", 0)) + float(value.get("nanosec", 0)) / 1e9
+    return float(getattr(value, "sec", 0)) + float(getattr(value, "nanosec", 0)) / 1e9
+
+
+def _bad(kind: str, message: str, **kwargs: Any) -> Violation:
+    return Violation(kind=kind, message=message, **kwargs)
+
+
+def check_trajectory(
+    traj: Any,
+    current_joint_positions: Mapping[str, float],
+    limits: Mapping[str, JointLimit] | None = None,
+    *,
+    limit_epsilon: float = DEFAULT_LIMIT_EPSILON,
+) -> Violation | None:
+    """Return the first fail-closed violation, or ``None``; never mutate ``traj``.
+
+    ``traj`` may be a ROS-like object or a plain mapping with ``joint_names`` and
+    ``points``. Explicit limits make tests and later adapters deterministic; when
+    omitted, the shipped vendor hard limits and hardware override are loaded.
+    """
+    if not math.isfinite(limit_epsilon) or limit_epsilon < 0:
+        raise ValueError("limit_epsilon must be finite and non-negative")
+    if limits is None:
+        hard = _default_hard_limits()
+        limits = effective_limits(hard, load_hw_override(hard_limits=hard))
+    limits = dict(limits)
+    names = list(_field(traj, "joint_names", []) or [])
+    if not names:
+        return _bad("joint_names", "joint_names must be non-empty")
+    if len(names) != len(set(names)):
+        return _bad("joint_names", "joint_names contains duplicates")
+    unknown = set(names) - set(limits)
+    if unknown:
+        return _bad("joint_names", f"unknown joints: {sorted(unknown)}")
+    if set(names) != set(limits):
+        return _bad("joint_names", "partial joint goals are not allowed")
+    if set(current_joint_positions) != set(limits):
+        return _bad("current_state", "current state must contain exactly all controlled joints")
+    current: dict[str, float] = {}
+    for joint, raw in current_joint_positions.items():
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return _bad("non_finite", f"current state for {joint} is not numeric", joint=joint)
+        if not math.isfinite(value):
+            return _bad("non_finite", f"current state for {joint} is not finite", joint=joint, value=value)
+        lim = limits[joint]
+        lo, hi = lim.min_position + limit_epsilon, lim.max_position - limit_epsilon
+        if value < lo or value > hi:
+            return _bad(
+                "current_position",
+                f"current state for {joint} is outside limits",
+                joint=joint,
+                value=value,
+                bound=lo if value < lo else hi,
+            )
+        current[joint] = value
+
+    points = list(_field(traj, "points", []) or [])
+    if not points:
+        return _bad("points", "trajectory points must be non-empty")
+    previous_time: float | None = None
+    previous_positions: Sequence[float] | None = None
+    n = len(names)
+    for index, point in enumerate(points):
+        positions = list(_field(point, "positions", []) or [])
+        if len(positions) != n:
+            return _bad("array_length", "positions length must match joint_names", point_index=index)
+        arrays = {
+            "velocities": list(_field(point, "velocities", []) or []),
+            "accelerations": list(_field(point, "accelerations", []) or []),
+            "effort": list(_field(point, "effort", []) or []),
+        }
+        for field_name, values in arrays.items():
+            if len(values) not in (0, n):
+                return _bad("array_length", f"{field_name} length must be zero or match joint_names", point_index=index)
+        try:
+            time_from_start = _seconds(_field(point, "time_from_start", 0.0))
+            numeric_positions = [float(v) for v in positions]
+            numeric_arrays = {key: [float(v) for v in values] for key, values in arrays.items()}
+        except (TypeError, ValueError):
+            return _bad("non_finite", "trajectory contains a non-numeric value", point_index=index)
+        all_values = [time_from_start, *numeric_positions]
+        for values in numeric_arrays.values():
+            all_values.extend(values)
+        if not all(math.isfinite(v) for v in all_values):
+            return _bad("non_finite", "trajectory contains NaN or infinity", point_index=index)
+        if time_from_start < 0:
+            return _bad(
+                "time", "time_from_start must be non-negative", value=time_from_start, bound=0.0, point_index=index
+            )
+        if previous_time is not None and time_from_start <= previous_time:
+            return _bad(
+                "time",
+                "time_from_start must be strictly increasing",
+                value=time_from_start,
+                bound=previous_time,
+                point_index=index,
+            )
+
+        for offset, joint in enumerate(names):
+            lim = limits[joint]
+            pos = numeric_positions[offset]
+            lo = lim.min_position + limit_epsilon
+            hi = lim.max_position - limit_epsilon
+            vmax = max(0.0, lim.max_velocity - limit_epsilon)
+            emax = max(0.0, lim.max_effort - limit_epsilon)
+            if pos < lo or pos > hi:
+                return _bad(
+                    "position",
+                    f"{joint} position is outside limits",
+                    joint=joint,
+                    value=pos,
+                    bound=lo if pos < lo else hi,
+                    point_index=index,
+                )
+            if numeric_arrays["velocities"] and abs(numeric_arrays["velocities"][offset]) > vmax:
+                return _bad(
+                    "velocity",
+                    f"{joint} velocity exceeds limit",
+                    joint=joint,
+                    value=numeric_arrays["velocities"][offset],
+                    bound=vmax,
+                    point_index=index,
+                )
+            if numeric_arrays["effort"] and abs(numeric_arrays["effort"][offset]) > emax:
+                return _bad(
+                    "effort",
+                    f"{joint} effort exceeds limit",
+                    joint=joint,
+                    value=numeric_arrays["effort"][offset],
+                    bound=emax,
+                    point_index=index,
+                )
+            if previous_positions is None:
+                start = current[joint]
+                dt = time_from_start
+                if dt == 0.0:
+                    if abs(pos - start) > limit_epsilon:
+                        return _bad(
+                            "initial_position",
+                            f"{joint} first point at t=0 differs from current state",
+                            joint=joint,
+                            value=pos,
+                            bound=start,
+                            point_index=index,
+                        )
+                elif abs(pos - start) / dt > vmax:
+                    return _bad(
+                        "segment_velocity",
+                        f"{joint} current-to-first mean velocity exceeds limit",
+                        joint=joint,
+                        value=abs(pos - start) / dt,
+                        bound=vmax,
+                        point_index=index,
+                    )
+            else:
+                dt = time_from_start - previous_time  # positive by the check above
+                mean_velocity = abs(pos - previous_positions[offset]) / dt
+                if mean_velocity > vmax:
+                    return _bad(
+                        "segment_velocity",
+                        f"{joint} segment mean velocity exceeds limit",
+                        joint=joint,
+                        value=mean_velocity,
+                        bound=vmax,
+                        point_index=index,
+                    )
+        previous_time = time_from_start
+        previous_positions = numeric_positions
+    return None

--- a/robot/control/workbench_motion/workbench_motion/launch_utils.py
+++ b/robot/control/workbench_motion/workbench_motion/launch_utils.py
@@ -1,0 +1,61 @@
+"""Shared parameter assembly for the phase-1 and phase-2 launch files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from launch.substitutions import Command
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def require_file(path: Path, what: str) -> Path:
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"{what} not found at {path}. Did you `colcon build --packages-select "
+            "workbench_motion` and `source install/setup.bash`?"
+        )
+    return path
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def robot_description(xacro: Path, xacro_args: dict[str, str] | None = None) -> dict[str, Any]:
+    require_file(xacro, "arm xacro")
+    command: list[str] = ["xacro ", str(xacro)]
+    for name, value in (xacro_args or {}).items():
+        command.extend([f" {name}:=", value])
+    return {"robot_description": ParameterValue(Command(command), value_type=str)}
+
+
+def move_group_parameters(
+    share: Path,
+    description: dict[str, Any],
+    *,
+    use_sim_time: bool,
+) -> list[dict[str, Any]]:
+    """Assemble MoveIt parameters without creating any nodes or publishers."""
+    moveit_dir = share / "config" / "moveit"
+    srdf = require_file(moveit_dir / "workbench_arm.srdf", "SRDF")
+    kinematics = require_file(moveit_dir / "kinematics.yaml", "kinematics.yaml")
+    joint_limits = require_file(moveit_dir / "joint_limits.yaml", "joint_limits.yaml")
+    ompl = require_file(moveit_dir / "ompl_planning.yaml", "ompl_planning.yaml")
+    return [
+        description,
+        {"robot_description_semantic": ParameterValue(srdf.read_text(encoding="utf-8"), value_type=str)},
+        {"robot_description_kinematics": load_yaml(kinematics)},
+        {"robot_description_planning": load_yaml(joint_limits)},
+        {
+            "planning_pipelines": ["ompl"],
+            "default_planning_pipeline": "ompl",
+            "ompl": load_yaml(ompl),
+        },
+        {"publish_robot_description_semantic": True},
+        {"use_sim_time": use_sim_time},
+    ]

--- a/robot/control/workbench_motion/workbench_motion/phase2_probe.py
+++ b/robot/control/workbench_motion/workbench_motion/phase2_probe.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+"""Phase-2 controller/TF/collision/mimic evidence probe.
+
+ROS imports are lazy. Classification, path densification, mimic math, report
+validation, and orchestration stay ROS-free and are unit-tested with fake IO.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from itertools import pairwise
+from pathlib import Path
+from typing import Any, Protocol
+
+from workbench_motion.arm_config import ArmConfig, load_arm_config
+from workbench_motion.joint_limits import (
+    JointLimit,
+    Violation,
+    check_trajectory,
+    effective_limits,
+    load_hard_limits,
+    load_hw_override,
+)
+
+SAFE_BEHAVIORS = frozenset({"rejected", "aborted"})
+FAIL_BEHAVIORS = frozenset({"clamped", "executed_over_limit", "timeout", "unclassified"})
+FOLLOWERS = {
+    "robotiq_85_right_knuckle_joint": -1.0,
+    "robotiq_85_left_inner_knuckle_joint": 1.0,
+    "robotiq_85_right_inner_knuckle_joint": -1.0,
+    "robotiq_85_left_finger_tip_joint": -1.0,
+    "robotiq_85_right_finger_tip_joint": 1.0,
+}
+TF_CHAIN = (
+    "world",
+    "base_link",
+    "base_link_inertia",
+    "shoulder_link",
+    "upper_arm_link",
+    "forearm_link",
+    "wrist_1_link",
+    "wrist_2_link",
+    "wrist_3_link",
+    "flange",
+    "tool0",
+    "grasp_tcp",
+)
+
+
+@dataclass(frozen=True)
+class JointSnapshot:
+    positions: dict[str, float]
+    stamp_s: float
+
+
+@dataclass(frozen=True)
+class ActionObservation:
+    accepted: bool
+    status: str
+    timed_out: bool
+    requested: dict[str, float]
+    before: JointSnapshot
+    after: JointSnapshot
+    samples: tuple[JointSnapshot, ...] = ()
+
+
+class ProbeIO(Protocol):
+    def endpoint_status(self) -> Mapping[str, bool]: ...
+    def robot_description(self) -> str: ...
+    def controller_states(self) -> list[dict[str, str]]: ...
+    def tf_chain(self, frames: Sequence[str], staleness_s: float) -> dict[str, Any]: ...
+    def joint_snapshot(self, staleness_s: float) -> JointSnapshot: ...
+    def execute_arm(self, target: Mapping[str, float], duration_s: float, staleness_s: float) -> ActionObservation: ...
+    def collision_check(self, states: Sequence[Mapping[str, float]]) -> dict[str, Any]: ...
+    def execute_gripper(self, position: float, staleness_s: float) -> ActionObservation: ...
+    def versions(self) -> Mapping[str, str]: ...
+
+
+def _resolve_output_path(output: str, start: Path | None = None) -> Path:
+    path = Path(output)
+    if path.is_absolute():
+        return path
+    start = start or Path.cwd()
+    for parent in (start, *start.parents):
+        if (parent / ".git").exists():
+            return parent / path
+    return path
+
+
+def is_stale(stamp_s: float, now_s: float, staleness_s: float) -> bool:
+    if not all(math.isfinite(value) for value in (stamp_s, now_s, staleness_s)) or staleness_s < 0:
+        return True
+    return stamp_s <= 0.0 or now_s - stamp_s > staleness_s or stamp_s > now_s + staleness_s
+
+
+def hardware_is_gazebo(robot_description: str) -> bool:
+    return "<plugin>gz_ros2_control/GazeboSimSystem</plugin>" in robot_description
+
+
+def snapshot_is_complete(snapshot: JointSnapshot, required_joints: Sequence[str]) -> bool:
+    """Return true only for a finite snapshot containing every controlled joint."""
+    if not math.isfinite(snapshot.stamp_s) or snapshot.stamp_s <= 0.0:
+        return False
+    return all(joint in snapshot.positions and math.isfinite(snapshot.positions[joint]) for joint in required_joints)
+
+
+def _outside(
+    snapshot: JointSnapshot, limits: Mapping[str, JointLimit], epsilon: float = 1e-6
+) -> list[dict[str, float | str]]:
+    found = []
+    for joint, limit in limits.items():
+        value = snapshot.positions.get(joint)
+        if value is None or not math.isfinite(value):
+            continue
+        if value < limit.min_position - epsilon:
+            found.append({"joint": joint, "value": value, "bound": limit.min_position})
+        elif value > limit.max_position + epsilon:
+            found.append({"joint": joint, "value": value, "bound": limit.max_position})
+    return found
+
+
+def classify_over_limit(
+    observation: ActionObservation, limits: Mapping[str, JointLimit], tolerance: float = 0.01
+) -> str:
+    """Classify actual controller behavior into the frozen six-class taxonomy."""
+    required = tuple(limits)
+    snapshots = (observation.before, *observation.samples, observation.after)
+    # An incomplete /joint_states message is evidence failure, never evidence
+    # that an aborted goal was safe.  This is deliberately checked before the
+    # action status so an empty after snapshot cannot produce "aborted".
+    if any(not snapshot_is_complete(sample, required) for sample in snapshots):
+        return "unclassified"
+    if observation.timed_out:
+        return "timeout"
+    samples = (*observation.samples, observation.after)
+    if any(_outside(sample, limits) for sample in samples):
+        return "executed_over_limit"
+    moved = any(
+        abs(observation.after.positions.get(joint, before) - before) > tolerance
+        for joint, before in observation.before.positions.items()
+    )
+    if not observation.accepted:
+        return "rejected" if not moved else "unclassified"
+    clamped = False
+    for joint, requested in observation.requested.items():
+        limit = limits.get(joint)
+        actual = observation.after.positions.get(joint)
+        if limit is None or actual is None or not math.isfinite(actual):
+            continue
+        if requested < limit.min_position and abs(actual - limit.min_position) <= tolerance:
+            clamped = True
+        elif requested > limit.max_position and abs(actual - limit.max_position) <= tolerance:
+            clamped = True
+    if moved and clamped:
+        return "clamped"
+    if observation.status == "aborted":
+        return "aborted" if not moved else "unclassified"
+    return "unclassified"
+
+
+def smoothness_report(
+    samples: Sequence[JointSnapshot],
+    target: Mapping[str, float],
+    *,
+    velocity_jump_limit: float = 1.0,
+    overshoot_tolerance: float = 0.01,
+) -> dict[str, Any]:
+    """Machine-check sampled trajectory timing, velocity jumps and overshoot."""
+    joints = tuple(target)
+    report: dict[str, Any] = {
+        "samples_checked": len(samples),
+        "velocity_jump_limit_rad_s": velocity_jump_limit,
+        "overshoot_tolerance_rad": overshoot_tolerance,
+        "velocity_continuous": False,
+        "overshoot_free": False,
+        "max_velocity_jump_rad_s": None,
+        "valid": False,
+        "reason": None,
+    }
+    if len(samples) < 2 or any(not snapshot_is_complete(sample, joints) for sample in samples):
+        report["reason"] = "insufficient_or_invalid_joint_state_samples"
+        return report
+    velocities: list[dict[str, float]] = []
+    for previous, current in pairwise(samples):
+        dt = current.stamp_s - previous.stamp_s
+        if not math.isfinite(dt) or dt <= 0.0:
+            report["reason"] = "non_increasing_sample_timestamps"
+            return report
+        velocities.append({joint: (current.positions[joint] - previous.positions[joint]) / dt for joint in joints})
+    jumps = [abs(current[joint] - previous[joint]) for previous, current in pairwise(velocities) for joint in joints]
+    max_jump = max(jumps, default=0.0)
+    report["max_velocity_jump_rad_s"] = max_jump
+    report["velocity_continuous"] = max_jump <= velocity_jump_limit
+    overshoot = False
+    for joint in joints:
+        start = samples[0].positions[joint]
+        goal = target[joint]
+        direction = goal - start
+        if abs(direction) <= overshoot_tolerance:
+            continue
+        for sample in samples[1:]:
+            progress = sample.positions[joint] - start
+            if (direction > 0 and progress > direction + overshoot_tolerance) or (
+                direction < 0 and progress < direction - overshoot_tolerance
+            ):
+                overshoot = True
+                break
+    report["overshoot_free"] = not overshoot
+    report["valid"] = report["velocity_continuous"] and report["overshoot_free"]
+    if not report["valid"]:
+        report["reason"] = "velocity_jump_or_overshoot"
+    return report
+
+
+def behavior_gate(kind: str) -> str:
+    if kind in SAFE_BEHAVIORS:
+        return "safe"
+    if kind in FAIL_BEHAVIORS:
+        return "fail"
+    raise ValueError(f"unknown over-limit behavior {kind!r}")
+
+
+def mimic_ratios(
+    before: Mapping[str, float],
+    after: Mapping[str, float],
+    driver_joint: str,
+    followers: Mapping[str, float] = FOLLOWERS,
+    tolerance_abs: float = 0.02,
+) -> dict[str, Any]:
+    driver_delta = after[driver_joint] - before[driver_joint]
+    if not math.isfinite(driver_delta) or abs(driver_delta) <= 1e-9:
+        raise ValueError("gripper driver did not move; mimic ratios are undefined")
+    entries = []
+    for joint, nominal in followers.items():
+        observed = (after[joint] - before[joint]) / driver_delta
+        entries.append(
+            {
+                "joint": joint,
+                "nominal_multiplier": nominal,
+                "observed_ratio": observed,
+                "ok": math.isfinite(observed) and abs(observed - nominal) <= tolerance_abs,
+            }
+        )
+    return {
+        "control_declaration": "explicit_followers_with_vendor_multipliers",
+        "tolerance_abs": tolerance_abs,
+        "driver_joint": driver_joint,
+        "followers": entries,
+        "all_ok": all(entry["ok"] for entry in entries),
+    }
+
+
+def densify_joint_path(states: Sequence[Mapping[str, float]], resolution_rad: float = 0.05) -> list[dict[str, float]]:
+    if not math.isfinite(resolution_rad) or resolution_rad <= 0:
+        raise ValueError("resolution_rad must be positive and finite")
+    if not states:
+        return []
+    result = [dict(states[0])]
+    joints = set(states[0])
+    for start, end in pairwise(states):
+        if set(start) != joints or set(end) != joints:
+            raise ValueError("all path states must contain the same joints")
+        steps = max(1, math.ceil(max(abs(end[j] - start[j]) for j in joints) / resolution_rad))
+        for step in range(1, steps + 1):
+            alpha = step / steps
+            result.append({joint: start[joint] + alpha * (end[joint] - start[joint]) for joint in joints})
+    return result
+
+
+def validate_report(report: Mapping[str, Any]) -> None:
+    required = {
+        "generated_at",
+        "commit",
+        "git_dirty",
+        "config_hashes",
+        "versions",
+        "arm",
+        "controllers",
+        "tf_chain",
+        "gripper_mimic",
+        "legal_trajectory",
+        "observed_controller_over_limit_behavior",
+        "validator_violation",
+        "all_passed",
+    }
+    missing = required - set(report)
+    if missing:
+        raise ValueError(f"phase-2 report is missing fields: {sorted(missing)}")
+    kind = report["observed_controller_over_limit_behavior"].get("kind")
+    if kind not in SAFE_BEHAVIORS | FAIL_BEHAVIORS:
+        raise ValueError(f"invalid over-limit classification: {kind!r}")
+    legal = report["legal_trajectory"]
+    smoothness = legal.get("smoothness") if isinstance(legal, Mapping) else None
+    if not isinstance(smoothness, Mapping) or not isinstance(smoothness.get("valid"), bool):
+        raise ValueError("legal_trajectory.smoothness is missing or invalid")
+
+
+def atomic_write_report(path: Path, report: Mapping[str, Any]) -> None:
+    validate_report(report)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as handle:
+            temporary = Path(handle.name)
+            json.dump(report, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise
+
+
+def _git_metadata(repo: Path) -> tuple[str, bool]:
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    dirty = bool(
+        subprocess.run(["git", "status", "--porcelain"], cwd=repo, check=True, capture_output=True, text=True).stdout
+    )
+    return commit, dirty
+
+
+def _sha256(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _command_version(command: list[str]) -> str:
+    if shutil.which(command[0]) is None:
+        return "unavailable"
+    completed = subprocess.run(command, check=False, capture_output=True, text=True, timeout=5.0)
+    output = (completed.stdout or completed.stderr).strip()
+    return output.splitlines()[0] if output else "unknown"
+
+
+def _deb_version(package: str) -> str:
+    return _command_version(["dpkg-query", "-W", "-f=${Version}", package])
+
+
+def _snapshot_dict(snapshot: JointSnapshot) -> dict[str, Any]:
+    return {"stamp_s": snapshot.stamp_s, "positions": snapshot.positions}
+
+
+def _violation_dict(violation: Violation | None) -> dict[str, Any] | None:
+    return asdict(violation) if violation is not None else None
+
+
+def run_probe(
+    io: ProbeIO,
+    *,
+    arm: ArmConfig,
+    limits: Mapping[str, JointLimit],
+    output: Path,
+    repo: Path,
+    config_dir: Path,
+    staleness_s: float = 1.0,
+    collision_check_resolution_rad: float = 0.05,
+) -> int:
+    """Run the probe and publish evidence only after every gate has data."""
+
+    def fail(code: int, reason: str) -> int:
+        print(f"phase2_probe: {reason}", file=sys.stderr)
+        return code
+
+    try:
+        endpoints = dict(io.endpoint_status())
+        if not endpoints or not all(endpoints.values()):
+            unavailable = sorted(name for name, available in endpoints.items() if not available)
+            return fail(2, f"required endpoints unavailable: {unavailable}")
+        description = io.robot_description()
+        if not hardware_is_gazebo(description):
+            return fail(2, "robot_description is not using gz_ros2_control/GazeboSimSystem")
+        controllers = io.controller_states()
+        expected = {arm.joint_state_broadcaster, arm.arm_trajectory_controller, arm.gripper_controller}
+        if {entry["name"] for entry in controllers if entry.get("state") == "active"} != expected:
+            return fail(2, "the expected controller set is not active")
+        tf_report = io.tf_chain(TF_CHAIN, staleness_s)
+        if not tf_report.get("present"):
+            return fail(2, f"TF chain is incomplete or stale: {tf_report}")
+        before = io.joint_snapshot(staleness_s)
+        if not snapshot_is_complete(before, arm.joints):
+            return fail(2, "initial /joint_states is incomplete or non-finite")
+        current = {joint: before.positions[joint] for joint in arm.joints}
+        legal_target = dict(current)
+        joint = arm.joints[0]
+        direction = -1.0 if current[joint] + 0.05 >= limits[joint].max_position else 1.0
+        legal_target[joint] += direction * 0.05
+        legal = io.execute_arm(legal_target, 2.0, staleness_s)
+        path = densify_joint_path([current, legal_target], collision_check_resolution_rad)
+        path.extend(sample.positions for sample in legal.samples)
+        collision = io.collision_check(path)
+        collision["resolution_rad"] = collision_check_resolution_rad
+        legal_samples = [legal.before, *legal.samples, legal.after]
+        # A fake or controller may report the terminal sample both in its
+        # history and as ``after``; retain one copy so equal timestamps do not
+        # masquerade as a discontinuity.
+        legal_samples = [
+            sample
+            for index, sample in enumerate(legal_samples)
+            if index == 0 or sample.stamp_s != legal_samples[index - 1].stamp_s
+        ]
+        smoothness = smoothness_report(legal_samples, legal_target)
+        tracking_ok = snapshot_is_complete(legal.after, arm.joints) and all(
+            abs(legal.after.positions[j] - legal_target[j]) <= 0.05 for j in arm.joints
+        )
+        if legal.status != "succeeded" or not tracking_ok or not smoothness["valid"] or not collision.get("all_valid"):
+            return fail(
+                2,
+                f"legal trajectory gate failed: status={legal.status}, "
+                f"tracking_ok={tracking_ok}, smoothness={smoothness}, collision={collision}",
+            )
+
+        over_target = dict(legal_target)
+        over_target[joint] = limits[joint].max_position + 0.1
+        validator_traj = {
+            "joint_names": list(arm.joints),
+            "points": [{"positions": [over_target[j] for j in arm.joints], "time_from_start": 2.0}],
+        }
+        validator = check_trajectory(validator_traj, {j: legal.after.positions[j] for j in arm.joints}, limits)
+        if validator is None:
+            return fail(2, "local validator accepted the over-limit trajectory")
+        over = io.execute_arm(over_target, 2.0, staleness_s)
+        kind = classify_over_limit(over, limits)
+        gate = behavior_gate(kind)
+
+        gripper_before = io.joint_snapshot(staleness_s)
+        gripper = io.execute_gripper(0.5, staleness_s)
+        if gripper.status != "succeeded" or gripper.timed_out:
+            return fail(2, f"gripper action failed: status={gripper.status}, timed_out={gripper.timed_out}")
+        mimic = mimic_ratios(gripper_before.positions, gripper.after.positions, arm.driver_joint)
+        if not mimic["all_ok"]:
+            return fail(2, f"gripper mimic ratio gate failed: {mimic}")
+
+        commit, dirty = _git_metadata(repo)
+        report = {
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "commit": commit,
+            "git_dirty": dirty,
+            "config_hashes": {
+                "arm.yaml": _sha256(config_dir / "arm.yaml"),
+                "controllers.yaml": _sha256(config_dir / "controllers.yaml"),
+            },
+            "versions": dict(io.versions()),
+            "arm": arm.arm_label,
+            "controllers": controllers,
+            "tf_chain": tf_report,
+            "gripper_mimic": mimic,
+            "legal_trajectory": {
+                "tracking_tolerance_rad": 0.05,
+                "joint_states_before": _snapshot_dict(legal.before),
+                "joint_states_after": _snapshot_dict(legal.after),
+                "tracking_ok": tracking_ok,
+                "smoothness": smoothness,
+                "collision": collision,
+            },
+            "observed_controller_over_limit_behavior": {
+                "kind": kind,
+                "gate": gate,
+                "is_phase4_bypass_risk": kind in {"clamped", "executed_over_limit"},
+                "joint_states_before": _snapshot_dict(over.before),
+                "joint_states_after": _snapshot_dict(over.after),
+                "over_limit_joints": _outside(over.after, limits),
+            },
+            "validator_violation": _violation_dict(validator),
+            "all_passed": gate == "safe" and mimic["all_ok"] and collision["all_valid"] and tf_report["present"],
+        }
+        if not report["all_passed"]:
+            return fail(1, f"observed controller over-limit behavior is {kind!r}")
+        atomic_write_report(output, report)
+        return 0
+    except (KeyError, ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
+        return fail(2, f"{type(exc).__name__}: {exc}")
+
+
+class RosProbeIO:
+    """Small synchronous adapter over the ROS services/actions used by the probe."""
+
+    def __init__(self, arm: ArmConfig, timeout_s: float = 10.0):
+        import rclpy
+        from control_msgs.action import FollowJointTrajectory, GripperCommand
+        from controller_manager_msgs.srv import ListControllers
+        from moveit_msgs.srv import GetStateValidity
+        from rclpy.action import ActionClient
+        from rclpy.node import Node
+        from rclpy.parameter import Parameter
+        from rclpy.parameter_client import AsyncParameterClient
+        from sensor_msgs.msg import JointState
+        from tf2_ros import Buffer, TransformListener
+
+        self.rclpy = rclpy
+        self.arm = arm
+        self.timeout_s = timeout_s
+        self.node = Node(
+            "phase2_probe",
+            parameter_overrides=[Parameter("use_sim_time", Parameter.Type.BOOL, True)],
+        )
+        self.list_client = self.node.create_client(ListControllers, "/controller_manager/list_controllers")
+        self.state_client = self.node.create_client(GetStateValidity, "/check_state_validity")
+        self.arm_action = ActionClient(
+            self.node, FollowJointTrajectory, f"/{arm.arm_trajectory_controller}/follow_joint_trajectory"
+        )
+        self.gripper_action = ActionClient(self.node, GripperCommand, f"/{arm.gripper_controller}/gripper_cmd")
+        self.parameter_client = AsyncParameterClient(self.node, "/robot_state_publisher")
+        self.tf_buffer = Buffer(node=self.node)
+        self.tf_listener = TransformListener(self.tf_buffer, self.node)
+        self.latest: JointSnapshot | None = None
+        self.history: list[JointSnapshot] = []
+        self.node.create_subscription(JointState, "/joint_states", self._on_joint_state, 50)
+
+    def _spin(self, future, timeout_s: float | None = None):
+        self.rclpy.spin_until_future_complete(self.node, future, timeout_sec=timeout_s or self.timeout_s)
+        return future.result() if future.done() else None
+
+    def _on_joint_state(self, message):
+        if len(message.name) != len(message.position) or len(set(message.name)) != len(message.name):
+            return
+        stamp = float(message.header.stamp.sec) + float(message.header.stamp.nanosec) / 1e9
+        snapshot = JointSnapshot(dict(zip(message.name, message.position, strict=False)), stamp)
+        # Keep malformed messages visible as a missing fresh sample.  The
+        # consumer then times out/fails closed instead of treating them as a
+        # safe action result.
+        if snapshot_is_complete(snapshot, self.arm.joints):
+            self.latest = snapshot
+            self.history.append(snapshot)
+
+    def endpoint_status(self) -> Mapping[str, bool]:
+        return {
+            "list_controllers": self.list_client.wait_for_service(timeout_sec=self.timeout_s),
+            "check_state_validity": self.state_client.wait_for_service(timeout_sec=self.timeout_s),
+            "arm_action": self.arm_action.wait_for_server(timeout_sec=self.timeout_s),
+            "gripper_action": self.gripper_action.wait_for_server(timeout_sec=self.timeout_s),
+            "robot_description": self.parameter_client.wait_for_services(timeout_sec=self.timeout_s),
+        }
+
+    def robot_description(self) -> str:
+        deadline = time.monotonic() + self.timeout_s
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            result = self._spin(
+                self.parameter_client.get_parameters(["robot_description"]),
+                min(2.0, remaining),
+            )
+            if result is not None and result.values and result.values[0].string_value:
+                return result.values[0].string_value
+        raise RuntimeError("robot_description unavailable")
+
+    def controller_states(self) -> list[dict[str, str]]:
+        from controller_manager_msgs.srv import ListControllers
+
+        result = self._spin(self.list_client.call_async(ListControllers.Request()))
+        if result is None:
+            raise RuntimeError("ListControllers timed out")
+        return [{"name": item.name, "type": item.type, "state": item.state} for item in result.controller]
+
+    def tf_chain(self, frames: Sequence[str], staleness_s: float) -> dict[str, Any]:
+        from rclpy.time import Time
+        from tf2_ros import TransformException
+
+        pending = {(parent, child): "missing" for parent, child in pairwise(frames)}
+        deadline = time.monotonic() + self.timeout_s
+        while pending and time.monotonic() < deadline:
+            self.rclpy.spin_once(self.node, timeout_sec=0.1)
+            now = self.node.get_clock().now().nanoseconds / 1e9
+            for parent, child in tuple(pending):
+                try:
+                    transform = self.tf_buffer.lookup_transform(parent, child, Time())
+                    stamp = transform.header.stamp.sec + transform.header.stamp.nanosec / 1e9
+                    if stamp > 0.0 and is_stale(stamp, now, staleness_s):
+                        pending[(parent, child)] = "stale"
+                    else:
+                        del pending[(parent, child)]
+                except TransformException:
+                    continue
+        missing = [f"{parent}->{child}" for (parent, child), state in pending.items() if state == "missing"]
+        stale = [f"{parent}->{child}" for (parent, child), state in pending.items() if state == "stale"]
+        return {"expected": list(frames), "present": not missing and not stale, "missing": missing, "stale": stale}
+
+    def joint_snapshot(self, staleness_s: float) -> JointSnapshot:
+        deadline = time.monotonic() + self.timeout_s
+        while time.monotonic() < deadline:
+            self.rclpy.spin_once(self.node, timeout_sec=0.1)
+            now = self.node.get_clock().now().nanoseconds / 1e9
+            if (
+                self.latest is not None
+                and snapshot_is_complete(self.latest, self.arm.joints)
+                and not is_stale(self.latest.stamp_s, now, staleness_s)
+            ):
+                return self.latest
+        raise RuntimeError("fresh /joint_states unavailable")
+
+    def execute_arm(self, target: Mapping[str, float], duration_s: float, staleness_s: float) -> ActionObservation:
+        from action_msgs.msg import GoalStatus
+        from control_msgs.action import FollowJointTrajectory
+        from trajectory_msgs.msg import JointTrajectoryPoint
+
+        before = self.joint_snapshot(staleness_s)
+        history_start = len(self.history)
+        goal = FollowJointTrajectory.Goal()
+        goal.trajectory.joint_names = list(self.arm.joints)
+        point = JointTrajectoryPoint()
+        point.positions = [target[joint] for joint in self.arm.joints]
+        point.time_from_start.sec = int(duration_s)
+        point.time_from_start.nanosec = int((duration_s - int(duration_s)) * 1e9)
+        goal.trajectory.points = [point]
+        goal_handle = self._spin(self.arm_action.send_goal_async(goal))
+        if goal_handle is None:
+            return ActionObservation(False, "unknown", True, dict(target), before, before)
+        if not goal_handle.accepted:
+            after = self.joint_snapshot(staleness_s)
+            return ActionObservation(
+                False, "rejected", False, dict(target), before, after, tuple(self.history[history_start:])
+            )
+        wrapped = self._spin(goal_handle.get_result_async(), duration_s + self.timeout_s)
+        if wrapped is None:
+            after = self.joint_snapshot(staleness_s)
+            return ActionObservation(
+                True, "unknown", True, dict(target), before, after, tuple(self.history[history_start:])
+            )
+        status = {
+            GoalStatus.STATUS_SUCCEEDED: "succeeded",
+            GoalStatus.STATUS_ABORTED: "aborted",
+            GoalStatus.STATUS_CANCELED: "canceled",
+        }.get(wrapped.status, "unknown")
+        after = self.joint_snapshot(staleness_s)
+        return ActionObservation(True, status, False, dict(target), before, after, tuple(self.history[history_start:]))
+
+    def collision_check(self, states: Sequence[Mapping[str, float]]) -> dict[str, Any]:
+        from moveit_msgs.srv import GetStateValidity
+        from sensor_msgs.msg import JointState
+
+        first_invalid = None
+        for index, state in enumerate(states):
+            request = GetStateValidity.Request()
+            request.group_name = self.arm.planning_group
+            request.robot_state.joint_state = JointState(
+                name=list(self.arm.joints), position=[state[j] for j in self.arm.joints]
+            )
+            response = self._spin(self.state_client.call_async(request))
+            if response is None:
+                raise RuntimeError("/check_state_validity timed out")
+            if not response.valid and first_invalid is None:
+                first_invalid = {"index": index, "positions": dict(state)}
+        return {
+            "source": "moveit",
+            "resolution_rad": 0.05,
+            "states_checked": len(states),
+            "all_valid": first_invalid is None,
+            "first_invalid": first_invalid,
+        }
+
+    def execute_gripper(self, position: float, staleness_s: float) -> ActionObservation:
+        from action_msgs.msg import GoalStatus
+        from control_msgs.action import GripperCommand
+
+        before = self.joint_snapshot(staleness_s)
+        start = len(self.history)
+        goal = GripperCommand.Goal()
+        goal.command.position = position
+        goal.command.max_effort = 20.0
+        handle = self._spin(self.gripper_action.send_goal_async(goal))
+        if handle is None or not handle.accepted:
+            return ActionObservation(
+                False, "rejected", handle is None, {self.arm.driver_joint: position}, before, before
+            )
+        wrapped = self._spin(handle.get_result_async(), self.timeout_s)
+        after = self.joint_snapshot(staleness_s)
+        status = "succeeded" if wrapped is not None and wrapped.status == GoalStatus.STATUS_SUCCEEDED else "aborted"
+        return ActionObservation(
+            True, status, wrapped is None, {self.arm.driver_joint: position}, before, after, tuple(self.history[start:])
+        )
+
+    def versions(self) -> Mapping[str, str]:
+        return {
+            "ros_distro": os.environ.get("ROS_DISTRO", "unknown"),
+            "gz": _command_version(["gz", "sim", "--versions"]),
+            "gz_ros2_control": _deb_version("ros-jazzy-gz-ros2-control"),
+            "jtc": _deb_version("ros-jazzy-joint-trajectory-controller"),
+            "gripper_controllers": _deb_version("ros-jazzy-gripper-controllers"),
+        }
+
+    def close(self):
+        self.node.destroy_node()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Phase-2 Gazebo controller evidence probe")
+    parser.add_argument("--arm-config", default=None)
+    parser.add_argument("--output", default="docs/evaluation/phase2-controllers.json")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--staleness", type=float, default=1.0)
+    parser.add_argument("--collision-resolution", type=float, default=0.05)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    arm = load_arm_config(args.arm_config)
+    hard = load_hard_limits(arm.vendor_description_pkg, arm.ur_type)
+    limits = effective_limits(hard, load_hw_override(hard_limits=hard))
+    output = _resolve_output_path(args.output)
+    repo = next((parent for parent in (Path.cwd(), *Path.cwd().parents) if (parent / ".git").exists()), Path.cwd())
+    if args.arm_config:
+        config_dir = Path(args.arm_config).parent
+    else:
+        from ament_index_python.packages import get_package_share_directory
+
+        config_dir = Path(get_package_share_directory("workbench_motion")) / "config"
+
+    import rclpy
+
+    rclpy.init()
+    io = RosProbeIO(arm, args.timeout)
+    try:
+        return run_probe(
+            io,
+            arm=arm,
+            limits=limits,
+            output=output,
+            repo=repo,
+            config_dir=config_dir,
+            staleness_s=args.staleness,
+            collision_check_resolution_rad=args.collision_resolution,
+        )
+    finally:
+        io.close()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Related Issue
  Closes #116
  Related to #57
## What changed
  - 在合并 URDF 中通过 `sim_gz` 参数按需启用 `gz_ros2_control`
  - 添加 UR5e JointTrajectoryController、Robotiq GripperActionController 和 JointStateBroadcaster
  - 将控制器名称、更新频率和夹爪驱动关节集中到 `config/arm.yaml`
  - 添加厂商硬限位加载、硬件 override 叠加和纯逻辑 `check_trajectory` 校验器
  - 添加独立的 `sim_control.launch.py`
  - 添加 `phase2_probe`，检查控制器、TF、合法轨迹、MoveIt 状态有效性、夹爪 mimic 和裸 JTC 越限行为
  - 抽取 MoveIt 参数装配逻辑，保持阶段 1 launch 行为不变
  - 添加阶段 2 Task Packet、文档和攻击性单元测试
## Interfaces affected
  未修改 `interfaces/` 或 `libs/contracts/`。

  本 PR 仅修改 Motion 内部配置、launch、校验逻辑和验收工具，不产出 ActionResult，不改变对外契约。
## Tests and commands
  ```bash
  make task-check PACKET=docs/task_packets/motion-002-limits-control.json
  # passed
  ```

  ```bash
  uv run --directory robot/control pytest -q
  # 146 passed
  ```

  ```bash
  source /opt/ros/jazzy/setup.bash
  colcon build --packages-select workbench_motion
  source install/setup.bash
  # 1 package finished
  ```

  ```bash
  xacro \
    "$(ros2 pkg prefix workbench_motion)/share/workbench_motion/config/arm_on_workbench.urdf.xacro" \
    sim_gz:=true > /tmp/wb_ctrl.urdf

  check_urdf /tmp/wb_ctrl.urdf
  # Successfully Parsed XML; root Link: world
  ```

  ```bash
  make PYTHON='uv run python' lint test contract scenario-check context-check
  # lint passed
  # 102 root tests passed
  # contract/scenario/context checks passed
  ```

## Evidence
  - xacro 展开包含 `gz_ros2_control/GazeboSimSystem` 和 `gz_ros2_control-system`
  - ros2_control 展开包含 7 个 position command interface
  - 三个控制器均为 `active`：
    - `joint_state_broadcaster`
    - `arm_trajectory_controller`
    - `gripper_controller`
  - `world -> grasp_tcp` TF 持续可解析
  - `/joint_states` 包含 6 个臂关节、夹爪 driver 和 5 个 mimic follower
  - 合法轨迹到位，MoveIt 状态检查有效，夹爪 mimic 比例通过
  - 阶段 1回归：block `20/20`、tray `20/20`
  - 裸 JTC 越限行为实测为 `clamped`；实际关节未超过硬限位，登记为阶段 4防绕过风险

## Risks and rollback
  - 本 PR 的 `check_trajectory` 仅部分满足 #57：已覆盖纯逻辑 fail-closed 限位校验，但不关闭 #57；严格关节顺序、最大轨迹总时长、稳定 reason code、确定性轨迹 hash 和完整边界/property 测试将在 #57 的独立 PR 中完成。
  - 裸 JTC 接口仍可接收越限目标并由 Gazebo clamp；阶段 4必须将适配器设为唯一入口，在下发前复用 `check_trajectory`
  - 本阶段的校验器是保守前置筛查，不计算 JTC 样条区间极值，也不替代执行期监控
  - launch、`package.xml` 和 `setup.py` 变更需要 Linux/Integration Owner review
  - 回滚方式：revert 本 PR；`sim_gz` 默认值为 `false`，不启用控制插件时保持阶段 1行为

## Checklist

  - [x] I changed only approved paths.
  - [x] Tests and contract checks pass.
  - [x] I covered normal and failure behavior.
  - [x] I updated examples/docs when an interface changed.
  - [x] I did not add secrets, private data or unreviewed assets.
