### PR TITLE
feat(agent-runtime): add language-layer policy validator with exact field-set whitelist

### DIFF
--- a/docs/task_packets/agent-a5-policy-validator.json
+++ b/docs/task_packets/agent-a5-policy-validator.json
@@ -1,0 +1,63 @@
+{
+  "issue": 118,
+  "human_owner": "zhangjia-1111",
+  "objective": "Build a language-layer PolicyValidator that enforces exact field-set equality against the A1 ToolRegistry whitelist, fail-closed.",
+  "allowed_paths": [
+    "services/agent_runtime/workbench_agent_runtime/policy_validator.py",
+    "tests/unit/test_policy_validator.py",
+    "docs/task_packets/agent-a5-policy-validator.json"
+  ],
+  "read_only_paths": [
+    "services/agent_runtime/workbench_agent_runtime/tool_registry.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_schemas.py",
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "services/agent_runtime/workbench_agent_runtime/local_model.py",
+    "interfaces/**",
+    "libs/contracts/**"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "robot/control/**",
+    "services/world_model/**",
+    "services/backend/**",
+    "services/perception/**",
+    "sim/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "PolicyValidator reads whitelist from ToolRegistry, no second field list",
+    "valid SemanticAction passes",
+    "exact field-set equality, not subset",
+    "extra fields rejected",
+    "missing required fields rejected",
+    "isinstance(duration_ms, bool) checked before int",
+    "other int slots also bool-before-int",
+    "type mismatches rejected",
+    "fail-closed: any violation raises PolicyViolation",
+    "validator never emits VerificationResult",
+    "15+ behavioural assertions in unit tests"
+  ],
+  "commands": [
+    "make lint",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "make demo-scripted",
+    "make demo-offline"
+  ],
+  "evidence": [
+    "test_policy_validator.py output (25+ assertions)",
+    "make lint output",
+    "make test full suite output",
+    "make contract output",
+    "make demo-scripted output"
+  ],
+  "stop_conditions": [
+    "ToolRegistry interface not merged to main",
+    "adding a new ActionType enum value",
+    "modifying interfaces/ or libs/contracts/",
+    "validator emitting VerificationResult or claiming task completion",
+    "make demo-scripted regression"
+  ]
+}

--- a/services/agent_runtime/workbench_agent_runtime/policy_validator.py
+++ b/services/agent_runtime/workbench_agent_runtime/policy_validator.py
@@ -1,0 +1,243 @@
+"""Language-layer policy validator: exact field-set whitelist, fail-closed.
+
+A5 validates the ``TaskGraph`` produced from a natural-language goal against the
+tool whitelist before anything reaches Motion / the MCU.  It reads
+``required_params`` / ``optional_params`` / ``param_types`` from
+:class:`~workbench_agent_runtime.tool_registry.ToolRegistry` — the single source
+of truth — and enforces **exact field-set equality**: every required key must be
+present, and no key outside the allow-list may appear.
+
+``bool`` is checked *before* ``int`` / ``float`` because ``isinstance(True, int)``
+is ``True`` in Python; without that ordering a ``duration_ms=True`` would pass
+an integer slot as ``1``.
+
+Three rules this module obeys and never crosses:
+
+1. **The model never touches joints.**  Only the six semantic actions
+   (``observe``/``grasp``/``place``/``ask_confirm``/``express``/``stop``) are
+   valid; any joint/firmware field is an allow-list violation and is rejected.
+2. **Completion is judged only by the world-model verifier.**  This module never
+   constructs a ``VerificationResult`` and never declares a task done.
+3. **Success claims carry evidence.**  Out of scope here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from workbench_contracts import ActionType, TaskGraph, TaskStep
+
+from .tool_registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# public types
+# ---------------------------------------------------------------------------
+
+
+class PolicyViolation(RuntimeError):
+    """A TaskGraph or action violates the tool whitelist (fail-closed)."""
+
+
+@dataclass(frozen=True)
+class PolicyFinding:
+    """One whitelist violation, located to a step and field."""
+
+    step_id: str
+    action_id: str
+    field: str
+    message: str
+
+
+@dataclass(frozen=True)
+class PolicyReport:
+    """Aggregated whitelist result for a TaskGraph."""
+
+    findings: tuple[PolicyFinding, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.findings
+
+
+# ---------------------------------------------------------------------------
+# validator
+# ---------------------------------------------------------------------------
+
+
+class PolicyValidator:
+    """Validate TaskGraphs against the tool whitelist with fail-closed semantics.
+
+    The whitelist data lives in :class:`ToolRegistry`; this module holds no
+    second copy of the field list.  Two entry points:
+
+    * :meth:`check` returns a :class:`PolicyReport` (inspection, never raises).
+    * :meth:`enforce` raises :class:`PolicyViolation` on the first invalid graph.
+    """
+
+    def __init__(self, registry: ToolRegistry | None = None) -> None:
+        self._registry = registry if registry is not None else ToolRegistry()
+
+    # -- public API ----------------------------------------------------------
+
+    def check(self, graph: TaskGraph) -> PolicyReport:
+        """Return every whitelist violation across all steps (never raises)."""
+        findings: list[PolicyFinding] = []
+        for step in graph.steps:
+            findings.extend(self._check_step(step))
+        return PolicyReport(tuple(findings))
+
+    def enforce(self, graph: TaskGraph) -> None:
+        """Fail-closed: raise :class:`PolicyViolation` if any step is invalid."""
+        report = self.check(graph)
+        if not report.is_valid:
+            raise PolicyViolation(_format_findings(report.findings))
+
+    # -- internals -----------------------------------------------------------
+
+    def _check_step(self, step: TaskStep) -> list[PolicyFinding]:
+        action = step.action
+        findings: list[PolicyFinding] = []
+        step_id = step.step_id
+        action_id = action.action_id
+
+        # 0. action_type must be a registered ActionType
+        if not isinstance(action.action_type, ActionType):
+            return [
+                PolicyFinding(
+                    step_id,
+                    action_id,
+                    "action_type",
+                    f"expected an ActionType enum member, got {type(action.action_type).__name__!r}",
+                )
+            ]
+        if action.action_type not in self._registry.list_all():
+            return [
+                PolicyFinding(
+                    step_id,
+                    action_id,
+                    "action_type",
+                    f"unknown action_type '{action.action_type.value}'",
+                )
+            ]
+
+        schema = self._registry.get(action.action_type)
+        target_id_required: bool = schema.get("target_id_required", False)
+        required: frozenset[str] = schema["required_params"]
+        optional: frozenset[str] = schema["optional_params"]
+        allowed: frozenset[str] = required | optional
+        param_types: Mapping[str, type | object] = schema["param_types"]
+
+        # 1. target_id requirement (physical-safety boundary)
+        if target_id_required and (not isinstance(action.target_id, str) or not action.target_id.strip()):
+            findings.append(
+                PolicyFinding(
+                    step_id,
+                    action_id,
+                    "target_id",
+                    f"'{action.action_type.value}' requires a non-empty target_id",
+                )
+            )
+
+        # 2. parameters must be a mapping — fail-closed on malformed input
+        params = action.parameters
+        if not isinstance(params, Mapping):
+            findings.append(
+                PolicyFinding(
+                    step_id,
+                    action_id,
+                    "parameters",
+                    f"expected a mapping, got {type(params).__name__!r}",
+                )
+            )
+            return findings
+
+        # 3. exact field-set equality: reject extra and missing keys
+        actual_keys = set(params)
+        extra = actual_keys - allowed
+        missing = required - actual_keys
+        if extra:
+            findings.append(
+                PolicyFinding(
+                    step_id,
+                    action_id,
+                    "parameters",
+                    f"forbidden keys for '{action.action_type.value}': " f"{sorted(extra)}; allowed: {sorted(allowed)}",
+                )
+            )
+        if missing:
+            findings.append(
+                PolicyFinding(
+                    step_id,
+                    action_id,
+                    "parameters",
+                    f"missing required keys for '{action.action_type.value}': " f"{sorted(missing)}",
+                )
+            )
+
+        # 4. type safety (bool-before-int) — only for keys in the allow-list
+        for key, value in params.items():
+            expected_type = param_types.get(key)
+            if expected_type is None:
+                # undeclared key — already reported as forbidden, or permissive
+                continue
+            type_error = _type_error(key, value, expected_type)
+            if type_error is not None:
+                findings.append(PolicyFinding(step_id, action_id, f"parameters.{key}", type_error))
+
+        return findings
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _type_error(key: str, value: object, expected: type | object) -> str | None:
+    """Return an error message if *value* violates *expected*; ``None`` if ok.
+
+    ``bool`` is checked before ``int`` / ``float`` because ``bool`` subclasses
+    ``int`` in Python.  ``duration_ms`` and any other integer slot must reject
+    ``True`` / ``False`` rather than coercing them to ``1`` / ``0``.
+    """
+    if expected is bool:
+        if not isinstance(value, bool):
+            return f"expected bool, got {_type_label(value)}"
+        return None
+    if expected is int:
+        if isinstance(value, bool):
+            return "expected int, got bool (bool is not int)"
+        if not isinstance(value, int):
+            return f"expected int, got {_type_label(value)}"
+        return None
+    if expected is float:
+        if isinstance(value, bool):
+            return "expected float, got bool"
+        if not isinstance(value, int | float):
+            return f"expected float, got {_type_label(value)}"
+        return None
+    if expected is str:
+        if not isinstance(value, str):
+            return f"expected str, got {_type_label(value)}"
+        return None
+    if expected is list:
+        if not isinstance(value, list):
+            return f"expected list, got {_type_label(value)}"
+        return None
+    if not isinstance(value, expected):
+        return f"expected {getattr(expected, '__name__', str(expected))}, got {_type_label(value)}"
+    return None
+
+
+def _type_label(value: object) -> str:
+    if isinstance(value, bool):
+        return "bool"
+    return type(value).__name__
+
+
+def _format_findings(findings: tuple[PolicyFinding, ...]) -> str:
+    lines = []
+    for finding in findings:
+        loc = f"step '{finding.step_id}'" if finding.step_id else "step '(unknown)'"
+        lines.append(f"{loc} action '{finding.action_id}': {finding.field}: {finding.message}")
+    return "TaskGraph violates tool whitelist:\n" + "\n".join(lines)

--- a/tests/unit/test_policy_validator.py
+++ b/tests/unit/test_policy_validator.py
@@ -1,0 +1,340 @@
+"""Behavioural tests for policy_validator — A5.
+
+Covers exact field-set equality (reject extra AND missing), bool-before-int
+(duration_ms and other integer slots), type mismatches, fail-closed enforcement,
+TaskGraph-level aggregation, non-ActionType input, target_id requirement, and
+the rule that the validator never emits a VerificationResult.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [
+    str(ROOT / "libs/contracts"),
+    str(ROOT / "services/agent_runtime"),
+    str(ROOT / "tools/scripts"),
+]
+
+from workbench_agent_runtime.policy_validator import (
+    PolicyFinding,
+    PolicyReport,
+    PolicyValidator,
+    PolicyViolation,
+)
+from workbench_agent_runtime.tool_registry import ToolRegistry
+from workbench_contracts import ActionType, SemanticAction, TaskGraph, TaskStep
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _action(
+    action_type: ActionType,
+    *,
+    action_id: str = "act-test",
+    target_id: str | None = None,
+    parameters: dict | None = None,
+) -> SemanticAction:
+    return SemanticAction(
+        action_id=action_id,
+        action_type=action_type,
+        target_id=target_id,
+        parameters=parameters or {},
+    )
+
+
+def _graph(*actions: SemanticAction) -> TaskGraph:
+    steps = [TaskStep(step_id=f"step-{index}", action=action) for index, action in enumerate(actions, start=1)]
+    return TaskGraph(task_id="task-test", goal="test", steps=steps, planner="test")
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class PolicyValidatorValidActionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_observe_with_no_params_is_valid(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.OBSERVE)))
+        self.assertTrue(report.is_valid)
+
+    def test_grasp_with_target_id_is_valid(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.GRASP, target_id="red_block")))
+        self.assertTrue(report.is_valid)
+
+    def test_place_with_destination_is_valid(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.PLACE,
+                    target_id="red_block",
+                    parameters={"destination_id": "tray"},
+                )
+            )
+        )
+        self.assertTrue(report.is_valid)
+
+    def test_ask_confirm_is_valid(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.ASK_CONFIRM, parameters={"question": "proceed?"})))
+        self.assertTrue(report.is_valid)
+
+    def test_express_is_valid(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.EXPRESS, parameters={"emotion_state": "pleased"})))
+        self.assertTrue(report.is_valid)
+
+    def test_stop_is_valid(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.STOP)))
+        self.assertTrue(report.is_valid)
+
+
+class PolicyValidatorFieldSetTests(unittest.TestCase):
+    """Exact field-set equality: reject extra AND missing."""
+
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_extra_field_is_rejected(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.OBSERVE, parameters={"joint_angle": 90})))
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("forbidden keys" in f.message for f in report.findings))
+
+    def test_missing_required_field_is_rejected(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.PLACE, target_id="red_block", parameters={})))
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("missing required" in f.message for f in report.findings))
+
+    def test_exact_field_set_equality_is_not_subset(self) -> None:
+        """A subset of allowed params that omits a required key must be rejected.
+
+        This is the A5 acceptance point: the field set must be EXACTLY equal to
+        the whitelist requirement, not merely a subset of the allow-list."""
+        # place requires destination_id; omitting it leaves a subset -> reject
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.PLACE,
+                    target_id="red_block",
+                    parameters={"routing_reason": "verified_intact"},
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("missing required" in f.message for f in report.findings))
+
+    def test_optional_fields_may_be_absent(self) -> None:
+        """Optional fields are not required; their absence must not fail."""
+        report = self.validator.check(_graph(_action(ActionType.ASK_CONFIRM, parameters={"question": "ok?"})))
+        self.assertTrue(report.is_valid)
+
+
+class PolicyValidatorBoolBeforeIntTests(unittest.TestCase):
+    """bool must be rejected for integer slots, not coerced to 1/0."""
+
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_duration_ms_bool_is_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.EXPRESS,
+                    parameters={"emotion_state": "pleased", "duration_ms": True},
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("bool is not int" in f.message for f in report.findings))
+
+    def test_timeout_s_bool_is_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.ASK_CONFIRM,
+                    parameters={"question": "ok?", "timeout_s": False},
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("bool is not int" in f.message for f in report.findings))
+
+    def test_destination_capacity_bool_is_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.PLACE,
+                    target_id="box",
+                    parameters={"destination_id": "bin", "destination_capacity": True},
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("bool" in f.message.lower() for f in report.findings))
+
+    def test_genuine_integer_is_accepted(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.EXPRESS,
+                    parameters={"emotion_state": "pleased", "duration_ms": 500},
+                )
+            )
+        )
+        self.assertTrue(report.is_valid)
+
+
+class PolicyValidatorTypeMismatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_str_slot_with_int_is_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.PLACE,
+                    target_id="red_block",
+                    parameters={"destination_id": 42},
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("expected str" in f.message for f in report.findings))
+
+    def test_float_slot_with_str_is_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.OBSERVE,
+                    parameters={"required_confidence": "high"},
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("expected float" in f.message for f in report.findings))
+
+
+class PolicyValidatorEnforcementTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_enforce_raises_on_invalid_graph(self) -> None:
+        with self.assertRaises(PolicyViolation):
+            self.validator.enforce(_graph(_action(ActionType.PLACE, target_id="red_block", parameters={})))
+
+    def test_enforce_passes_valid_graph(self) -> None:
+        self.validator.enforce(
+            _graph(
+                _action(
+                    ActionType.PLACE,
+                    target_id="red_block",
+                    parameters={"destination_id": "tray"},
+                )
+            )
+        )
+
+    def test_enforce_message_locates_step_and_field(self) -> None:
+        with self.assertRaises(PolicyViolation) as context:
+            self.validator.enforce(_graph(_action(ActionType.GRASP, parameters={})))
+        message = str(context.exception)
+        self.assertIn("step 'step-1'", message)
+        self.assertIn("target_id", message)
+
+
+class PolicyValidatorAggregationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_multiple_invalid_steps_aggregate_all_findings(self) -> None:
+        graph = _graph(
+            _action(ActionType.GRASP, action_id="act-1", parameters={}),
+            _action(
+                ActionType.PLACE,
+                action_id="act-2",
+                target_id="red_block",
+                parameters={},
+            ),
+        )
+        report = self.validator.check(graph)
+        self.assertFalse(report.is_valid)
+        self.assertEqual(len(report.findings), 2)
+
+    def test_single_step_with_multiple_errors_reports_all(self) -> None:
+        # missing destination_id AND forbidden key on the same action
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.PLACE,
+                    target_id="red_block",
+                    parameters={"joint_angle": 90},
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertEqual(len(report.findings), 2)
+
+
+class PolicyValidatorBoundaryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_non_action_type_input_is_rejected(self) -> None:
+        action = SemanticAction.model_construct(
+            action_id="act-bad",
+            action_type="grasp",  # raw string, bypasses Pydantic coercion
+            target_id="red_block",
+        )
+        report = self.validator.check(_graph(action))
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("ActionType" in f.message for f in report.findings))
+
+    def test_grasp_without_target_id_is_rejected(self) -> None:
+        report = self.validator.check(_graph(_action(ActionType.GRASP)))
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any(f.field == "target_id" for f in report.findings))
+
+    def test_empty_task_graph_is_valid(self) -> None:
+        """Structural minItems is Pydantic's job; the validator passes empty."""
+        report = self.validator.check(TaskGraph(task_id="task-empty", goal="test", steps=[], planner="test"))
+        self.assertTrue(report.is_valid)
+
+    def test_validator_uses_injected_registry(self) -> None:
+        """The validator must read its whitelist from the injected registry,
+        not a hardcoded second copy."""
+        empty_registry = ToolRegistry(load_defaults=False)
+        validator = PolicyValidator(registry=empty_registry)
+        report = validator.check(_graph(_action(ActionType.OBSERVE)))
+        self.assertFalse(report.is_valid)  # nothing registered -> reject
+
+
+class PolicyValidatorRuleBoundaryTests(unittest.TestCase):
+    def test_validator_does_not_emit_verification_result(self) -> None:
+        """Rule 2: completion is judged only by the world-model verifier.
+        The validator's output must be a PolicyReport, never a VerificationResult."""
+        validator = PolicyValidator()
+        report = validator.check(_graph(_action(ActionType.OBSERVE)))
+        self.assertIsInstance(report, PolicyReport)
+        self.assertIsInstance(report.findings, tuple)
+        # No VerificationResult is constructed anywhere in this path.
+        from workbench_contracts import VerificationResult
+
+        self.assertNotIsInstance(report, VerificationResult)
+
+    def test_report_findings_are_policy_findings(self) -> None:
+        validator = PolicyValidator()
+        report = validator.check(_graph(_action(ActionType.GRASP)))
+        for finding in report.findings:
+            self.assertIsInstance(finding, PolicyFinding)
+            self.assertIsInstance(finding.step_id, str)
+            self.assertIsInstance(finding.field, str)
+            self.assertIsInstance(finding.message, str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a language-layer `PolicyValidator` that enforces **exact field-set equality** against the A1 `ToolRegistry` whitelist, fail-closed, for every `SemanticAction` in a `TaskGraph`.

**Scope** — Agent Language Layer / A5 (issue #118). No `interfaces/` schema or `libs/contracts/` model is modified; the validator reads its whitelist from the A1 registry and holds no second field list.

  ## Evidence boundary

The policy validator is a pure-software correctness gate at the language boundary. It proves that a model- or planner-produced `TaskGraph` carries exactly the allowed parameter fields, with correct types, before any action reaches Motion or the MCU. It does not prove that a downstream executor respects the rejection — that is A3 (Execution Controller) and the Motion safety layer.

`bool`-before-`int` rejection is explicitly implemented and tested. The validator never constructs a `VerificationResult` and never declares task completion — that boundary is owned by the world-model verifier (rule 2).

  ## Verification

  Task Packet validation: passed (`make task-check PACKET=docs/task_packets/agent-a5-policy-validator.json`)
  A5 unit tests: **27 passed**
  Full default suite: **223 passed** (0 regressions)
  Ruff rules and format: passed (2 changed files)
  contract, scenario, golden-set, and context validation: passed
  scripted and offline demos: passed

  Policy-validator behavioural coverage:

  | Behaviour | Assertions |
  |---|---|
  | Valid actions pass (all six action types) | 6 |
  | Exact field-set equality — not subset | 1 |
  | Extra (forbidden) field rejected | 1 |
  | Missing required field rejected | 1 |
  | Optional fields may be absent | 1 |
  | `duration_ms` bool rejected before int | 1 |
  | `timeout_s` / `destination_capacity` bool rejected | 2 |
  | Genuine integer accepted | 1 |
  | Type mismatch rejected (str slot, float slot) | 2 |
  | `enforce()` fail-closed raises / passes | 3 |
  | TaskGraph aggregation (multi-step, multi-error) | 2 |
  | Non-ActionType input rejected | 1 |
  | `target_id` required for grasp/place | 1 |
  | Empty graph valid | 1 |
  | Injected registry respected (no hardcoded list) | 1 |
  | No `VerificationResult` emitted | 2 |

  ## Review boundary

This PR is limited to the Agent Language Layer Task Packet paths (`policy_validator.py`, its test, and the Task Packet). It does not change `interfaces/` or `libs/contracts/`, and does not modify the A1 `tool_registry.py` / `tool_schemas.py`. AI must not merge it or make a Go/No-Go decision.

Closes #118

