### PR TITLE
feat(world-model): add deterministic schema-shaped mocks

### DIFF
--- a/services/world_model/workbench_world_model/__init__.py
+++ b/services/world_model/workbench_world_model/__init__.py
@@ -1,4 +1,5 @@
 from .event_store import SQLiteEventStore
+from .mock import mock_verification, mock_world_state
 from .reducer import WorldState, apply_event, reduce_events
 from .verifier import (
     verify_inspection_evidence,
@@ -13,6 +14,8 @@ __all__ = [
     "SQLiteEventStore",
     "WorldState",
     "apply_event",
+    "mock_verification",
+    "mock_world_state",
     "reduce_events",
     "verify_inspection_evidence",
     "verify_kit_contents",

--- a/services/world_model/workbench_world_model/mock.py
+++ b/services/world_model/workbench_world_model/mock.py
@@ -1,0 +1,93 @@
+import hashlib
+
+_FIXED_TIMESTAMP = "2026-08-04T00:00:16.200Z"
+
+
+def mock_world_state(run_id: str) -> dict[str, object]:
+    """Return deterministic, Schema-shaped WorldState data for development consumers."""
+    return {
+        "run_id": run_id,
+        "sequence_no": 31,
+        "state_hash": hashlib.sha256(f"mock-world-state:{run_id}".encode()).hexdigest(),
+        "entities": [
+            {
+                "entity_id": "red_block",
+                "entity_type": "block",
+                "pose": {
+                    "frame_id": "table",
+                    "position": {"x": 0.31, "y": -0.04, "z": 0.035},
+                    "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                },
+                "belief": "observed",
+                "confidence": 0.96,
+                "last_observed_at": "2026-08-04T00:00:16.100Z",
+                "evidence_refs": ["obs-mock-block"],
+            },
+            {
+                "entity_id": "tray",
+                "entity_type": "tray",
+                "pose": {
+                    "frame_id": "table",
+                    "position": {"x": 0.30, "y": -0.05, "z": 0.0},
+                    "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                },
+                "belief": "observed",
+                "confidence": 0.99,
+                "last_observed_at": "2026-08-04T00:00:16.100Z",
+                "evidence_refs": ["obs-mock-tray"],
+            },
+        ],
+        "relations": [
+            {
+                "subject_id": "red_block",
+                "predicate": "inside",
+                "object_id": "tray",
+                "belief": "observed",
+                "evidence_refs": ["obs-mock-block", "obs-mock-tray"],
+            }
+        ],
+        "reduced_at": _FIXED_TIMESTAMP,
+        "clock_id": "monotonic",
+    }
+
+
+def mock_verification(status: str) -> dict[str, object]:
+    """Return deterministic, Schema-shaped VerificationResult data."""
+    outcomes = {
+        "confirmed": {
+            "claim": "red_block inside tray",
+            "reason_code": "goal_satisfied",
+            "completeness": 1.0,
+            "recovery_hint": "none",
+        },
+        "refuted": {
+            "claim": "red_block inside tray",
+            "reason_code": "goal_not_satisfied",
+            "completeness": 1.0,
+            "recovery_hint": "retry_action",
+        },
+        "insufficient_evidence": {
+            "claim": "red_block inside tray could not be verified",
+            "reason_code": "target_not_observed",
+            "completeness": 0.5,
+            "recovery_hint": "re_observe",
+        },
+    }
+    try:
+        outcome = outcomes[status]
+    except KeyError as exc:
+        raise ValueError(f"unsupported verification status: {status}") from exc
+
+    return {
+        "verification_id": f"ver-mock-{status}",
+        "run_id": "run-mock-001",
+        "task_id": "task-mock-001",
+        "claim": outcome["claim"],
+        "status": status,
+        "reason_code": outcome["reason_code"],
+        "completeness": outcome["completeness"],
+        "evidence_refs": ["evidence-mock-001"],
+        "recovery_hint": outcome["recovery_hint"],
+        "verified_at": _FIXED_TIMESTAMP,
+        "clock_id": "monotonic",
+    }

--- a/tests/unit/test_world_model_mock.py
+++ b/tests/unit/test_world_model_mock.py
@@ -1,0 +1,135 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "services/world_model")]
+
+from workbench_world_model import mock_verification, mock_world_state
+
+SCHEMA_DIR = ROOT / "interfaces" / "json_schema"
+FIXED_TIMESTAMP = "2026-08-04T00:00:16.200Z"
+
+
+def schema_validator(schema_name: str) -> Draft202012Validator:
+    resources = []
+    for path in sorted(SCHEMA_DIR.glob("*.schema.json")):
+        contents = json.loads(path.read_text(encoding="utf-8"))
+        resources.append((path.name, Resource.from_contents(contents)))
+    registry = Registry().with_resources(resources)
+    schema = json.loads((SCHEMA_DIR / schema_name).read_text(encoding="utf-8"))
+    return Draft202012Validator(schema, registry=registry)
+
+
+class WorldModelMockTests(unittest.TestCase):
+    def assert_schema_valid(self, payload: dict[str, object], schema_name: str) -> None:
+        json.dumps(payload)
+        errors = list(schema_validator(schema_name).iter_errors(payload))
+        self.assertEqual(errors, [], [error.message for error in errors])
+
+    def test_mock_world_state_is_complete_and_schema_valid(self) -> None:
+        state = mock_world_state("run-test-001")
+
+        self.assertIsInstance(state, dict)
+        self.assertEqual(state["run_id"], "run-test-001")
+        self.assertEqual(set(("run_id", "sequence_no", "state_hash", "entities", "reduced_at")) - state.keys(), set())
+        self.assertRegex(state["state_hash"], r"^[0-9a-f]{64}$")
+        self.assertEqual(state["reduced_at"], FIXED_TIMESTAMP)
+
+        entities = {entity["entity_id"]: entity for entity in state["entities"]}
+        self.assertIn("red_block", entities)
+        self.assertEqual(entities["red_block"]["entity_type"], "block")
+        self.assertGreater(len(entities["red_block"]["evidence_refs"]), 0)
+        self.assertIn("tray", entities)
+        self.assertEqual(entities["tray"]["entity_type"], "tray")
+        self.assertGreater(len(entities["tray"]["evidence_refs"]), 0)
+
+        inside_relations = [
+            relation
+            for relation in state["relations"]
+            if relation["subject_id"] == "red_block"
+            and relation["predicate"] == "inside"
+            and relation["object_id"] == "tray"
+        ]
+        self.assertEqual(len(inside_relations), 1)
+        self.assertGreater(len(inside_relations[0]["evidence_refs"]), 0)
+        self.assert_schema_valid(state, "world_state.schema.json")
+
+    def test_mock_verification_supports_all_schema_statuses(self) -> None:
+        expected = {
+            "confirmed": ("red_block inside tray", "goal_satisfied", 1.0, "none"),
+            "refuted": ("red_block inside tray", "goal_not_satisfied", 1.0, "retry_action"),
+            "insufficient_evidence": (
+                "red_block inside tray could not be verified",
+                "target_not_observed",
+                0.5,
+                "re_observe",
+            ),
+        }
+
+        for status, (claim, reason_code, completeness, recovery_hint) in expected.items():
+            with self.subTest(status=status):
+                result = mock_verification(status)
+                self.assertIsInstance(result, dict)
+                self.assertEqual(result["status"], status)
+                self.assertEqual(result["claim"], claim)
+                self.assertEqual(result["reason_code"], reason_code)
+                self.assertEqual(result["completeness"], completeness)
+                self.assertEqual(result["recovery_hint"], recovery_hint)
+                self.assertEqual(result["verified_at"], FIXED_TIMESTAMP)
+                self.assertGreater(len(result["evidence_refs"]), 0)
+                self.assert_schema_valid(result, "verification_result.schema.json")
+
+    def test_refuted_keeps_the_positive_claim(self) -> None:
+        result = mock_verification("refuted")
+
+        self.assertEqual(result["claim"], "red_block inside tray")
+
+    def test_insufficient_evidence_has_reason_and_recovery(self) -> None:
+        result = mock_verification("insufficient_evidence")
+
+        self.assertEqual(result["reason_code"], "target_not_observed")
+        self.assertEqual(result["recovery_hint"], "re_observe")
+        self.assertGreater(len(result["evidence_refs"]), 0)
+
+    def test_unknown_verification_status_raises_value_error(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported verification status"):
+            mock_verification("unknown")
+
+    def test_mock_outputs_are_deterministic_and_do_not_share_mutable_state(self) -> None:
+        first_state = mock_world_state("run-test-001")
+        second_state = mock_world_state("run-test-001")
+        self.assertEqual(first_state, second_state)
+
+        first_state["entities"][0]["evidence_refs"].append("mutated")
+        self.assertNotIn("mutated", second_state["entities"][0]["evidence_refs"])
+        self.assertEqual(second_state, mock_world_state("run-test-001"))
+
+        first_verification = mock_verification("confirmed")
+        second_verification = mock_verification("confirmed")
+        self.assertEqual(first_verification, second_verification)
+
+        first_verification["evidence_refs"].append("mutated")
+        self.assertNotIn("mutated", second_verification["evidence_refs"])
+        self.assertEqual(second_verification, mock_verification("confirmed"))
+
+    def test_mock_generation_does_not_use_runtime_world_model_services(self) -> None:
+        with (
+            patch("sqlite3.connect", side_effect=AssertionError("database accessed")),
+            patch("workbench_world_model.reducer.reduce_events", side_effect=AssertionError("reducer accessed")),
+            patch(
+                "workbench_world_model.verifier.verify_object_in_tray",
+                side_effect=AssertionError("verifier accessed"),
+            ),
+        ):
+            mock_world_state("run-test-001")
+            mock_verification("confirmed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Related Issue

Closes #122

- Human Owner: @kukuboring
- Module: World Model
- Task: B1 — 提供符合 Schema 的 WorldState 与 VerificationResult 假数据接口

## What changed

- 新增 `mock_world_state(run_id: str)`：
  - 保留调用者传入的 `run_id`；
  - 返回可 JSON 序列化、符合 `world_state.schema.json` 的普通字典；
  - 包含 `red_block`、`tray`、`inside` 关系和非空证据引用；
  - 使用固定时间戳和确定性的 Schema-shaped `state_hash`。
- 新增 `mock_verification(status: str)`：
  - 支持 `confirmed`、`refuted` 和 `insufficient_evidence`；
  - 返回符合 `verification_result.schema.json` 的普通字典；
  - 为三种状态提供一致的 claim、reason code、completeness、recovery hint 和证据；
  - 未知 status 明确抛出 `ValueError`。
- 从 `workbench_world_model` 包根导出两个 mock API。
- 新增正常、边界和失败行为单元测试。

## Interfaces affected

- 新增两个增量 Python API：
  - `mock_world_state(run_id: str)`
  - `mock_verification(status: str)`
- 未修改任何 JSON Schema。
- 未修改旧 Pydantic 模型。
- 未修改 reducer、event store 或 verifier。
- 未增加 `mock_world_event()`。
- 返回值按 Issue #122 的批准范围使用 Schema-shaped、JSON-serializable 普通字典。

## Tests and commands

专项测试：

```text
python3 -m pytest tests/unit/test_world_model_mock.py -v
7 passed