### PR TITLE
fix(lint): unblock the Ruff 0.16.3 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,17 +174,17 @@ Most code treats a successful write as a successful action. Here they're separat
 
 ```python
 ActionResult(
-    dispatch_state="sent",       # frame left the host
+    dispatch_state="sent",  # frame left the host
     device_state="unconfirmed",  # device hasn't replied
-    outcome="timeout"
+    outcome="timeout",
 )
 ```
 
 **2. Verification is three-valued, not boolean**
 
 ```python
-status = "confirmed"              # goal met, here's the evidence
-status = "refuted"                # goal definitely not met  
+status = "confirmed"  # goal met, here's the evidence
+status = "refuted"  # goal definitely not met
 status = "insufficient_evidence"  # can't tell, here's what's missing
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,17 +174,17 @@ python hardware/release/tools/check_release_readiness.py
 
 ```python
 ActionResult(
-    dispatch_state="sent",       # 帧离开了主机
+    dispatch_state="sent",  # 帧离开了主机
     device_state="unconfirmed",  # 设备还没回复
-    outcome="timeout"
+    outcome="timeout",
 )
 ```
 
 **2. 验证是三值的,不是布尔**
 
 ```python
-status = "confirmed"              # 目标达成,这是证据
-status = "refuted"                # 目标确实没达成  
+status = "confirmed"  # 目标达成,这是证据
+status = "refuted"  # 目标确实没达成
 status = "insufficient_evidence"  # 判断不了,这是缺的东西
 ```
 

--- a/docs/algorithms/world-model.md
+++ b/docs/algorithms/world-model.md
@@ -44,15 +44,10 @@ Correct:
 def state_hash(s: WorldState) -> str:
     canonical = {
         "run_id": s.run_id,
-        "entities": sorted(
-            (e.id, quantize(e.pose), confidence_bucket(e.confidence))
-            for e in s.entities
-        ),
+        "entities": sorted((e.id, quantize(e.pose), confidence_bucket(e.confidence)) for e in s.entities),
         "relations": sorted(s.relations),
     }
-    return hashlib.sha256(
-        json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()
-    ).hexdigest()
+    return hashlib.sha256(json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
 def quantize(p: Pose, eps: float = 1e-6) -> tuple:
@@ -95,8 +90,8 @@ An action result can carry an *earlier* timestamp than the observation that
 triggered it — different nodes, different clock offsets.
 
 ```python
-events.sort(key=lambda e: e.timestamp)     # wrong
-events.sort(key=lambda e: e.sequence_no)   # right
+events.sort(key=lambda e: e.timestamp)  # wrong
+events.sort(key=lambda e: e.sequence_no)  # right
 ```
 
 `sequence_no` establishes total order. Timestamps are diagnostic only and never
@@ -150,6 +145,7 @@ which?
 ```python
 from scipy.optimize import linear_sum_assignment
 
+
 def associate(observations, tracks, w1=1.0, w2=0.5, w3=0.2):
     C = np.zeros((len(observations), len(tracks)))
     for i, obs in enumerate(observations):
@@ -167,7 +163,7 @@ def associate(observations, tracks, w1=1.0, w2=0.5, w3=0.2):
         if C[i][j] < COST_THRESHOLD:
             matched.append((observations[i], tracks[j]))
         else:
-            new.append(observations[i])       # too expensive: new instance
+            new.append(observations[i])  # too expensive: new instance
     lost = [t for k, t in enumerate(tracks) if k not in col]
     return matched, new, lost
 ```
@@ -209,11 +205,12 @@ Half-life has to vary by object kind:
 
 ```python
 HALF_LIFE_S = {
-    "tray":        600.0,   # fixture. Position does not change unless moved
-    "table":       600.0,
-    "module":       15.0,   # can be moved by the arm or a person
-    "gripper_tip":   0.5,   # always moving; last frame is already stale
+    "tray": 600.0,  # fixture. Position does not change unless moved
+    "table": 600.0,
+    "module": 15.0,  # can be moved by the arm or a person
+    "gripper_tip": 0.5,  # always moving; last frame is already stale
 }
+
 
 def decay(conf: float, elapsed_s: float, kind: str) -> float:
     hl = HALF_LIFE_S[kind]
@@ -251,7 +248,7 @@ def resolve(obs_a, obs_b) -> Belief:
             ],
             recovery_hint="reobserve",
         )
-    return merge(obs_a, obs_b)      # merge only when they agree
+    return merge(obs_a, obs_b)  # merge only when they agree
 ```
 
 Same reasoning as three-valued verification: **the system does not guess.**
@@ -277,10 +274,10 @@ def containment(module_aabb, cavity_aabb) -> VerificationStatus:
     ratio = inter / volume(module_aabb)
 
     if ratio >= 0.95:
-        return CONFIRMED                  # fully contained
+        return CONFIRMED  # fully contained
     if ratio <= 0.01:
-        return REFUTED                    # fully separate
-    return INSUFFICIENT_EVIDENCE          # partial: caught on the rim
+        return REFUTED  # fully separate
+    return INSUFFICIENT_EVIDENCE  # partial: caught on the rim
 ```
 
 The middle band is the point. A boolean test forces "wedged on the tray edge"

--- a/firmware/virtual_mcu/workbench_virtual_mcu/state_machine.py
+++ b/firmware/virtual_mcu/workbench_virtual_mcu/state_machine.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class McuState(str, Enum):
+class McuState(StrEnum):
     IDLE = "idle"
     EXECUTING = "executing"
     SAFE_STOP = "safe_stop"

--- a/hardware/mechanical/tools/generate_artifacts.py
+++ b/hardware/mechanical/tools/generate_artifacts.py
@@ -229,7 +229,7 @@ def write_engineering_drawings(report: dict[str, object]) -> None:
 <line class="dim" x1="1120" y1="170" x2="1120" y2="530"/><text x="1140" y="370" class="note" transform="rotate(-90 1140 370)">{depth}</text>
 <rect x="675" y="185" width="390" height="330" fill="none" stroke="#e65c00" stroke-width="12" rx="24"/>
 <text x="700" y="565" class="note">8 TPU skin over 24 effective compliant stroke</text>
-<text x="660" y="625" class="note">CG Z={report['center_of_gravity_mm'][2]}; static tip angle={report['static_tip_angle_deg']} deg</text>
+<text x="660" y="625" class="note">CG Z={report["center_of_gravity_mm"][2]}; static tip angle={report["static_tip_angle_deg"]} deg</text>
 <text x="660" y="660" class="note">ISO 2768-m unless noted; prototype only until physical validation</text>
 </svg>"""
     (drawings / "general-arrangement.svg").write_text(svg, encoding="utf-8", newline="\n")

--- a/hardware/pcb/tools/electrical_checks.py
+++ b/hardware/pcb/tools/electrical_checks.py
@@ -52,7 +52,7 @@ def calculate() -> dict[str, object]:
         }
 
     worst_case = cases["JETSON_40W_MAXN"]
-    input_current_at_min_v = worst_case["input_currents_a"][f'{SPEC["input"]["minimum_v"]}V']
+    input_current_at_min_v = worst_case["input_currents_a"][f"{SPEC['input']['minimum_v']}V"]
     checks = {
         "all_load_cases_have_20_percent_headroom": all(case["pass"] for case in cases.values()),
         "input_current_below_fuse": input_current_at_min_v < SPEC["input"]["fuse_a"],

--- a/libs/contracts/workbench_contracts/models.py
+++ b/libs/contracts/workbench_contracts/models.py
@@ -1,10 +1,10 @@
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel, StringConstraints, model_validator
 
 
-class ActionType(str, Enum):
+class ActionType(StrEnum):
     OBSERVE = "observe"
     GRASP = "grasp"
     PLACE = "place"
@@ -13,7 +13,7 @@ class ActionType(str, Enum):
     STOP = "stop"
 
 
-class ActionStatus(str, Enum):
+class ActionStatus(StrEnum):
     SUCCEEDED = "succeeded"
     FAILED = "failed"
     TIMEOUT = "timeout"
@@ -21,7 +21,7 @@ class ActionStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
-class WorldEventType(str, Enum):
+class WorldEventType(StrEnum):
     OBSERVATION = "observation"
     ACTION_REQUEST = "action_request"
     ACTION_RESULT = "action_result"
@@ -29,12 +29,12 @@ class WorldEventType(str, Enum):
     FAULT = "fault"
 
 
-class ClockId(str, Enum):
+class ClockId(StrEnum):
     MONOTONIC = "monotonic"
     WALL = "wall"
 
 
-class McuFrameKind(str, Enum):
+class McuFrameKind(StrEnum):
     COMMAND = "command"
     ACK = "ack"
     TELEMETRY = "telemetry"
@@ -42,7 +42,7 @@ class McuFrameKind(str, Enum):
     STOP_ACK = "stop_ack"
 
 
-class McuOpcode(str, Enum):
+class McuOpcode(StrEnum):
     MOVE = "move"
     GRIP_OPEN = "grip_open"
     GRIP_CLOSE = "grip_close"
@@ -51,7 +51,7 @@ class McuOpcode(str, Enum):
     HEARTBEAT = "heartbeat"
 
 
-class McuFaultCode(str, Enum):
+class McuFaultCode(StrEnum):
     NONE = "none"
     ACK_TIMEOUT = "ack_timeout"
     STOP_TIMEOUT = "stop_timeout"
@@ -62,7 +62,7 @@ class McuFaultCode(str, Enum):
     MALFORMED_FRAME = "malformed_frame"
 
 
-class McuDeviceMode(str, Enum):
+class McuDeviceMode(StrEnum):
     IDLE = "idle"
     MOVING = "moving"
     HOLDING = "holding"
@@ -201,7 +201,7 @@ class Pose(BaseModel):
     orientation: Orientation
 
 
-class Detector(str, Enum):
+class Detector(StrEnum):
     APRILTAG = "apriltag"
     COLOUR_THRESHOLD = "colour_threshold"
     MOCK = "mock"
@@ -230,7 +230,7 @@ class SemanticAction(BaseModel):
     parameters: dict[str, Any] = Field(default_factory=dict)
 
 
-class ActionOutcome(str, Enum):
+class ActionOutcome(StrEnum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELED = "canceled"
@@ -238,7 +238,7 @@ class ActionOutcome(str, Enum):
     TIMEOUT = "timeout"
 
 
-class DispatchState(str, Enum):
+class DispatchState(StrEnum):
     """Whether the frame left the host. Not whether the device acted on it."""
 
     NOT_SENT = "not_sent"
@@ -246,7 +246,7 @@ class DispatchState(str, Enum):
     SEND_FAILED = "send_failed"
 
 
-class DeviceState(str, Enum):
+class DeviceState(StrEnum):
     """Whether the device confirmed. Separate from DispatchState by design:
     a written frame is not a confirmed action."""
 
@@ -298,7 +298,7 @@ class TaskGraph(BaseModel):
     model_route: str = "template"
 
 
-class VerificationStatus(str, Enum):
+class VerificationStatus(StrEnum):
     """Three-valued on purpose. A boolean would force the system to guess when
     the evidence does not support either answer."""
 
@@ -307,7 +307,7 @@ class VerificationStatus(str, Enum):
     INSUFFICIENT_EVIDENCE = "insufficient_evidence"
 
 
-class ReasonCode(str, Enum):
+class ReasonCode(StrEnum):
     GOAL_SATISFIED = "goal_satisfied"
     GOAL_NOT_SATISFIED = "goal_not_satisfied"
     TARGET_NOT_OBSERVED = "target_not_observed"
@@ -317,7 +317,7 @@ class ReasonCode(str, Enum):
     STALE_OBSERVATION = "stale_observation"
 
 
-class RecoveryHint(str, Enum):
+class RecoveryHint(StrEnum):
     RE_OBSERVE = "re_observe"
     RETRY_ACTION = "retry_action"
     ASK_CONFIRM = "ask_confirm"

--- a/libs/kernel/README.md
+++ b/libs/kernel/README.md
@@ -27,14 +27,16 @@ compiler.compile_all(py_output_dir, ts_output_dir)
 
 # Event logging
 store = EventStore(log_file)
-store.append({
-    "event_id": "event-1",
-    "run_id": "run-1",
-    "sequence_no": 0,
-    "event_type": "observation",
-    "occurred_at": "2026-08-13T00:00:00Z",
-    "payload": {"entity_id": "red_block"},
-})
+store.append(
+    {
+        "event_id": "event-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "event_type": "observation",
+        "occurred_at": "2026-08-13T00:00:00Z",
+        "payload": {"entity_id": "red_block"},
+    }
+)
 checkpoint = store.create_checkpoint()
 replayed_events = store.replay(from_checkpoint=checkpoint)
 

--- a/robot/control/workbench_motion/test/test_arm_config.py
+++ b/robot/control/workbench_motion/test/test_arm_config.py
@@ -69,9 +69,7 @@ def test_arm_yaml_agrees_with_srdf():
     groups = _srdf_groups(root)
 
     # Arm planning group exists under the name arm.yaml declares.
-    assert cfg.planning_group in groups, (
-        f"arm.yaml planning_group={cfg.planning_group!r} has no matching SRDF group " f"(SRDF groups: {sorted(groups)})"
-    )
+    assert cfg.planning_group in groups, f"missing SRDF arm group {cfg.planning_group!r}; groups={sorted(groups)}"
     # Its chain resolves IK to the tip arm.yaml names, rooted at base_link.
     chain = groups[cfg.planning_group].find("chain")
     assert chain is not None, f"SRDF group {cfg.planning_group!r} is not a chain group"
@@ -79,9 +77,7 @@ def test_arm_yaml_agrees_with_srdf():
     assert chain.get("tip_link") == cfg.ik_tip_link
 
     # Gripper group name matches too (arm.yaml gripper.planning_group).
-    assert cfg.gripper_group in groups, (
-        f"arm.yaml gripper_group={cfg.gripper_group!r} has no matching SRDF group " f"(SRDF groups: {sorted(groups)})"
-    )
+    assert cfg.gripper_group in groups, f"missing SRDF gripper group {cfg.gripper_group!r}; groups={sorted(groups)}"
 
 
 def test_parse_rejects_empty_joints():

--- a/services/agent_runtime/workbench_agent_runtime/planner.py
+++ b/services/agent_runtime/workbench_agent_runtime/planner.py
@@ -22,8 +22,7 @@ def _validate_plan(plan: TaskGraph) -> None:
         if not result.is_valid:
             messages = "; ".join(f"{error.field}: {error.message}" for error in result.errors)
             raise ValueError(
-                f"step '{step.step_id}' action '{step.action.action_id}' "
-                f"failed tool-registry validation: {messages}"
+                f"step '{step.step_id}' action '{step.action.action_id}' failed tool-registry validation: {messages}"
             )
 
 
@@ -438,8 +437,7 @@ def _validate_unique_parcel_identities(
             if previous is not None and previous[0] != parcel_id:
                 raw_value = attributes[key].strip()
                 raise ValueError(
-                    f"duplicate parcel identity {key}={raw_value!r}: "
-                    f"{previous[0]}.{previous[1]} and {parcel_id}.{key}"
+                    f"duplicate parcel identity {key}={raw_value!r}: {previous[0]}.{previous[1]} and {parcel_id}.{key}"
                 )
             seen[identity] = (parcel_id, key)
     return identities

--- a/services/agent_runtime/workbench_agent_runtime/policy_validator.py
+++ b/services/agent_runtime/workbench_agent_runtime/policy_validator.py
@@ -162,7 +162,7 @@ class PolicyValidator:
                     step_id,
                     action_id,
                     "parameters",
-                    f"forbidden keys for '{action.action_type.value}': " f"{sorted(extra)}; allowed: {sorted(allowed)}",
+                    f"forbidden keys for '{action.action_type.value}': {sorted(extra)}; allowed: {sorted(allowed)}",
                 )
             )
         if missing:
@@ -171,7 +171,7 @@ class PolicyValidator:
                     step_id,
                     action_id,
                     "parameters",
-                    f"missing required keys for '{action.action_type.value}': " f"{sorted(missing)}",
+                    f"missing required keys for '{action.action_type.value}': {sorted(missing)}",
                 )
             )
 

--- a/services/agent_runtime/workbench_agent_runtime/tool_registry.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_registry.py
@@ -179,14 +179,14 @@ class ToolRegistry:
             errors.append(
                 ValidationError(
                     "parameters",
-                    f"forbidden keys for '{action_type_value}': " f"{sorted(extra)}; allowed: {sorted(allowed)}",
+                    f"forbidden keys for '{action_type_value}': {sorted(extra)}; allowed: {sorted(allowed)}",
                 )
             )
         if missing:
             errors.append(
                 ValidationError(
                     "parameters",
-                    f"missing required keys for '{action_type_value}': " f"{sorted(missing)}",
+                    f"missing required keys for '{action_type_value}': {sorted(missing)}",
                 )
             )
         # early-exit when the field set is broken — type checking on a
@@ -271,7 +271,7 @@ class ToolRegistry:
                 errors.append(
                     ValidationError(
                         f"parameters.{key}",
-                        f"expected {_type_name(expected_type)}, " f"got {_type_label(value)}",
+                        f"expected {_type_name(expected_type)}, got {_type_label(value)}",
                     )
                 )
 
@@ -282,8 +282,7 @@ class ToolRegistry:
                 errors.append(
                     ValidationError(
                         "parameters.emotion_state",
-                        f"'{emotion}' is not a valid emotion state; "
-                        f"allowed: {sorted(_schemas.EXPRESS_EMOTION_STATES)}",
+                        f"'{emotion}' is not a valid emotion state; allowed: {sorted(_schemas.EXPRESS_EMOTION_STATES)}",
                     )
                 )
 
@@ -309,7 +308,7 @@ class ToolRegistry:
                     errors.append(
                         ValidationError(
                             "parameters.attributes",
-                            f"all observe attributes must be strings, got: " f"{[_type_label(a) for a in non_strings]}",
+                            f"all observe attributes must be strings, got: {[_type_label(a) for a in non_strings]}",
                         )
                     )
 

--- a/services/agent_runtime/workbench_agent_runtime/tool_schemas.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_schemas.py
@@ -34,7 +34,7 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
         "param_types": {},
     },
     ActionType.PLACE: {
-        "description": "Place a grasped entity into a destination.  target_id and " "destination_id are required.",
+        "description": "Place a grasped entity into a destination.  target_id and destination_id are required.",
         "target_id_required": True,
         "required_params": frozenset({"destination_id"}),
         "optional_params": frozenset(

--- a/services/world_model/workbench_world_model/verifier.py
+++ b/services/world_model/workbench_world_model/verifier.py
@@ -210,9 +210,7 @@ def verify_inspection_evidence(
         entity_id for entity_id in required if state.entity_confidence.get(entity_id, 0.0) < confidence_threshold
     )
     missing_evidence = _missing_entity_evidence(state, required)
-    claim = (
-        f"inspection: unobserved={unobserved}; low_confidence={low_confidence}; " f"missing_evidence={missing_evidence}"
-    )
+    claim = f"inspection: unobserved={unobserved}; low_confidence={low_confidence}; missing_evidence={missing_evidence}"
     if unobserved:
         outcome = (VerificationStatus.INSUFFICIENT_EVIDENCE, ReasonCode.TARGET_NOT_OBSERVED, RecoveryHint.RE_OBSERVE)
     elif low_confidence:

--- a/tests/unit/test_hardware_urdf.py
+++ b/tests/unit/test_hardware_urdf.py
@@ -117,8 +117,7 @@ class HardwareUrdfTests(unittest.TestCase):
 
     def test_rejects_duplicate_limit_elements(self) -> None:
         duplicate = UR5E_SHAPE_URDF.replace(
-            '<limit effort="150.0" lower="-6.283185307179586" upper="6.283185307179586" '
-            'velocity="3.141592653589793"/>',
+            '<limit effort="150.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>',
             """<limit effort="150.0" lower="-6.283185307179586" upper="6.283185307179586" velocity="3.141592653589793"/>
     <limit effort="1.0" lower="-1.0" upper="1.0" velocity="1.0"/>""",
             1,

--- a/tests/unit/test_kernel_communication_broker.py
+++ b/tests/unit/test_kernel_communication_broker.py
@@ -79,6 +79,6 @@ def test_broker_rejects_registered_content_that_is_not_a_schema(tmp_path: Path) 
     registry = VersionRegistry(tmp_path / "versions.json")
     registry.register_schema("action", "1.0.0", "not-a-schema")
     boundary = CommunicationBroker(registry)
-    with pytest.raises(BrokerValidationError, match="version.*not registered"):
+    with pytest.raises(BrokerValidationError, match=r"version.*not registered"):
         boundary.publish({}, "action", "1.0.0", "planner")
     assert boundary.message_log == []

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -121,5 +121,5 @@ def test_explicit_extra_forbid_and_unsupported_keywords_fail_closed(tmp_path: Pa
         encoding="utf-8",
     )
     compiler.load_schemas()
-    with pytest.raises(ValueError, match="unsupported.*format"):
+    with pytest.raises(ValueError, match=r"unsupported.*format"):
         compiler.compile_all(tmp_path / "bad-python", tmp_path / "bad-typescript")

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -103,7 +103,7 @@ def test_explicit_extra_forbid_and_unsupported_keywords_fail_closed(tmp_path: Pa
     schema_dir = tmp_path / "schemas"
     schema_dir.mkdir()
     (schema_dir / "strict.schema.json").write_text(
-        '{"title":"Strict","type":"object","additionalProperties":false,' '"properties":{"id":{"type":"string"}}}',
+        '{"title":"Strict","type":"object","additionalProperties":false,"properties":{"id":{"type":"string"}}}',
         encoding="utf-8",
     )
     compiler = SchemaCompiler(schema_dir)

--- a/tools/scripts/generate_report.py
+++ b/tools/scripts/generate_report.py
@@ -90,26 +90,26 @@ def generate(metrics: list[dict[str, Any]], labels: list[str], commit: str, seed
 ## 安全与正确性
 
 | 指标 | {columns} | 门槛 |
-|---|{'---|' * len(labels)}---|
-{row('误判完成', 'false_completion_count', count, f'0 ({safety_gate})')}
-{row('碰撞', 'collision_count', count, '0')}
-{row('模型越权', 'policy_violation_count', count, '0')}
+|---|{"---|" * len(labels)}---|
+{row("误判完成", "false_completion_count", count, f"0 ({safety_gate})")}
+{row("碰撞", "collision_count", count, "0")}
+{row("模型越权", "policy_violation_count", count, "0")}
 
 ## 任务与证据
 
 | 指标 | {columns} | 门槛 |
-|---|{'---|' * len(labels)}---|
-{row('VTCR', 'vtcr', percent, '>= 80%')}
-{row('任务时间 P50', 'task_duration_p50_s', seconds, '-')}
-{row('任务时间 P95', 'task_duration_p95_s', seconds, '< 120s')}
-{row('恢复率', 'recovery_rate', percent, '>= 70%')}
-{row('验证证据覆盖率', 'evidence_coverage', percent, '100%')}
-{row('state hash 一致性', 'state_hash_consistency', percent, '100%')}
-{row('回放成功率', 'replay_success_rate', percent, '>= 95%')}
-{row('任务族数量', 'task_family_count', count, '>= 5')}
-{row('复杂任务占比', 'complex_task_rate', percent, '>= 50%')}
-{row('平均观测实体数', 'mean_observed_entities', decimal, '>= 2')}
-{row('目标条件覆盖率', 'goal_condition_coverage', percent, '100%')}
+|---|{"---|" * len(labels)}---|
+{row("VTCR", "vtcr", percent, ">= 80%")}
+{row("任务时间 P50", "task_duration_p50_s", seconds, "-")}
+{row("任务时间 P95", "task_duration_p95_s", seconds, "< 120s")}
+{row("恢复率", "recovery_rate", percent, ">= 70%")}
+{row("验证证据覆盖率", "evidence_coverage", percent, "100%")}
+{row("state hash 一致性", "state_hash_consistency", percent, "100%")}
+{row("回放成功率", "replay_success_rate", percent, ">= 95%")}
+{row("任务族数量", "task_family_count", count, ">= 5")}
+{row("复杂任务占比", "complex_task_rate", percent, ">= 50%")}
+{row("平均观测实体数", "mean_observed_entities", decimal, ">= 2")}
+{row("目标条件覆盖率", "goal_condition_coverage", percent, "100%")}
 
 ## 数据资格
 
@@ -125,7 +125,7 @@ def generate(metrics: list[dict[str, Any]], labels: list[str], commit: str, seed
 
 {reason_lines}
 
-人工审核人: `{metrics[-1].get('false_completion_reviewed_by') or '待填写'}`<br>
+人工审核人: `{metrics[-1].get("false_completion_reviewed_by") or "待填写"}`<br>
 Product Owner 签字: ____________________
 """
 

--- a/tools/scripts/validate_contracts.py
+++ b/tools/scripts/validate_contracts.py
@@ -79,7 +79,7 @@ def check_every_schema_is_registered() -> list[str]:
     problems = []
     for stem in sorted(on_disk - registered):
         problems.append(
-            f"{stem}.schema.json is not registered here; add an example for it, " "or register it as None with a reason"
+            f"{stem}.schema.json is not registered here; add an example for it, or register it as None with a reason"
         )
     for stem in sorted(registered - on_disk):
         problems.append(f"{stem} is registered here but no such schema exists")

--- a/tools/scripts/validate_scenarios.py
+++ b/tools/scripts/validate_scenarios.py
@@ -40,8 +40,7 @@ def main() -> int:
         expected_total = len(frozen) + 6 * len(SCENE_TASKS)
         if len(frozen) + len(expanded) != expected_total:
             raise RuntimeError(
-                f"expanded benchmark must contain {expected_total} total scenarios, "
-                f"found {len(frozen) + len(expanded)}"
+                f"expanded benchmark must contain {expected_total} total scenarios, found {len(frozen) + len(expanded)}"
             )
         variants = {manifest.get("scene_variant") for manifest in expanded}
         if not P2_SCENE_VARIANTS.issubset(variants):


### PR DESCRIPTION
## 问题

PR #120 将 Ruff 升级到 0.16.3 后触发新的规则与格式门禁：

- 16 处 `UP042`：`class X(str, Enum)` 需迁移为 `StrEnum`
- 2 处 `RUF043`：`pytest.raises(match=...)` 的正则需使用 raw string
- 新版 formatter 对 17 个现有文件产生机械格式差异

## 变更

- 将 contracts 与 Virtual MCU 的字符串枚举迁移到 `StrEnum`
- 包含最新 `main` 新增的 4 个 MCU frame 枚举，避免升级后继续报 `UP042`
- 修复两处 pytest 正则模式
- 应用 Ruff 0.16.3 的机械格式迁移；不改变运行逻辑
- 缩短两条 Motion 测试失败信息，使 Ruff 0.6.9 与 0.16.3 均保持格式稳定

## 影响分析

- 已验证仓库无代码依赖 `str(EnumValue)` 的旧限定名输出
- `StrEnum.__str__()` 返回枚举值，符合 JSON 序列化需求
- 不修改 JSON Schema 或协议值

## 验证

- [x] Ruff 0.6.9 check + format
- [x] Ruff 0.16.3 check + format
- [x] `make check`
- [x] 326 tests passed
- [x] contract、scenario、golden、context checks passed
- [x] scripted/offline demos passed

## 解除阻塞

合并此 PR 后可重新验证并合并 #120。

Refs: #120