### PR TITLE
feat(kernel): migrate EventStore to SQLite with verified snapshots

### DIFF
--- a/docs/task_packets/kernel-sqlite-event-store.json
+++ b/docs/task_packets/kernel-sqlite-event-store.json
@@ -1,0 +1,31 @@
+{
+  "issue": 90,
+  "human_owner": "Quchaosheng",
+  "objective": "Migrate runtime event evidence from JSONL to SQLite with persistent checkpoints and verified backup/restore.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/event_store.py",
+    "libs/kernel/tests/**",
+    "tests/unit/test_kernel_event_store.py",
+    "libs/kernel/README.md",
+    "docs/task_packets/kernel-sqlite-event-store.json"
+  ],
+  "read_only_paths": ["interfaces/**", "AGENTS.md"],
+  "forbidden": ["robot/control/**", "firmware/**", "interfaces/**"],
+  "acceptance": [
+    "SQLite stores strict events and checkpoints across restart",
+    "strict JSONL migration validates before writing",
+    "snapshot restore verifies schema, checksum, integrity, and event count before atomic replacement",
+    "corrupt, torn, duplicate, mixed-run, and sequence-invalid data fails closed",
+    "a repeatable benchmark reports append and replay throughput"
+  ],
+  "commands": [
+    "python3 libs/kernel/tests/benchmark_event_store.py",
+    "python3 -m pytest tests/unit/test_kernel_event_store.py libs/kernel/tests -q"
+  ],
+  "evidence": ["SQLite restart/checkpoint assertions", "backup checksum assertions", "benchmark output"],
+  "stop_conditions": [
+    "a PostgreSQL driver or DSN is required",
+    "cross-process locking or distributed retention is required",
+    "schema/interface changes are required"
+  ]
+}

--- a/libs/kernel/README.md
+++ b/libs/kernel/README.md
@@ -9,7 +9,7 @@
 - **K1-K2**: Schema Compiler (JSON Schema → TypeScript + Python)
 - **K3**: Version Registry (schema version management)
 - **K4-K5**: Communication Layer (versioned messages + schema validation)
-- **K6-K7**: Event Store (append-only JSONL log with replay)
+- **K6-K7**: Event Store (append-only SQLite log with replay and checkpoints)
 - **K8**: ROS 2 Lifecycle (created → configured → active → deactivated → finalized)
 - **K9-K10**: System Startup (bootstrap + checklist)
 
@@ -17,7 +17,7 @@
 
 ```python
 from workbench.kernel.schema_compiler import SchemaCompiler
-from workbench.kernel.event_store import EventStore
+from workbench.kernel.event_store import EventStore, migrate_jsonl
 from workbench.kernel.lifecycle import LifecycleManager
 
 # Schema compilation
@@ -26,7 +26,7 @@ compiler.load_schemas()
 compiler.compile_all(py_output_dir, ts_output_dir)
 
 # Event logging
-store = EventStore(log_file)
+store = EventStore("runs/events.sqlite3")
 store.append({
     "event_id": "event-1",
     "run_id": "run-1",
@@ -38,14 +38,31 @@ store.append({
 checkpoint = store.create_checkpoint()
 replayed_events = store.replay(from_checkpoint=checkpoint)
 
+# One-time migration from a strict JSONL log:
+migrate_jsonl("runs/events.jsonl", "runs/events.sqlite3")
+
+# Backup/restore verifies a SHA-256 manifest before replacement:
+store.backup("runs/events.snapshot.sqlite3")
+restored = EventStore.restore("runs/events.snapshot.sqlite3", "runs/events-restored.sqlite3")
+
 # System lifecycle
 manager = LifecycleManager()
 node = manager.create_node("kernel")
 manager.startup_sequence()
 ```
 
-The default Event Store accepts one contiguous, contract-shaped run. Open legacy
-object logs with `EventStore(path, legacy_objects=True)` only while migrating them.
+The SQLite backend is the recommended runtime store. It persists checkpoints and
+keeps the complete event JSON so unknown extension fields survive migration.
+`.jsonl` remains a compatibility backend; open legacy object logs with
+`EventStore(path, legacy_objects=True)` only while migrating them. PostgreSQL is
+intentionally not bundled: add the approved DB-API driver and adapter when a
+deployment supplies a PostgreSQL DSN.
+
+Snapshots use SQLite's online backup API plus a SHA-256 sidecar manifest. Close
+the destination store before restore; checksum, schema version, database
+integrity and event count are checked before atomic replacement. Keep one daily
+snapshot for 30 days. The initial local target is RPO <= 24 hours and RTO <= 30
+minutes; deployment owners must tighten those values from measured restore drills.
 
 ## Tests
 

--- a/libs/kernel/tests/benchmark_event_store.py
+++ b/libs/kernel/tests/benchmark_event_store.py
@@ -1,0 +1,45 @@
+"""Small reproducible SQLite event-store benchmark; no third-party runner needed."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from workbench.kernel.event_store import EventStore
+
+
+def event(index: int) -> dict:
+    return {
+        "event_id": f"bench-{index}",
+        "run_id": "benchmark",
+        "sequence_no": index,
+        "event_type": "observation",
+        "occurred_at": "2026-08-18T00:00:00Z",
+        "payload": {"index": index},
+        "evidence_refs": [],
+    }
+
+
+def main() -> int:
+    count = 250
+    with tempfile.TemporaryDirectory() as directory:
+        store = EventStore(Path(directory) / "events.sqlite3")
+        started = time.perf_counter()
+        store.append_many([event(index) for index in range(count)])
+        append_seconds = time.perf_counter() - started
+        started = time.perf_counter()
+        replayed = store.replay()
+        replay_seconds = time.perf_counter() - started
+        assert len(replayed) == count
+        print(f"sqlite append: {count / append_seconds:.1f} events/s")
+        print(f"sqlite replay: {count / replay_seconds:.1f} events/s")
+        store.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/kernel/workbench/kernel/event_store.py
+++ b/libs/kernel/workbench/kernel/event_store.py
@@ -1,7 +1,14 @@
-"""K6-K7: Event Store"""
+"""Append-only event storage with a strict JSONL compatibility path and SQLite backend."""
 
+from __future__ import annotations
+
+import hashlib
 import json
+import os
+import shutil
+import sqlite3
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -21,20 +28,76 @@ EVENT_TYPES = {
     "recovery_complete",
 }
 REQUIRED_EVENT_FIELDS = {"event_id", "run_id", "sequence_no", "event_type", "occurred_at", "payload"}
+SQLITE_SUFFIXES = {".db", ".sqlite", ".sqlite3"}
+SCHEMA_VERSION = 1
 
 
 class EventStoreError(ValueError):
-    """Raised when the persisted event log cannot be replayed safely."""
+    """Raised when persisted evidence cannot be written or replayed safely."""
 
 
 class EventStore:
-    def __init__(self, log_file: Path, *, legacy_objects: bool = False):
-        self.log_file = log_file
+    """Persist one contiguous event run.
+
+    SQLite is the default for database-looking paths (``.sqlite3``, ``.sqlite``
+    and ``.db``). ``.jsonl`` remains an explicit compatibility format so old
+    logs can be inspected and migrated without silently changing their meaning.
+    """
+
+    def __init__(self, log_file: Path, *, legacy_objects: bool = False, backend: str | None = None):
+        self.log_file = Path(log_file)
         self.legacy_objects = legacy_objects
+        self.backend = backend or ("sqlite" if self.log_file.suffix.lower() in SQLITE_SUFFIXES else "jsonl")
+        if self.backend not in {"jsonl", "sqlite"}:
+            raise ValueError("backend must be 'jsonl' or 'sqlite'")
+        if self.backend == "sqlite" and legacy_objects:
+            raise ValueError("legacy_objects is only supported by the JSONL compatibility backend")
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
         self.events: list[dict[str, Any]] = []
         self.checkpoints: list[int] = []
         self._lock = threading.RLock()
+        self._connection: sqlite3.Connection | None = None
+        if self.backend == "sqlite":
+            self._connection = sqlite3.connect(self.log_file)
+            self._connection.execute("PRAGMA foreign_keys = ON")
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS event_store_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                """
+            )
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    sequence_no INTEGER NOT NULL UNIQUE,
+                    event_json TEXT NOT NULL
+                );
+                """
+            )
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS checkpoints (
+                    checkpoint_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_count INTEGER NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                """
+            )
+            self._connection.execute(
+                "INSERT OR IGNORE INTO event_store_meta(key, value) VALUES ('schema_version', ?)",
+                (str(SCHEMA_VERSION),),
+            )
+            self._connection.commit()
+            self.checkpoints = [
+                row[0]
+                for row in self._connection.execute(
+                    "SELECT event_count FROM checkpoints ORDER BY checkpoint_id"
+                ).fetchall()
+            ]
 
     def _validate_events(self, events: list[dict[str, Any]]) -> None:
         if self.legacy_objects:
@@ -76,7 +139,7 @@ class EventStore:
             if not isinstance(evidence_refs, list) or any(not isinstance(ref, str) for ref in evidence_refs):
                 raise EventStoreError(f"event at index {index} evidence_refs must be a string list")
 
-    def _read_events(self) -> list[dict[str, Any]]:
+    def _read_jsonl(self) -> list[dict[str, Any]]:
         if not self.log_file.exists():
             return []
         events = []
@@ -97,30 +160,102 @@ class EventStore:
         self._validate_events(events)
         return events
 
+    def _read_sqlite(self) -> list[dict[str, Any]]:
+        assert self._connection is not None
+        try:
+            version = self._connection.execute(
+                "SELECT value FROM event_store_meta WHERE key = 'schema_version'"
+            ).fetchone()
+            if version != (str(SCHEMA_VERSION),):
+                raise EventStoreError("event database schema version mismatch")
+            rows = self._connection.execute(
+                "SELECT event_id, run_id, sequence_no, event_json FROM events ORDER BY sequence_no"
+            ).fetchall()
+            events = []
+            for index, (event_id, run_id, sequence_no, encoded) in enumerate(rows):
+                try:
+                    event = json.loads(encoded)
+                except (TypeError, json.JSONDecodeError) as exc:
+                    raise EventStoreError(f"invalid event JSON in SQLite row {index}") from exc
+                if not isinstance(event, dict):
+                    raise EventStoreError(f"event in SQLite row {index} must be an object")
+                if (event.get("event_id"), event.get("run_id"), event.get("sequence_no")) != (
+                    event_id,
+                    run_id,
+                    sequence_no,
+                ):
+                    raise EventStoreError(f"indexed fields disagree with SQLite row {index}")
+                events.append(event)
+            self._validate_events(events)
+            return events
+        except sqlite3.DatabaseError as exc:
+            raise EventStoreError(f"event database is unavailable or corrupt: {self.log_file}") from exc
+
+    def _read_events(self) -> list[dict[str, Any]]:
+        return self._read_jsonl() if self.backend == "jsonl" else self._read_sqlite()
+
     def append(self, event: dict[str, Any]) -> None:
         if not isinstance(event, dict):
             raise TypeError("event must be an object")
+        self.append_many([event])
+
+    def append_many(self, new_events: list[dict[str, Any]]) -> None:
+        """Append a validated batch in one transaction."""
+        if any(not isinstance(event, dict) for event in new_events):
+            raise TypeError("event must be an object")
         try:
-            serialized = json.dumps(event, allow_nan=False, ensure_ascii=False, separators=(",", ":"))
+            serialized = [
+                json.dumps(event, allow_nan=False, ensure_ascii=False, separators=(",", ":")) for event in new_events
+            ]
         except (TypeError, ValueError) as exc:
             raise EventStoreError("event must contain strict JSON values") from exc
-        persisted_event = json.loads(serialized)
+        persisted_events = [json.loads(encoded) for encoded in serialized]
         with self._lock:
             events = self._read_events()
-            self._validate_events([*events, persisted_event])
-            try:
-                with self.log_file.open("a", encoding="utf-8", newline="\n") as handle:
-                    handle.write(serialized + "\n")
-            except OSError as exc:
-                raise EventStoreError(f"event log could not be appended: {self.log_file}") from exc
-            self.events = [*events, persisted_event]
+            self._validate_events([*events, *persisted_events])
+            if self.backend == "jsonl":
+                try:
+                    with self.log_file.open("a", encoding="utf-8", newline="\n") as handle:
+                        handle.writelines(f"{encoded}\n" for encoded in serialized)
+                except OSError as exc:
+                    raise EventStoreError(f"event log could not be appended: {self.log_file}") from exc
+            else:
+                assert self._connection is not None
+                try:
+                    self._connection.executemany(
+                        "INSERT INTO events(event_id, run_id, sequence_no, event_json) VALUES (?, ?, ?, ?)",
+                        [
+                            (event["event_id"], event["run_id"], event["sequence_no"], encoded)
+                            for event, encoded in zip(persisted_events, serialized, strict=True)
+                        ],
+                    )
+                    self._connection.commit()
+                except sqlite3.DatabaseError as exc:
+                    self._connection.rollback()
+                    raise EventStoreError(f"event database could not be appended: {self.log_file}") from exc
+            self.events = [*events, *persisted_events]
 
     def create_checkpoint(self) -> int:
         with self._lock:
             self.events = self._read_events()
-            checkpoint_id = len(self.events)
-            self.checkpoints.append(checkpoint_id)
-            return checkpoint_id
+            checkpoint = len(self.events)
+            if self.backend == "sqlite":
+                assert self._connection is not None
+                try:
+                    self._connection.execute("INSERT INTO checkpoints(event_count) VALUES (?)", (checkpoint,))
+                    self._connection.commit()
+                except sqlite3.DatabaseError as exc:
+                    self._connection.rollback()
+                    raise EventStoreError("checkpoint could not be persisted") from exc
+                self.checkpoints = [
+                    row[0]
+                    for row in self._connection.execute(
+                        "SELECT event_count FROM checkpoints ORDER BY checkpoint_id"
+                    ).fetchall()
+                ]
+            else:
+                self.checkpoints.append(checkpoint)
+            return checkpoint
 
     def replay(self, from_checkpoint: int | None = None) -> list[dict[str, Any]]:
         with self._lock:
@@ -133,7 +268,119 @@ class EventStore:
     def verify_integrity(self) -> bool:
         with self._lock:
             try:
+                if self.backend == "sqlite":
+                    assert self._connection is not None
+                    result = self._connection.execute("PRAGMA integrity_check").fetchone()
+                    if result != ("ok",):
+                        return False
                 self._read_events()
-            except EventStoreError:
+            except (EventStoreError, sqlite3.DatabaseError):
                 return False
             return True
+
+    def backup(self, destination: Path) -> Path:
+        """Create a checksummed SQLite snapshot and return its manifest path."""
+        if self.backend != "sqlite":
+            raise EventStoreError("backup requires the SQLite backend")
+        destination = Path(destination)
+        if destination.resolve() == self.log_file.resolve():
+            raise EventStoreError("snapshot destination must differ from the live database")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temp = destination.with_name(f".{destination.name}.backup-tmp")
+        if temp.exists():
+            temp.unlink()
+        with self._lock:
+            assert self._connection is not None
+            self._connection.commit()
+            target = sqlite3.connect(temp)
+            try:
+                self._connection.backup(target)
+            finally:
+                target.close()
+            self._read_events()
+        manifest = {
+            "format": "workbench-event-store-snapshot",
+            "database": "sqlite",
+            "sqlite_version": sqlite3.sqlite_version,
+            "schema_version": SCHEMA_VERSION,
+            "event_count": len(self.events),
+            "created_at": datetime.now(UTC).isoformat(),
+            "sha256": _sha256(temp),
+        }
+        manifest_path = Path(f"{destination}.manifest.json")
+        manifest_temp = Path(f"{temp}.manifest.json")
+        manifest_temp.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temp, destination)
+        os.replace(manifest_temp, manifest_path)
+        return manifest_path
+
+    @classmethod
+    def restore(cls, snapshot: Path, destination: Path) -> EventStore:
+        """Verify a snapshot before atomically replacing a destination database."""
+        snapshot = Path(snapshot)
+        destination = Path(destination)
+        if snapshot.resolve() == destination.resolve():
+            raise EventStoreError("restore destination must differ from the snapshot")
+        manifest_path = Path(f"{snapshot}.manifest.json")
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise EventStoreError("snapshot manifest is unavailable or malformed") from exc
+        if (
+            manifest.get("format") != "workbench-event-store-snapshot"
+            or manifest.get("schema_version") != SCHEMA_VERSION
+            or manifest.get("sha256") != _sha256(snapshot)
+        ):
+            raise EventStoreError("snapshot checksum or schema version mismatch")
+        probe = cls(snapshot, backend="sqlite")
+        try:
+            if not probe.verify_integrity() or len(probe.replay()) != manifest.get("event_count"):
+                raise EventStoreError("snapshot failed integrity or event-count verification")
+        finally:
+            probe.close()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temp = destination.with_name(f".{destination.name}.restore-tmp")
+        shutil.copy2(snapshot, temp)
+        os.replace(temp, destination)
+        shutil.copy2(manifest_path, Path(f"{destination}.manifest.json"))
+        return cls(destination, backend="sqlite")
+
+    def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    def __enter__(self) -> EventStore:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def migrate_jsonl(source: Path, destination: Path) -> EventStore:
+    """Migrate a strict JSONL log into SQLite after validating every event."""
+    source_store = EventStore(source, backend="jsonl")
+    events = source_store.replay()
+    destination = Path(destination)
+    if destination.exists():
+        raise EventStoreError(f"migration destination already exists: {destination}")
+    temp = destination.with_name(f".{destination.name}.migration-tmp")
+    if temp.exists():
+        temp.unlink()
+    target = EventStore(temp, backend="sqlite")
+    try:
+        target.append_many(events)
+        target.close()
+        os.replace(temp, destination)
+    except Exception:
+        target.close()
+        raise
+    return EventStore(destination, backend="sqlite")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/tests/unit/test_kernel_event_store.py
+++ b/tests/unit/test_kernel_event_store.py
@@ -7,7 +7,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 
-from workbench.kernel.event_store import EventStore, EventStoreError
+from workbench.kernel.event_store import EventStore, EventStoreError, migrate_jsonl
 
 
 def event(event_id: int, *, run_id: str = "run-1", sequence_no: int | None = None) -> dict:
@@ -118,3 +118,52 @@ def test_legacy_object_mode_is_explicit(tmp_path: Path) -> None:
     store.append({"id": 0})
     assert store.verify_integrity()
     assert store.replay() == [{"id": 0}]
+
+
+def test_sqlite_restart_checkpoint_and_unknown_fields(tmp_path: Path) -> None:
+    database = tmp_path / "events.sqlite3"
+    first = EventStore(database)
+    first.append({**event(0), "extension": {"source": "bench"}})
+    first.append(event(1))
+    checkpoint = first.create_checkpoint()
+    first.close()
+
+    reopened = EventStore(database)
+    assert reopened.checkpoints == [2]
+    assert reopened.replay(from_checkpoint=checkpoint) == []
+    assert reopened.replay()[0]["extension"] == {"source": "bench"}
+    assert reopened.verify_integrity()
+    reopened.close()
+
+
+def test_jsonl_migration_and_verified_restore(tmp_path: Path) -> None:
+    source = tmp_path / "events.jsonl"
+    legacy = EventStore(source)
+    legacy.append(event(0))
+    legacy.append(event(1))
+    database = tmp_path / "events.sqlite3"
+    migrated = migrate_jsonl(source, database)
+    assert migrated.replay() == [event(0), event(1)]
+    snapshot = tmp_path / "events.snapshot.sqlite3"
+    manifest = migrated.backup(snapshot)
+    metadata = json.loads(manifest.read_text(encoding="utf-8"))
+    migrated.close()
+    restored = EventStore.restore(snapshot, tmp_path / "restored.sqlite3")
+    assert manifest.exists()
+    assert metadata["database"] == "sqlite"
+    assert metadata["sqlite_version"]
+    assert metadata["created_at"].endswith("+00:00")
+    assert restored.replay() == [event(0), event(1)]
+    restored.close()
+
+    snapshot.write_bytes(snapshot.read_bytes() + b"tamper")
+    with pytest.raises(EventStoreError, match="checksum"):
+        EventStore.restore(snapshot, tmp_path / "rejected.sqlite3")
+
+
+def test_sqlite_batch_is_atomic_on_contract_failure(tmp_path: Path) -> None:
+    store = EventStore(tmp_path / "events.sqlite3")
+    with pytest.raises(EventStoreError, match="contiguous"):
+        store.append_many([event(0), event(2)])
+    assert store.replay() == []
+    store.close()


### PR DESCRIPTION
## Related Issue

Refs #90. This PR covers the kernel storage migration, persistent checkpoints, snapshot integrity, and replay-equivalence portion.

## What changed

- add a standard-library SQLite backend while keeping strict JSONL as an explicit migration/compatibility path
- persist checkpoints across restart and validate indexed fields against complete event JSON
- add atomic batch append, checksummed online backup, fail-closed restore, and JSONL-to-SQLite migration
- add a repeatable append/replay benchmark and focused regression coverage

## Interfaces affected

No schema or `interfaces/` changes. Existing `.jsonl` callers remain compatible; `.sqlite`, `.sqlite3`, and `.db` select SQLite. PostgreSQL is intentionally deferred until an approved driver and deployment DSN exist.

## Tests and commands

- `python -m pytest tests/unit/test_kernel_event_store.py -q` — 15 passed
- `python libs/kernel/tests/benchmark_event_store.py` — about 50k append events/s and 274k replay events/s on this host
- `python tools/scripts/validate_contracts.py` — passed
- `ruff check` on changed Python files — passed

## Evidence

- restart checkpoint assertions
- migration and atomic-batch assertions
- snapshot metadata/checksum/tamper/restore-equivalence assertions
- benchmark output

## Risks and rollback

SQLite is single-host storage; distributed PostgreSQL operation remains out of scope. Revert this PR to return to JSONL-only behavior; existing JSONL files are not modified by migration.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.