### PR TITLE
feat(api): publish versioned read-only OpenAPI contract

### DIFF
--- a/docs/api-openapi-v1.json
+++ b/docs/api-openapi-v1.json
@@ -1,0 +1,154 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Workbench Desk Robot read-only API",
+    "version": "1.0.0",
+    "description": "Read-only run, event, readiness, and expression projections. No endpoint grants robot or ROS control authority."
+  },
+  "servers": [{"url": "/"}],
+  "paths": {
+    "/healthz": {
+      "get": {
+        "operationId": "health",
+        "responses": {"200": {"description": "Process is responding.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Health"}}}}}
+      }
+    },
+    "/readyz": {
+      "get": {
+        "operationId": "readiness",
+        "responses": {
+          "200": {"description": "Event source is readable.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Readiness"}}}},
+          "503": {"description": "Event source is unavailable or malformed.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/openapi.json": {
+      "get": {"operationId": "apiContract", "responses": {"200": {"description": "This contract.", "content": {"application/json": {"schema": {"type": "object"}}}}}}
+    },
+    "/api/v1/runs": {
+      "get": {
+        "operationId": "listRuns",
+        "responses": {
+          "200": {"description": "Ordered run summaries.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/RunList"}}}},
+          "503": {"description": "Invalid source.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/runs/{run_id}": {
+      "get": {
+        "operationId": "getRun",
+        "parameters": [{"$ref": "#/components/parameters/RunId"}],
+        "responses": {
+          "200": {"description": "Run summary.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/RunDetail"}}}},
+          "400": {"description": "Identifier is empty or outside the allowed character set.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "404": {"description": "Run does not exist.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "413": {"description": "Response exceeds 4 MiB.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/runs/{run_id}/events": {
+      "get": {
+        "operationId": "getRunEvents",
+        "parameters": [{"$ref": "#/components/parameters/RunId"}],
+        "responses": {
+          "200": {"description": "Run summary and contiguous events.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/RunEvents"}}}},
+          "400": {"description": "Invalid run identifier.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "404": {"description": "Run does not exist.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "413": {"description": "Response exceeds 4 MiB.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "503": {"description": "Event source is unavailable or malformed.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/expression-states": {
+      "get": {"operationId": "expressionContract", "responses": {"200": {"description": "Expression states and transitions.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExpressionContract"}}}}}}
+    }
+  },
+  "components": {
+    "parameters": {
+      "RunId": {
+        "name": "run_id",
+        "in": "path",
+        "required": true,
+        "description": "1-128 ASCII letters, digits, dot, underscore, colon, or hyphen.",
+        "schema": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"}
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {"error": {"type": "string"}, "message": {"type": "string"}, "run_id": {"type": "string"}}
+      },
+      "Health": {
+        "type": "object",
+        "required": ["status", "service", "version"],
+        "properties": {"status": {"const": "ok"}, "service": {"type": "string"}, "version": {"type": "string"}}
+      },
+      "Readiness": {
+        "type": "object",
+        "required": ["status", "data_source"],
+        "properties": {"status": {"enum": ["ready", "not_ready"]}, "data_source": {"type": "string"}}
+      },
+      "Event": {
+        "type": "object",
+        "required": ["event_id", "run_id", "sequence_no", "event_type", "occurred_at", "payload"],
+        "properties": {
+          "event_id": {"type": "string", "minLength": 1},
+          "run_id": {"type": "string", "minLength": 1},
+          "sequence_no": {"type": "integer", "minimum": 0},
+          "event_type": {"type": "string", "minLength": 1},
+          "occurred_at": {"type": "string", "minLength": 1},
+          "payload": {"type": "object"},
+          "evidence_refs": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "RunSummary": {
+        "type": "object",
+        "required": ["run_id", "status", "expression", "event_count", "visible_event_count", "safety"],
+        "properties": {
+          "run_id": {"type": "string"},
+          "status": {"type": "string"},
+          "expression": {"enum": ["idle", "thinking", "uncertain", "pleased"]},
+          "event_count": {"type": "integer", "minimum": 1},
+          "visible_event_count": {"type": "integer", "minimum": 1},
+          "evidence_refs": {"type": "array", "items": {"type": "string"}},
+          "safety": {"type": "object", "required": ["hardware_estop", "software_control"]}
+        },
+        "additionalProperties": true
+      },
+      "RunList": {
+        "type": "object",
+        "required": ["runs", "read_only"],
+        "properties": {"runs": {"type": "array", "items": {"$ref": "#/components/schemas/RunSummary"}}, "read_only": {"const": true}}
+      },
+      "RunDetail": {
+        "type": "object",
+        "required": ["run"],
+        "properties": {"run": {"$ref": "#/components/schemas/RunSummary"}}
+      },
+      "RunEvents": {
+        "type": "object",
+        "required": ["run", "events"],
+        "properties": {
+          "run": {"$ref": "#/components/schemas/RunSummary"},
+          "events": {"type": "array", "minItems": 1, "maxItems": 10000, "items": {"$ref": "#/components/schemas/Event"}}
+        }
+      },
+      "ExpressionContract": {
+        "type": "object",
+        "required": ["states", "transitions"],
+        "properties": {
+          "states": {"type": "array", "items": {"enum": ["idle", "thinking", "uncertain", "pleased"]}},
+          "transitions": {"type": "object"}
+        }
+      }
+    }
+  },
+  "x-compatibility": {
+    "current": "/api/v1",
+    "legacy_alias": "/api",
+    "policy": "v1 is additive and read-only; aliases remain until a documented v2 migration."
+  },
+  "x-limits": {"max_response_bytes": 4194304, "max_event_log_bytes": 10485760, "max_events_per_run": 10000},
+  "x-headers": {"content_type": "application/json; charset=utf-8", "api_version": "X-API-Version"}
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,20 @@
 # API reference
 
+The versioned HTTP contract is checked in as
+[`api-openapi-v1.json`](api-openapi-v1.json). `GET` is the only API method;
+`POST`, `PUT`, `PATCH`, and `DELETE` return `405 read_only`. The service emits
+`Content-Type: application/json; charset=utf-8`, `Cache-Control: no-store`,
+`X-Content-Type-Options: nosniff`, and `X-API-Version: 1` on `/api/v1/*`.
+
+`/api/*` is a compatibility alias for v1. Local and split-host clients use the
+same `/api/v1` paths. Run and event responses are capped at 4 MiB; source files
+are capped at 10 MiB and 10,000 events per run. Invalid run identifiers return
+`400`, unknown runs return `404`, malformed sources return `503`, and oversized
+responses return `413`. No endpoint writes, controls, or acknowledges a task.
+
+The compatibility policy is additive within v1. A future v2 must be introduced
+under `/api/v2`; aliases are not silently repointed.
+
 The Python API pages are generated from source docstrings during the MkDocs build.
 
 ::: workbench.kernel.lifecycle

--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -33,7 +33,9 @@ emit the `TaskGraph`. A model response never becomes a joint, velocity, firmware
 ## Operational boundary
 
 - `/healthz` reports process health; `/readyz` checks that the event source is readable.
-- `/api/runs` and `/api/runs/{run_id}/events` expose ordered read models.
+- `/api/v1/runs` and `/api/v1/runs/{run_id}/events` expose ordered read models;
+  `/api/*` remains a compatibility alias. The checked-in OpenAPI contract is
+  `docs/api-openapi-v1.json`.
 - Event JSONL files are cached by path, modification time and size; changed files invalidate automatically.
 - Static responses use ETags, while versioned vendored assets use immutable caching.
 - `POST`, `PUT`, `PATCH` and `DELETE` return `405 read_only`.

--- a/docs/task_packets/api-read-only-contract.json
+++ b/docs/task_packets/api-read-only-contract.json
@@ -1,0 +1,28 @@
+{
+  "issue": 80,
+  "human_owner": "Quchaosheng",
+  "objective": "Publish and test a versioned read-only Dashboard API contract for local and split-host clients.",
+  "allowed_paths": [
+    "services/backend/**",
+    "tests/unit/test_dashboard_backend.py",
+    "tests/unit/test_multi_host.py",
+    "docs/api.md",
+    "docs/api-openapi-v1.json",
+    "docs/architecture/system.md",
+    "docs/task_packets/api-read-only-contract.json"
+  ],
+  "read_only_paths": ["interfaces/**", "robot/control/**", "firmware/**"],
+  "forbidden": ["interfaces/**", "robot/control/**", "firmware/**"],
+  "acceptance": [
+    "checked-in OpenAPI v1 lists methods, statuses, limits, and read-only policy",
+    "local and remote clients use the same versioned paths and validate the same response shape",
+    "malformed identifiers, missing runs, malformed sources, and oversized responses fail closed",
+    "legacy /api aliases remain additive and no write endpoint is introduced"
+  ],
+  "commands": [
+    "python3 -m pytest tests/unit/test_dashboard_backend.py tests/unit/test_multi_host.py -q",
+    "python3 -m mkdocs build --strict"
+  ],
+  "evidence": ["OpenAPI fixture assertions", "local/remote HTTP test output", "strict docs build"],
+  "stop_conditions": ["schema changes are required", "a write/control operation is requested"]
+}

--- a/services/backend/workbench_backend/read_model.py
+++ b/services/backend/workbench_backend/read_model.py
@@ -40,10 +40,15 @@ EVENT_TYPES = {
 MAX_EVENT_LOG_BYTES = 10 * 1024 * 1024
 MAX_EVENTS_PER_RUN = 10_000
 MAX_READ_ATTEMPTS = 2
+MAX_REMOTE_RESPONSE_BYTES = 4 * 1024 * 1024
 
 
 class ReadModelError(ValueError):
     """Raised when a persisted run cannot be trusted as an ordered event stream."""
+
+
+class ReadModelResponseTooLarge(ReadModelError):
+    """Raised when a local or remote projection exceeds the HTTP contract."""
 
 
 class DashboardReadModel:
@@ -207,7 +212,16 @@ class RemoteDashboardReadModel(DashboardReadModel):
         request = urllib.request.Request(f"{self.base_url}{path}", headers={"Accept": "application/json"})
         try:
             with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
-                payload = json.loads(response.read())
+                body = response.read(MAX_REMOTE_RESPONSE_BYTES + 1)
+                if len(body) > MAX_REMOTE_RESPONSE_BYTES:
+                    raise ReadModelError("remote event source response is too large")
+                payload = json.loads(body)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                raise KeyError(path) from None
+            if exc.code == 413:
+                raise ReadModelResponseTooLarge("remote event source response is too large") from None
+            raise ReadModelError(f"remote event source unavailable: {self.base_url}") from exc
         except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
             raise ReadModelError(f"remote event source unavailable: {self.base_url}") from exc
         if not isinstance(payload, dict):
@@ -222,7 +236,7 @@ class RemoteDashboardReadModel(DashboardReadModel):
         return payload.get("status") == "ready"
 
     def list_runs(self) -> list[dict[str, Any]]:
-        payload = self._request("/api/runs")
+        payload = self._request("/api/v1/runs")
         runs = payload.get("runs")
         if not isinstance(runs, list) or not all(isinstance(run, dict) for run in runs):
             raise ReadModelError("remote event source returned invalid runs")
@@ -230,7 +244,7 @@ class RemoteDashboardReadModel(DashboardReadModel):
 
     def list_events(self, run_id: str) -> list[dict[str, Any]]:
         encoded = urllib.parse.quote(run_id, safe="")
-        payload = self._request(f"/api/runs/{encoded}/events")
+        payload = self._request(f"/api/v1/runs/{encoded}/events")
         events = payload.get("events")
         if not isinstance(events, list) or not all(isinstance(event, dict) for event in events):
             raise ReadModelError("remote event source returned invalid events")

--- a/services/backend/workbench_backend/server.py
+++ b/services/backend/workbench_backend/server.py
@@ -2,18 +2,28 @@ import argparse
 import json
 import mimetypes
 import os
+import re
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
 from .logging import StructuredLogger
-from .read_model import DashboardReadModel, ReadModelError, RemoteDashboardReadModel
+from .read_model import (
+    DashboardReadModel,
+    ReadModelError,
+    ReadModelResponseTooLarge,
+    RemoteDashboardReadModel,
+)
 
 SOURCE_ROOT = Path(__file__).resolve().parents[3]
 ROOT = Path.cwd() if (Path.cwd() / "apps" / "dashboard").is_dir() else SOURCE_ROOT
 DEFAULT_STATIC_DIR = ROOT / "apps" / "dashboard"
 DEFAULT_DATA_DIR = DEFAULT_STATIC_DIR / "data"
+OPENAPI_PATH = SOURCE_ROOT / "docs" / "api-openapi-v1.json"
+API_VERSION = "1"
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 
 class DashboardHandler(BaseHTTPRequestHandler):
@@ -26,12 +36,21 @@ class DashboardHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args) -> None:
         self.logger.emit("http_access", format % args, details={"client": self.client_address[0]})
 
-    def _send_json(self, payload: object, status: HTTPStatus = HTTPStatus.OK) -> None:
+    def _send_json(
+        self, payload: object, status: HTTPStatus = HTTPStatus.OK, *, api_version: str | None = None
+    ) -> None:
         body = json.dumps(payload, ensure_ascii=False).encode()
+        if len(body) > MAX_RESPONSE_BYTES:
+            status = HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+            body = json.dumps(
+                {"error": "response_too_large", "message": "The requested read model exceeds the response limit."}
+            ).encode()
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
+        if api_version:
+            self.send_header("X-API-Version", api_version)
         self._send_security_headers()
         self.end_headers()
         self.wfile.write(body)
@@ -95,6 +114,11 @@ class DashboardHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         try:
             self._do_get()
+        except ReadModelResponseTooLarge:
+            self._send_json(
+                {"error": "response_too_large", "message": "The requested read model exceeds the response limit."},
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+            )
         except ReadModelError as exc:
             self.logger.emit("read_model_error", str(exc), level="ERROR")
             self._send_json(
@@ -104,6 +128,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
 
     def _do_get(self) -> None:
         route = urlparse(self.path).path
+        api_version = API_VERSION if route.startswith("/api/v1/") else None
         if route == "/healthz":
             self._send_json({"status": "ok", "service": "workbench-backend", "version": "0.1.0"})
             return
@@ -114,25 +139,41 @@ class DashboardHandler(BaseHTTPRequestHandler):
                 HTTPStatus.OK if ready else HTTPStatus.SERVICE_UNAVAILABLE,
             )
             return
-        if route == "/api/runs":
-            self._send_json({"runs": self.read_model.list_runs(), "read_only": True})
+        if route in {"/api/openapi.json", "/api/v1/openapi.json"}:
+            try:
+                contract = json.loads(OPENAPI_PATH.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                self._send_json(
+                    {"error": "contract_unavailable"}, HTTPStatus.SERVICE_UNAVAILABLE, api_version=api_version
+                )
+                return
+            self._send_json(contract, api_version=api_version)
             return
-        if route == "/api/expression-states":
-            self._send_json(self.read_model.expression_contract())
+        if route in {"/api/runs", "/api/v1/runs"}:
+            self._send_json({"runs": self.read_model.list_runs(), "read_only": True}, api_version=api_version)
             return
-        if route.startswith("/api/runs/"):
-            suffix = unquote(route.removeprefix("/api/runs/"))
+        if route in {"/api/expression-states", "/api/v1/expression-states"}:
+            self._send_json(self.read_model.expression_contract(), api_version=api_version)
+            return
+        run_prefix = "/api/v1/runs/" if route.startswith("/api/v1/runs/") else "/api/runs/"
+        if route.startswith(run_prefix):
+            suffix = unquote(route.removeprefix(run_prefix))
             include_events = suffix.endswith("/events")
             run_id = suffix.removesuffix("/events") if include_events else suffix
+            if not RUN_ID_PATTERN.fullmatch(run_id):
+                self._send_json({"error": "invalid_run_id"}, HTTPStatus.BAD_REQUEST, api_version=api_version)
+                return
             try:
                 events = self.read_model.list_events(run_id)
             except KeyError:
-                self._send_json({"error": "run_not_found", "run_id": run_id}, HTTPStatus.NOT_FOUND)
+                self._send_json(
+                    {"error": "run_not_found", "run_id": run_id}, HTTPStatus.NOT_FOUND, api_version=api_version
+                )
                 return
             payload = {"run": self.read_model.summarize(events)}
             if include_events:
                 payload["events"] = events
-            self._send_json(payload)
+            self._send_json(payload, api_version=api_version)
             return
         static_path = "index.html" if route in {"", "/"} else route.lstrip("/")
         self._send_file(static_path)

--- a/tests/unit/test_dashboard_backend.py
+++ b/tests/unit/test_dashboard_backend.py
@@ -281,6 +281,47 @@ class DashboardApiTests(unittest.TestCase):
         self.assertEqual(events_status, 200)
         self.assertEqual(replay["events"][0]["sequence_no"], 0)
 
+    def test_versioned_contract_and_identifier_limits(self) -> None:
+        status, contract = self.read_json("/api/v1/openapi.json")
+        self.assertEqual(status, 200)
+        self.assertEqual(contract["info"]["version"], "1.0.0")
+        self.assertTrue(all(set(operations) == {"get"} for operations in contract["paths"].values()))
+        self.assertIn("RunEvents", contract["components"]["schemas"])
+        request = urllib.request.Request(f"{self.base_url}/api/v1/runs/bad%2Fid")
+        with self.assertRaises(urllib.error.HTTPError) as caught:
+            urllib.request.urlopen(request, timeout=2)
+        self.assertEqual(caught.exception.code, 400)
+        with self.assertRaises(urllib.error.HTTPError) as missing:
+            urllib.request.urlopen(f"{self.base_url}/api/v1/runs/missing", timeout=2)
+        self.assertEqual(missing.exception.code, 404)
+        with urllib.request.urlopen(f"{self.base_url}/api/v1/runs", timeout=2) as response:
+            self.assertEqual(response.headers["X-API-Version"], "1")
+
+    def test_oversized_api_response_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "large.jsonl").write_text(
+                json.dumps(
+                    {
+                        **stored_event("large", 0, "task_accepted"),
+                        "payload": {"goal": "x" * (4 * 1024 * 1024)},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            server = create_server("127.0.0.1", 0, data_dir=temp_dir)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                url = f"http://127.0.0.1:{server.server_address[1]}/api/v1/runs/large/events"
+                with self.assertRaises(urllib.error.HTTPError) as caught:
+                    urllib.request.urlopen(url, timeout=2)
+                self.assertEqual(caught.exception.code, 413)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
     def test_write_requests_fail_closed(self) -> None:
         request = urllib.request.Request(f"{self.base_url}/api/runs/run-confirmed", data=b"{}", method="POST")
         with self.assertRaises(urllib.error.HTTPError) as caught:

--- a/tests/unit/test_multi_host.py
+++ b/tests/unit/test_multi_host.py
@@ -55,9 +55,12 @@ class MultiHostReadModelTests(unittest.TestCase):
                 with urllib.request.urlopen(f"{controller_url}/readyz", timeout=2) as response:
                     self.assertEqual(response.status, 200)
                     self.assertEqual(json.loads(response.read())["data_source"], "remote-simulation-event-source")
-                with urllib.request.urlopen(f"{controller_url}/api/runs/run-remote/events", timeout=2) as response:
+                with urllib.request.urlopen(f"{controller_url}/api/v1/runs/run-remote/events", timeout=2) as response:
                     payload = json.loads(response.read())
                     self.assertEqual(payload["events"][0]["run_id"], "run-remote")
+                with self.assertRaises(urllib.error.HTTPError) as missing:
+                    urllib.request.urlopen(f"{controller_url}/api/v1/runs/missing/events", timeout=2)
+                self.assertEqual(missing.exception.code, 404)
                 sim.shutdown()
                 sim.server_close()
                 sim_thread.join(timeout=2)


### PR DESCRIPTION
## Related Issue

Refs #80.

## What changed

- add checked-in OpenAPI 3.1 v1 contract with payload schemas, status codes, limits, headers, and read-only policy
- add `/api/v1/*` routes while retaining `/api/*` compatibility aliases
- validate malformed IDs, missing runs, oversized responses, malformed sources, and remote 404/413 behavior
- make split-host clients consume the same versioned paths
- expose the contract at `GET /api/v1/openapi.json` and document the compatibility policy

## Interfaces affected

This adds a read-only HTTP version; no `interfaces/` schema changes and no control/write endpoint.

## Tests and commands

- `python -m pytest tests/unit/test_dashboard_backend.py tests/unit/test_multi_host.py -q` — 18 passed
- `python -m mkdocs build --strict` — passed
- `ruff check` on changed Python files — passed

## Evidence

OpenAPI fixture assertions, local/remote endpoint tests, 400/404/413/503 behavior, and strict docs output.

## Risks and rollback

Legacy `/api` aliases remain available. Revert this PR to remove v1 while preserving existing routes.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.