### PR TITLE
fix(world-model): enforce append-only event integrity

### DIFF
--- a/docs/task_packets/issue-46-world-event-store-integrity.json
+++ b/docs/task_packets/issue-46-world-event-store-integrity.json
@@ -1,0 +1,67 @@
+{
+  "issue": 46,
+  "human_owner": "kukuboring",
+  "objective": "Make SQLiteEventStore reject conflicting event identities and sequence numbers while preserving exact duplicate idempotency and deterministic replay.",
+  "allowed_paths": [
+    "services/world_model/workbench_world_model/event_store.py",
+    "tests/unit/test_world_event_store.py",
+    "docs/task_packets/issue-46-world-event-store-integrity.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "docs/architecture/system.md",
+    "interfaces/json_schema/world_event.schema.json",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/world_model/workbench_world_model/__init__.py",
+    "tests/conftest.py",
+    "tests/integration/test_observe_plan_act.py"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/world_model/workbench_world_model/reducer.py",
+    "services/world_model/workbench_world_model/verifier.py",
+    "services/backend/**",
+    "robot/control/**",
+    "firmware/**"
+  ],
+  "acceptance": [
+    "Exact re-append of the same WorldEvent is idempotent and leaves exactly one stored row.",
+    "Reusing an event_id with different canonical event content raises a typed integrity error and preserves the original event.",
+    "Two different events cannot use the same run_id and sequence_no; the conflicting append raises a typed integrity error.",
+    "Every append is transactional and a failed append leaves no partial or additional row.",
+    "list_run returns events in deterministic sequence_no order.",
+    "Closing and reopening the database preserves stored events and all identity and sequence invariants.",
+    "Opening a legacy world_events table without the required sequence uniqueness constraint fails closed with an actionable backup-and-rebuild recovery instruction; automatic migration is not implemented.",
+    "Concurrent conflicting appends through separate SQLite connections result in exactly one stored event and an explicit failure for the conflicting writer."
+  ],
+  "commands": [
+    "python3 -m pytest tests/unit/test_world_event_store.py -v",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "make demo-scripted",
+    "make check"
+  ],
+  "evidence": [
+    "Targeted unit test output covering normal, boundary, conflict, reopen, legacy database and concurrent behavior.",
+    "Stored row count and original event content after duplicate and conflicting append attempts.",
+    "Deterministic sequence_no ordering from list_run.",
+    "Database reopen test output proving constraints remain active.",
+    "Legacy database failure message containing backup-and-rebuild recovery instructions.",
+    "Concurrent conflict test proving only one event is stored.",
+    "Required repository check outputs."
+  ],
+  "stop_conditions": [
+    "Implementation requires changing interfaces/** or libs/contracts/**.",
+    "Implementation requires changing reducer, verifier, backend, robot control or firmware.",
+    "A public WorldEvent schema or Pydantic model change is required.",
+    "Legacy database handling requires automatic or destructive migration instead of the approved fail-closed strategy.",
+    "The typed integrity error requires an unapproved package-level API change outside event_store.py.",
+    "Concurrent correctness cannot be demonstrated with temporary SQLite databases and separate connections.",
+    "A safety, interface or cross-module conflict is discovered.",
+    "Any required modification falls outside allowed_paths."
+  ]
+}

--- a/services/world_model/workbench_world_model/event_store.py
+++ b/services/world_model/workbench_world_model/event_store.py
@@ -43,7 +43,7 @@ class SQLiteEventStore:
         expected_columns = {"event_id", "run_id", "sequence_no", "event_json"}
         has_world_event_triggers = (
             self.connection.execute(
-                "SELECT 1 FROM sqlite_master " "WHERE type = 'trigger' AND tbl_name = 'world_events' LIMIT 1"
+                "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'world_events' LIMIT 1"
             ).fetchone()
             is not None
         )

--- a/services/world_model/workbench_world_model/event_store.py
+++ b/services/world_model/workbench_world_model/event_store.py
@@ -5,30 +5,123 @@ from pathlib import Path
 from workbench_contracts import WorldEvent
 
 
+class EventStoreIntegrityError(RuntimeError):
+    """The requested append conflicts with the persisted event stream."""
+
+
+class EventStoreMigrationRequiredError(EventStoreIntegrityError):
+    """The database schema cannot be upgraded safely by this store."""
+
+
 class SQLiteEventStore:
     def __init__(self, database_path: str | Path) -> None:
         self.connection = sqlite3.connect(database_path)
-        self.connection.execute(
-            """
-            CREATE TABLE IF NOT EXISTS world_events (
-                event_id TEXT PRIMARY KEY,
-                run_id TEXT NOT NULL,
-                sequence_no INTEGER NOT NULL,
-                event_json TEXT NOT NULL
+        try:
+            table_exists = self.connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'world_events'"
+            ).fetchone()
+            if table_exists is None:
+                with self.connection:
+                    self.connection.execute(
+                        """
+                        CREATE TABLE world_events (
+                            event_id TEXT PRIMARY KEY,
+                            run_id TEXT NOT NULL,
+                            sequence_no INTEGER NOT NULL,
+                            event_json TEXT NOT NULL,
+                            UNIQUE(run_id, sequence_no)
+                        )
+                        """
+                    )
+            self._validate_schema()
+        except Exception:
+            self.connection.close()
+            raise
+
+    def _validate_schema(self) -> None:
+        columns = {row[1]: row for row in self.connection.execute("PRAGMA table_info(world_events)").fetchall()}
+        expected_columns = {"event_id", "run_id", "sequence_no", "event_json"}
+        has_world_event_triggers = (
+            self.connection.execute(
+                "SELECT 1 FROM sqlite_master " "WHERE type = 'trigger' AND tbl_name = 'world_events' LIMIT 1"
+            ).fetchone()
+            is not None
+        )
+        primary_key_columns = [row[1] for row in sorted(columns.values(), key=lambda column: column[5]) if row[5] > 0]
+        event_id_is_only_primary_key = primary_key_columns == ["event_id"]
+        required_columns_are_not_null = all(
+            columns.get(name, (None,) * 4)[3] == 1 for name in ("run_id", "sequence_no", "event_json")
+        )
+
+        has_run_sequence_unique_index = False
+        for index in self.connection.execute("PRAGMA index_list(world_events)").fetchall():
+            if index[2] != 1 or index[4] != 0:
+                continue
+            indexed_columns = [
+                row[0]
+                for row in self.connection.execute(
+                    "SELECT name FROM pragma_index_info(?) ORDER BY seqno", (index[1],)
+                ).fetchall()
+            ]
+            if indexed_columns == ["run_id", "sequence_no"]:
+                has_run_sequence_unique_index = True
+                break
+
+        if (
+            set(columns) != expected_columns
+            or not event_id_is_only_primary_key
+            or not required_columns_are_not_null
+            or not has_run_sequence_unique_index
+            or has_world_event_triggers
+        ):
+            raise EventStoreMigrationRequiredError(
+                "Unsupported legacy world_events schema. Create a backup, then rebuild the database "
+                "with a fresh SQLiteEventStore and replay only validated events."
             )
-            """
+
+    @staticmethod
+    def _canonical_event_json(event: WorldEvent) -> str:
+        return json.dumps(
+            event.model_dump(mode="json"),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
         )
 
     def append(self, event: WorldEvent) -> None:
-        self.connection.execute(
-            "INSERT OR IGNORE INTO world_events(event_id, run_id, sequence_no, event_json) VALUES (?, ?, ?, ?)",
-            (event.event_id, event.run_id, event.sequence_no, event.model_dump_json()),
-        )
-        self.connection.commit()
+        event_json = self._canonical_event_json(event)
+        try:
+            with self.connection:
+                self.connection.execute(
+                    "INSERT OR ABORT INTO world_events(event_id, run_id, sequence_no, event_json) VALUES (?, ?, ?, ?)",
+                    (event.event_id, event.run_id, event.sequence_no, event_json),
+                )
+        except sqlite3.IntegrityError as error:
+            existing_event = self.connection.execute(
+                "SELECT run_id, sequence_no, event_json FROM world_events WHERE event_id = ?",
+                (event.event_id,),
+            ).fetchone()
+            if existing_event is not None:
+                if existing_event == (event.run_id, event.sequence_no, event_json):
+                    return
+                raise EventStoreIntegrityError(
+                    f"event_id {event.event_id!r} already exists with different canonical event content"
+                ) from error
+
+            sequence_owner = self.connection.execute(
+                "SELECT event_id FROM world_events WHERE run_id = ? AND sequence_no = ?",
+                (event.run_id, event.sequence_no),
+            ).fetchone()
+            if sequence_owner is not None:
+                raise EventStoreIntegrityError(
+                    f"run_id {event.run_id!r} already contains sequence_no {event.sequence_no} "
+                    f"for event_id {sequence_owner[0]!r}"
+                ) from error
+            raise EventStoreIntegrityError("world event violates an unknown SQLite integrity constraint") from error
 
     def list_run(self, run_id: str) -> list[WorldEvent]:
         rows = self.connection.execute(
-            "SELECT event_json FROM world_events WHERE run_id = ? ORDER BY sequence_no", (run_id,)
+            "SELECT event_json FROM world_events WHERE run_id = ? ORDER BY sequence_no ASC", (run_id,)
         ).fetchall()
         return [WorldEvent.model_validate(json.loads(row[0])) for row in rows]
 

--- a/tests/unit/test_world_event_store.py
+++ b/tests/unit/test_world_event_store.py
@@ -1,0 +1,383 @@
+import sqlite3
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "libs/contracts"), str(ROOT / "services/world_model")]
+
+from workbench_contracts import WorldEvent, WorldEventType
+from workbench_world_model import event_store as event_store_module
+
+SQLiteEventStore = event_store_module.SQLiteEventStore
+EventStoreIntegrityError = event_store_module.EventStoreIntegrityError
+EventStoreMigrationRequiredError = event_store_module.EventStoreMigrationRequiredError
+
+
+def make_event(
+    event_id: str,
+    *,
+    run_id: str = "run-001",
+    sequence_no: int = 1,
+    payload: dict[str, object] | None = None,
+) -> WorldEvent:
+    return WorldEvent(
+        event_id=event_id,
+        run_id=run_id,
+        sequence_no=sequence_no,
+        event_type=WorldEventType.OBSERVATION,
+        occurred_at="2026-08-04T10:00:00Z",
+        payload=payload or {"entity_id": "red_block", "location": "on:table"},
+        evidence_refs=["camera-frame-001"],
+    )
+
+
+def open_legacy_store(database_path: Path, table_sql: str) -> SQLiteEventStore:
+    connection = sqlite3.connect(database_path)
+    try:
+        connection.execute(table_sql)
+        connection.commit()
+    finally:
+        connection.close()
+    return SQLiteEventStore(database_path)
+
+
+def test_exact_reappend_is_idempotent(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    event = make_event("evt-001")
+
+    store.append(event)
+    store.append(event)
+
+    assert store.list_run("run-001") == [event]
+    store.close()
+
+
+def test_canonical_payload_key_order_is_idempotent(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    first = make_event("evt-001", payload={"entity_id": "red_block", "confidence": 0.98})
+    reordered = make_event("evt-001", payload={"confidence": 0.98, "entity_id": "red_block"})
+
+    store.append(first)
+    store.append(reordered)
+
+    assert store.list_run("run-001") == [first]
+    store.close()
+
+
+def test_conflicting_event_id_raises_integrity_error_and_preserves_original(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    original = make_event("evt-001")
+    conflict = make_event("evt-001", payload={"entity_id": "blue_block", "location": "on:table"})
+    store.append(original)
+
+    with pytest.raises(EventStoreIntegrityError, match="event_id"):
+        store.append(conflict)
+
+    assert store.list_run("run-001") == [original]
+    store.close()
+
+
+def test_conflicting_run_sequence_raises_integrity_error_and_preserves_original(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    original = make_event("evt-001")
+    conflict = make_event("evt-002")
+    store.append(original)
+
+    with pytest.raises(EventStoreIntegrityError, match="run_id.*sequence_no"):
+        store.append(conflict)
+
+    assert store.list_run("run-001") == [original]
+    store.close()
+
+
+def test_same_sequence_number_is_allowed_for_different_runs(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    first = make_event("evt-001", run_id="run-001")
+    second = make_event("evt-002", run_id="run-002")
+
+    store.append(first)
+    store.append(second)
+
+    assert store.list_run("run-001") == [first]
+    assert store.list_run("run-002") == [second]
+    store.close()
+
+
+def test_failed_append_rolls_back_and_next_append_succeeds(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    original = make_event("evt-001", sequence_no=1)
+    conflict = make_event("evt-conflict", sequence_no=1)
+    following = make_event("evt-002", sequence_no=2)
+    store.append(original)
+
+    with pytest.raises(EventStoreIntegrityError):
+        store.append(conflict)
+    store.append(following)
+
+    assert store.list_run("run-001") == [original, following]
+    store.close()
+
+
+def test_list_run_orders_by_sequence_number(tmp_path: Path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.sqlite")
+    events = [
+        make_event("evt-003", sequence_no=3),
+        make_event("evt-001", sequence_no=1),
+        make_event("evt-002", sequence_no=2),
+    ]
+    for event in events:
+        store.append(event)
+
+    assert [event.sequence_no for event in store.list_run("run-001")] == [1, 2, 3]
+    store.close()
+
+
+def test_reopen_preserves_data_and_integrity_constraints(tmp_path: Path) -> None:
+    database_path = tmp_path / "events.sqlite"
+    original = make_event("evt-001")
+    store = SQLiteEventStore(database_path)
+    store.append(original)
+    store.close()
+
+    reopened = SQLiteEventStore(database_path)
+    reopened.append(original)
+    with pytest.raises(EventStoreIntegrityError, match="event_id"):
+        reopened.append(
+            make_event(
+                "evt-001",
+                payload={"entity_id": "blue_block", "location": "on:table"},
+            )
+        )
+    with pytest.raises(EventStoreIntegrityError):
+        reopened.append(make_event("evt-conflict"))
+
+    assert reopened.list_run("run-001") == [original]
+    reopened.close()
+
+
+def test_legacy_table_fails_closed_with_recovery_instruction(tmp_path: Path) -> None:
+    database_path = tmp_path / "legacy.sqlite"
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        """
+        CREATE TABLE world_events (
+            event_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL
+        )
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    try:
+        store = SQLiteEventStore(database_path)
+    except EventStoreMigrationRequiredError as exc:
+        message = str(exc).lower()
+        assert "backup" in message
+        assert "rebuild" in message
+    else:
+        store.close()
+        pytest.fail("legacy database must fail closed")
+
+    connection = sqlite3.connect(database_path)
+    columns = connection.execute("PRAGMA table_info(world_events)").fetchall()
+    connection.close()
+    assert [column[1] for column in columns] == ["event_id", "run_id", "sequence_no", "event_json"]
+
+
+def test_legacy_partial_sequence_index_fails_closed(tmp_path: Path) -> None:
+    database_path = tmp_path / "legacy-partial-index.sqlite"
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        """
+        CREATE TABLE world_events (
+            event_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE UNIQUE INDEX unique_run_sequence_partial
+        ON world_events(run_id, sequence_no)
+        WHERE sequence_no > 100
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(EventStoreMigrationRequiredError, match="backup.*rebuild"):
+        SQLiteEventStore(database_path)
+
+
+def test_legacy_composite_event_primary_key_fails_closed(tmp_path: Path) -> None:
+    database_path = tmp_path / "legacy-composite-primary-key.sqlite"
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        """
+        CREATE TABLE world_events (
+            event_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL,
+            PRIMARY KEY(event_id, run_id),
+            UNIQUE(run_id, sequence_no)
+        )
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(EventStoreMigrationRequiredError, match="backup.*rebuild"):
+        SQLiteEventStore(database_path)
+
+
+def test_legacy_table_with_trigger_fails_closed(tmp_path: Path) -> None:
+    database_path = tmp_path / "legacy-trigger.sqlite"
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        """
+        CREATE TABLE world_events (
+            event_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL,
+            UNIQUE(run_id, sequence_no)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TRIGGER ignore_world_event
+        BEFORE INSERT ON world_events
+        BEGIN
+            SELECT RAISE(IGNORE);
+        END
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(EventStoreMigrationRequiredError, match="backup.*rebuild"):
+        SQLiteEventStore(database_path)
+
+
+@pytest.mark.parametrize(
+    "table_sql",
+    [
+        """
+        CREATE TABLE world_events (
+            event_id TEXT PRIMARY KEY ON CONFLICT IGNORE,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL,
+            UNIQUE(run_id, sequence_no)
+        )
+        """,
+        """
+        CREATE TABLE world_events (
+            event_id TEXT PRIMARY KEY ON CONFLICT REPLACE,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL,
+            UNIQUE(run_id, sequence_no)
+        )
+        """,
+    ],
+    ids=["ignore", "replace"],
+)
+def test_event_id_conflict_policy_cannot_silence_typed_error(tmp_path: Path, table_sql: str) -> None:
+    store = open_legacy_store(tmp_path / "legacy-event-id-policy.sqlite", table_sql)
+    original = make_event("evt-001")
+    conflict = make_event(
+        "evt-001",
+        sequence_no=2,
+        payload={"entity_id": "blue_block", "location": "on:table"},
+    )
+
+    try:
+        store.append(original)
+        with pytest.raises(EventStoreIntegrityError, match="event_id"):
+            store.append(conflict)
+        assert store.list_run("run-001") == [original]
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize(
+    "table_sql",
+    [
+        """
+        CREATE TABLE world_events (
+            event_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL,
+            UNIQUE(run_id, sequence_no) ON CONFLICT IGNORE
+        )
+        """,
+        """
+        CREATE TABLE world_events (
+            event_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            sequence_no INTEGER NOT NULL,
+            event_json TEXT NOT NULL,
+            UNIQUE(run_id, sequence_no) ON CONFLICT REPLACE
+        )
+        """,
+    ],
+    ids=["ignore", "replace"],
+)
+def test_sequence_conflict_policy_cannot_silence_typed_error(tmp_path: Path, table_sql: str) -> None:
+    store = open_legacy_store(tmp_path / "legacy-sequence-policy.sqlite", table_sql)
+    original = make_event("evt-001")
+    conflict = make_event(
+        "evt-002",
+        payload={"entity_id": "blue_block", "location": "on:table"},
+    )
+
+    try:
+        store.append(original)
+        with pytest.raises(EventStoreIntegrityError, match="run_id.*sequence_no"):
+            store.append(conflict)
+        assert store.list_run("run-001") == [original]
+    finally:
+        store.close()
+
+
+def test_concurrent_sequence_conflict_has_one_winner(tmp_path: Path) -> None:
+    database_path = tmp_path / "events.sqlite"
+    initial = SQLiteEventStore(database_path)
+    initial.close()
+    barrier = Barrier(2)
+
+    def append(event: WorldEvent) -> str:
+        store = SQLiteEventStore(database_path)
+        barrier.wait()
+        try:
+            store.append(event)
+        except EventStoreIntegrityError:
+            return "conflict"
+        finally:
+            store.close()
+        return "stored"
+
+    events = [make_event("evt-001"), make_event("evt-002")]
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(append, events))
+
+    store = SQLiteEventStore(database_path)
+    stored = store.list_run("run-001")
+    store.close()
+
+    assert sorted(results) == ["conflict", "stored"]
+    assert len(stored) == 1
+    assert stored[0] in events

--- a/tests/unit/test_world_event_store.py
+++ b/tests/unit/test_world_event_store.py
@@ -87,7 +87,7 @@ def test_conflicting_run_sequence_raises_integrity_error_and_preserves_original(
     conflict = make_event("evt-002")
     store.append(original)
 
-    with pytest.raises(EventStoreIntegrityError, match="run_id.*sequence_no"):
+    with pytest.raises(EventStoreIntegrityError, match=r"run_id.*sequence_no"):
         store.append(conflict)
 
     assert store.list_run("run-001") == [original]
@@ -214,7 +214,7 @@ def test_legacy_partial_sequence_index_fails_closed(tmp_path: Path) -> None:
     connection.commit()
     connection.close()
 
-    with pytest.raises(EventStoreMigrationRequiredError, match="backup.*rebuild"):
+    with pytest.raises(EventStoreMigrationRequiredError, match=r"backup.*rebuild"):
         SQLiteEventStore(database_path)
 
 
@@ -236,7 +236,7 @@ def test_legacy_composite_event_primary_key_fails_closed(tmp_path: Path) -> None
     connection.commit()
     connection.close()
 
-    with pytest.raises(EventStoreMigrationRequiredError, match="backup.*rebuild"):
+    with pytest.raises(EventStoreMigrationRequiredError, match=r"backup.*rebuild"):
         SQLiteEventStore(database_path)
 
 
@@ -266,7 +266,7 @@ def test_legacy_table_with_trigger_fails_closed(tmp_path: Path) -> None:
     connection.commit()
     connection.close()
 
-    with pytest.raises(EventStoreMigrationRequiredError, match="backup.*rebuild"):
+    with pytest.raises(EventStoreMigrationRequiredError, match=r"backup.*rebuild"):
         SQLiteEventStore(database_path)
 
 
@@ -346,7 +346,7 @@ def test_sequence_conflict_policy_cannot_silence_typed_error(tmp_path: Path, tab
 
     try:
         store.append(original)
-        with pytest.raises(EventStoreIntegrityError, match="run_id.*sequence_no"):
+        with pytest.raises(EventStoreIntegrityError, match=r"run_id.*sequence_no"):
             store.append(conflict)
         assert store.list_run("run-001") == [original]
     finally:


### PR DESCRIPTION
## Summary

Fixes #46 by enforcing append-only identity and sequence integrity in `SQLiteEventStore`.

- preserve exact duplicate appends as explicit idempotent operations
- reject reused `event_id` values when canonical event content differs
- enforce uniqueness of `(run_id, sequence_no)`
- use `INSERT OR ABORT` so legacy `IGNORE` or `REPLACE` policies cannot suppress typed integrity errors
- validate that `event_id` is the only primary-key column
- reject partial sequence indexes and triggers on `world_events`
- fail closed on unsupported legacy schemas with actionable backup-and-rebuild instructions
- return events in deterministic `sequence_no` order

## Scope

Changed only the Issue #46 Task Packet allowed paths:

- `services/world_model/workbench_world_model/event_store.py`
- `tests/unit/test_world_event_store.py`
- `docs/task_packets/issue-46-world-event-store-integrity.json`

No interface schema, Pydantic contract, reducer, verifier, backend, robot-control, or firmware changes are included.

`docs/task_packets/issue-122-world-model-mocks.json` is unrelated existing work and is not included in this PR.

## Verification

### Focused event-store tests

```text
python3 -m pytest tests/unit/test_world_event_store.py -v

17 passed in 0.59s
These tests exercise the real SQLiteEventStore with temporary SQLite databases and cover:
exact duplicate and canonical-key-order idempotency
conflicting event IDs and sequence numbers
rollback after failed appends
deterministic replay ordering
close-and-reopen invariants
missing and partial uniqueness constraints
composite event primary keys
unexpected world_events triggers
schema-level IGNORE and REPLACE policies
concurrent conflicting writes through separate connections
Repository gate
make check
Result:
Ruff checks passed
Ruff format check passed: 126 files already formatted
test suite passed: 350 tests in 4.83s
contract validation passed
scenario validation passed
golden-set validation passed
context validation passed
scripted demo passed
offline demo passed
git diff --check passed
Risk
This change intentionally fails closed for unsupported existing databases.
An existing database will require recovery if it:
lacks the exact event_id primary key or (run_id, sequence_no) uniqueness constraint
uses a partial sequence index
defines triggers on world_events
Legacy IGNORE or REPLACE conflict policies can no longer suppress typed failures because appends explicitly use OR ABORT.
No public WorldEvent schema or Pydantic model changes are introduced.
Recovery and rollback
For an unsupported database:
stop event writers
create and verify a backup
create a fresh database with SQLiteEventStore
replay only validated events in deterministic sequence order
verify row counts, event identities, sequence uniqueness, and replay output before resuming writes
The code change can be reverted if necessary, but reverting restores the previous silent-conflict behavior. Preserve the database backup before rollback and do not treat rollback as evidence that a conflicting stream is valid.
Reviewers
Please request review from:
@kukuboring — Issue #46 human Owner
the actual World Model Owner for services/world_model/
CODEOWNERS currently contains @PLACEHOLDER_WORLD_MODEL_OWNER, so the real World Model Owner must be resolved manually.
Closes #46
```