### PR TITLE
fix(world-model): reject mixed-run and ambiguous event streams

### DIFF
--- a/docs/task_packets/issue-49-world-event-stream-integrity.json
+++ b/docs/task_packets/issue-49-world-event-stream-integrity.json
@@ -1,0 +1,94 @@
+{
+  "issue": 49,
+  "human_owner": "kukuboring",
+  "objective": "Preflight and deterministically reduce one non-empty run's WorldEvent stream, folding only content-identical duplicates and rejecting mixed-run or ambiguous event identities and sequence numbers before applying any event.",
+  "allowed_paths": [
+    "services/world_model/workbench_world_model/reducer.py",
+    "tests/unit/test_world_model.py",
+    "docs/task_packets/issue-49-world-event-stream-integrity.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "Makefile",
+    "docs/architecture/system.md",
+    "docs/task_packets/example-001-world-reducer.json",
+    "tools/scripts/check_task_packet.py",
+    "interfaces/json_schema/world_event.schema.json",
+    "interfaces/json_schema/world_state.schema.json",
+    "interfaces/json_schema/observation.schema.json",
+    "interfaces/json_schema/action_result.schema.json",
+    "interfaces/examples/observation-red-block.json",
+    "interfaces/examples/action-result-place-confirmed.json",
+    "interfaces/examples/world-state-block-in-tray.json",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/world_model/workbench_world_model/__init__.py",
+    "services/world_model/workbench_world_model/event_store.py",
+    "services/world_model/workbench_world_model/verifier.py",
+    "tests/integration/test_observe_plan_act.py"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/world_model/workbench_world_model/__init__.py",
+    "services/world_model/workbench_world_model/event_store.py",
+    "services/world_model/workbench_world_model/verifier.py",
+    "services/agent_runtime/**",
+    "services/backend/**",
+    "apps/**",
+    "robot/**",
+    "firmware/**",
+    "sim/**",
+    ".github/**",
+    "docs/task_packets/issue-122-world-model-mocks.json"
+  ],
+  "acceptance": [
+    "reduce_events rejects an empty requested run_id with ValueError before applying any event.",
+    "Every event must match the requested run_id; a mixed-run stream raises ValueError before applying any event.",
+    "Content-distinct events in one run cannot share sequence_no; the stream raises ValueError before applying any event.",
+    "Reusing an event_id with different complete model-dumped JSON content raises ValueError before applying any event.",
+    "Separate WorldEvent instances with equal complete model-dumped JSON content are treated as one idempotent event.",
+    "JSON object key insertion order alone does not make otherwise equal event content different.",
+    "After exact duplicates are folded, accepted events are applied exactly once in ascending sequence_no order.",
+    "Every permutation of the same accepted stream produces an identical WorldState model dump, evidence order and applied_event_ids order.",
+    "The complete stream is validated before the first apply_event call, so rejection cannot expose or return a partial state.",
+    "A valid non-empty run_id with an empty event list returns an empty WorldState for that run.",
+    "The reduce_events public signature, WorldState model, JSON Schemas and package-root exports remain unchanged."
+  ],
+  "commands": [
+    "python3 -m pytest tests/unit/test_world_model.py -v",
+    "python3 -m pytest tests/integration/test_observe_plan_act.py -v",
+    "make task-check PACKET=docs/task_packets/issue-49-world-event-stream-integrity.json",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "make demo-scripted",
+    "make check"
+  ],
+  "evidence": [
+    "Pre-implementation targeted test output showing the new tests fail for the expected missing validation and nondeterminism reasons.",
+    "Cause-specific ValueError assertions for empty run_id, mixed runs, duplicate sequence_no and conflicting duplicate event_id.",
+    "A spy assertion proving invalid streams are rejected before apply_event is called.",
+    "State assertions proving a content-identical duplicate is applied once without duplicate evidence.",
+    "All six permutations of a three-event accepted stream produce the same WorldState model dump and ordered applied_event_ids.",
+    "Targeted unit and existing integration test outputs.",
+    "Task Packet validation and all required repository check outputs with exit codes and test counts.",
+    "Final git status, git diff --name-only and git diff --check output proving only allowed paths changed."
+  ],
+  "stop_conditions": [
+    "Implementation requires changing interfaces/** or libs/contracts/**.",
+    "Implementation requires changing event_store.py, verifier.py, package-root exports or another runtime module.",
+    "A public exception type or reduce_events signature change is required.",
+    "Implementation requires resolving the pre-existing WorldState Pydantic and JSON Schema drift.",
+    "Content-identical duplicate semantics cannot be implemented from the existing WorldEvent model-dumped content.",
+    "Implementation requires robot, firmware, simulation, control or security configuration changes.",
+    "A new test does not fail for the expected reason before implementation.",
+    "Invalid-stream rejection cannot be proven to occur before the first apply_event call.",
+    "The working branch contains Issue #46 or another Issue's commits.",
+    "Pre-existing user changes overlap an allowed path and cannot be preserved safely.",
+    "Any required modification falls outside allowed_paths.",
+    "An interface, safety or cross-module conflict is discovered."
+  ]
+}
+

--- a/docs/task_packets/issue-49-world-event-stream-integrity.json
+++ b/docs/task_packets/issue-49-world-event-stream-integrity.json
@@ -91,4 +91,3 @@
     "An interface, safety or cross-module conflict is discovered."
   ]
 }
-

--- a/services/world_model/workbench_world_model/reducer.py
+++ b/services/world_model/workbench_world_model/reducer.py
@@ -1,3 +1,5 @@
+import json
+
 from pydantic import BaseModel, Field
 from workbench_contracts import WorldEvent, WorldEventType
 
@@ -53,8 +55,51 @@ def apply_event(state: WorldState, event: WorldEvent) -> WorldState:
     return next_state
 
 
+def _canonical_event_content(event: WorldEvent) -> str:
+    return json.dumps(
+        event.model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _validated_event_stream(run_id: str, events: list[WorldEvent]) -> list[WorldEvent]:
+    if not run_id:
+        raise ValueError("run_id must be non-empty")
+
+    content_by_event_id: dict[str, str] = {}
+    event_id_by_sequence: dict[int, str] = {}
+    unique_events: list[WorldEvent] = []
+
+    for event in events:
+        if event.run_id != run_id:
+            raise ValueError(f"event run_id {event.run_id!r} does not match requested run_id {run_id!r}")
+
+        event_content = _canonical_event_content(event)
+        previous_content = content_by_event_id.get(event.event_id)
+        if previous_content is not None:
+            if previous_content != event_content:
+                raise ValueError(f"event_id {event.event_id!r} is duplicated with different complete content")
+            continue
+
+        sequence_owner = event_id_by_sequence.get(event.sequence_no)
+        if sequence_owner is not None:
+            raise ValueError(
+                f"sequence_no {event.sequence_no} is shared by event_id {sequence_owner!r} and {event.event_id!r}"
+            )
+
+        content_by_event_id[event.event_id] = event_content
+        event_id_by_sequence[event.sequence_no] = event.event_id
+        unique_events.append(event)
+
+    return sorted(unique_events, key=lambda item: item.sequence_no)
+
+
 def reduce_events(run_id: str, events: list[WorldEvent]) -> WorldState:
+    """Preflight the full stream, fold exact duplicates, then replay by ascending sequence_no."""
+    ordered_events = _validated_event_stream(run_id, events)
     state = WorldState(run_id=run_id)
-    for event in sorted(events, key=lambda item: item.sequence_no):
+    for event in ordered_events:
         state = apply_event(state, event)
     return state

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -1,6 +1,8 @@
 import sys
 import unittest
+from itertools import permutations
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path[:0] = [str(ROOT / "libs/contracts"), str(ROOT / "services/world_model")]
@@ -28,6 +30,25 @@ def placed_event() -> WorldEvent:
         occurred_at="2026-08-04T00:00:00Z",
         payload={"outcome": "completed", "entity_id": "red_block", "resulting_location": "in:tray"},
         evidence_refs=["act-001"],
+    )
+
+
+def observation_event(
+    event_id: str,
+    sequence_no: int,
+    *,
+    run_id: str = "run-001",
+    entity_id: str = "red_block",
+    location: str = "on:table",
+) -> WorldEvent:
+    return WorldEvent(
+        event_id=event_id,
+        run_id=run_id,
+        sequence_no=sequence_no,
+        event_type=WorldEventType.OBSERVATION,
+        occurred_at=f"2026-08-04T00:00:{sequence_no:02d}Z",
+        payload={"entity_id": entity_id, "location": location, "confidence": 0.9},
+        evidence_refs=[f"frame://{event_id}"],
     )
 
 
@@ -63,6 +84,132 @@ class WorldModelTests(unittest.TestCase):
         twice = apply_event(once, placed_event())
         self.assertEqual(once.model_dump(), twice.model_dump())
         self.assertEqual(once.entity_evidence_refs["red_block"], ["act-001"])
+
+    def test_reduce_events_rejects_empty_run_id_before_apply(self) -> None:
+        streams = [[], [observation_event("evt-001", 1, run_id="")]]
+
+        for events in streams:
+            with self.subTest(event_count=len(events)):
+                with patch("workbench_world_model.reducer.apply_event", wraps=apply_event) as apply_spy:
+                    with self.assertRaisesRegex(ValueError, "run_id"):
+                        reduce_events("", events)
+                    apply_spy.assert_not_called()
+
+    def test_reduce_events_rejects_mixed_run_before_apply(self) -> None:
+        events = [
+            observation_event("evt-001", 1),
+            observation_event("evt-002", 2, run_id="run-002"),
+        ]
+
+        with patch("workbench_world_model.reducer.apply_event", wraps=apply_event) as apply_spy:
+            with self.assertRaisesRegex(ValueError, "run_id"):
+                reduce_events("run-001", events)
+            apply_spy.assert_not_called()
+
+    def test_reduce_events_rejects_duplicate_sequence_before_apply(self) -> None:
+        events = [
+            observation_event("evt-001", 1),
+            observation_event("evt-002", 1, location="in:tray"),
+        ]
+
+        with patch("workbench_world_model.reducer.apply_event", wraps=apply_event) as apply_spy:
+            with self.assertRaisesRegex(ValueError, "sequence_no"):
+                reduce_events("run-001", events)
+            apply_spy.assert_not_called()
+
+    def test_reduce_events_rejects_conflicting_duplicate_event_id_before_apply(self) -> None:
+        original = observation_event("evt-001", 1)
+        conflicts = [
+            original.model_copy(update={"sequence_no": 2}),
+            original.model_copy(update={"occurred_at": "2026-08-04T00:01:00Z"}),
+            original.model_copy(
+                update={
+                    "payload": {
+                        "entity_id": "red_block",
+                        "location": "in:tray",
+                        "confidence": 0.9,
+                    }
+                }
+            ),
+            original.model_copy(update={"evidence_refs": ["frame://different"]}),
+            original.model_copy(update={"event_type": WorldEventType.FAULT}),
+        ]
+
+        for conflict in conflicts:
+            with self.subTest(conflict=conflict.model_dump(mode="json")):
+                with patch("workbench_world_model.reducer.apply_event", wraps=apply_event) as apply_spy:
+                    with self.assertRaisesRegex(ValueError, "event_id"):
+                        reduce_events("run-001", [original, conflict])
+                    apply_spy.assert_not_called()
+
+    def test_reduce_events_accepts_exact_duplicate_idempotently(self) -> None:
+        original = observation_event("evt-001", 1)
+        duplicate = WorldEvent(
+            event_id=original.event_id,
+            run_id=original.run_id,
+            sequence_no=original.sequence_no,
+            event_type=original.event_type,
+            occurred_at=original.occurred_at,
+            payload={
+                "confidence": 0.9,
+                "location": "on:table",
+                "entity_id": "red_block",
+            },
+            evidence_refs=list(original.evidence_refs),
+        )
+
+        state = reduce_events("run-001", [original, duplicate])
+
+        self.assertEqual(state.applied_event_ids, ["evt-001"])
+        self.assertEqual(state.evidence_refs, ["frame://evt-001"])
+        self.assertEqual(state.entity_evidence_refs["red_block"], ["frame://evt-001"])
+
+    def test_reduce_events_orders_unique_events_by_sequence_number(self) -> None:
+        events = [
+            observation_event("evt-003", 3, entity_id="blue_block"),
+            observation_event("evt-001", 1),
+            observation_event("evt-002", 2, location="in:tray"),
+        ]
+
+        state = reduce_events("run-001", events)
+
+        self.assertEqual(state.applied_event_ids, ["evt-001", "evt-002", "evt-003"])
+        self.assertEqual(
+            state.evidence_refs,
+            ["frame://evt-001", "frame://evt-002", "frame://evt-003"],
+        )
+        self.assertEqual(state.entity_locations["red_block"], "in:tray")
+
+    def test_reduce_events_is_deterministic_for_every_input_permutation(self) -> None:
+        events = [
+            observation_event("evt-001", 1),
+            observation_event("evt-002", 2, location="in:tray"),
+            observation_event("evt-003", 3, entity_id="blue_block"),
+        ]
+        states = [
+            reduce_events("run-001", list(event_order)).model_dump(mode="json") for event_order in permutations(events)
+        ]
+
+        self.assertEqual(len(states), 6)
+        self.assertTrue(all(state == states[0] for state in states))
+        self.assertEqual(states[0]["applied_event_ids"], ["evt-001", "evt-002", "evt-003"])
+
+    def test_reduce_events_preflights_entire_stream_before_apply(self) -> None:
+        events = [
+            observation_event("evt-001", 1),
+            observation_event("evt-002", 2),
+            observation_event("evt-003", 2, location="in:tray"),
+        ]
+
+        with patch("workbench_world_model.reducer.apply_event", wraps=apply_event) as apply_spy:
+            with self.assertRaises(ValueError):
+                reduce_events("run-001", events)
+            apply_spy.assert_not_called()
+
+    def test_reduce_events_accepts_empty_stream_for_valid_run(self) -> None:
+        state = reduce_events("run-001", [])
+
+        self.assertEqual(state, WorldState(run_id="run-001"))
 
     def test_verifier_uses_state_relation(self) -> None:
         state = reduce_events("run-001", [placed_event()])


### PR DESCRIPTION
Closes #49.

## Summary

Reject mixed-run and ambiguous WorldEvent streams before applying any event. Fold exact duplicates and replay accepted events deterministically by ascending sequence number.

## Test results

- `python3 -m pytest tests/unit/test_world_model.py -v`: 17 passed
- `python3 -m pytest tests/integration/test_observe_plan_act.py -v`: 3 passed
- `make task-check PACKET=docs/task_packets/issue-49-world-event-stream-integrity.json`: passed
- `make test`: 342 passed
- `make contract`: passed
- `make scenario-check`: passed
- `make context-check`: passed
- `make demo-scripted`: passed
- `make check`: passed

## Scope

Only the World Model reducer, unit tests and Issue #49 Task Packet are changed. No Schema or cross-module changes.