### PR TITLE
fix(kernel): fail closed without wbcan debugfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
           fi
           test ! -e /sys/kernel/debug/wbcan
           sudo ip link del wbcan0
+          if sudo insmod kernel/wbcan/wbcan.ko fail_debugfs=1; then
+            echo "wbcan unexpectedly loaded with injected debugfs failure"
+            exit 1
+          fi
+          test ! -e /sys/class/net/wbcan0
+          test ! -e /sys/kernel/debug/wbcan
           sudo insmod kernel/wbcan/wbcan.ko
           if sudo insmod kernel/wbcan/wbcan.ko; then
             echo "wbcan unexpectedly allowed duplicate module insertion"
@@ -112,6 +118,13 @@ jobs:
             echo "| --- | --- |"
             echo "| Module insertion | $MODULE_LOAD_OUTCOME |"
             echo "| Fault suite | $FAULT_SUITE_OUTCOME |"
+            if [ "$MODULE_LOAD_OUTCOME" = success ] && [ "$FAULT_SUITE_OUTCOME" = success ]; then
+              echo "| Fault-plane readiness | PASS |"
+            elif [ "$MODULE_LOAD_OUTCOME" = skipped ] || [ "$FAULT_SUITE_OUTCOME" = skipped ]; then
+              echo "| Fault-plane readiness | NOT_EXECUTED |"
+            else
+              echo "| Fault-plane readiness | FAIL |"
+            fi
             if [ "$status" = PASS ]; then
               echo "| Fault-mode coverage | PASS (7/7 advertised modes) |"
             else

--- a/docs/task_packets/linux-wbcan-debugfs-readiness.json
+++ b/docs/task_packets/linux-wbcan-debugfs-readiness.json
@@ -1,0 +1,41 @@
+{
+  "issue": "141",
+  "human_owner": "Quchaosheng",
+  "objective": "Fail closed when the wbcan debugfs fault plane is unavailable and report readiness truthfully.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/test_wbcan.sh",
+    ".github/workflows/ci.yml",
+    "tests/unit/test_release_workflow.py",
+    "docs/task_packets/linux-wbcan-debugfs-readiness.json"
+  ],
+  "read_only_paths": ["firmware/**", "interfaces/**", "AGENTS.md"],
+  "forbidden": ["robot/control/**", "firmware/**", "interfaces/**"],
+  "acceptance": [
+    "debugfs directory and file creation results are checked for NULL and ERR_PTR",
+    "any fault-plane setup failure unregisters the CAN device and removes partial debugfs state",
+    "module logs readiness only after inject and status exist",
+    "an injected creation failure leaves no device or debugfs tree",
+    "CI reports fault-plane readiness as PASS, NOT_EXECUTED, or FAIL"
+  ],
+  "commands": [
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "python -m pytest tests/unit/test_release_workflow.py -v",
+    "sudo insmod kernel/wbcan/wbcan.ko fail_debugfs=1",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test"
+  ],
+  "evidence": [
+    "module build output",
+    "checkpatch output",
+    "workflow regression output",
+    "injected debugfs failure cleanup assertions",
+    "fault-plane readiness line in job summary"
+  ],
+  "stop_conditions": [
+    "debugfs must become a stable production control API",
+    "firmware or interface changes are required",
+    "the hosted runner cannot test module-init cleanup"
+  ]
+}

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -28,6 +28,13 @@ need python3
 
 [ -d "$DBG" ] || { red "no debugfs dir at $DBG - is the module loaded?"; exit 1; }
 ip link show "$IFACE" >/dev/null 2>&1 || { red "no interface $IFACE"; exit 1; }
+if [ -w "$DBG/inject" ] && [ -r "$DBG/status" ]; then
+	green "PASS  fault-plane readiness: PASS"
+	PASS=$((PASS + 1))
+else
+	red "FAIL  fault-plane readiness: FAIL"
+	FAIL=$((FAIL + 1))
+fi
 
 arm()   { echo "$*" > "$DBG/inject"; }
 clear_fault() { arm "none 0"; }

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -30,6 +30,7 @@
 #include <linux/netdevice.h>
 #include <linux/if_arp.h>
 #include <linux/debugfs.h>
+#include <linux/err.h>
 #include <linux/slab.h>
 #include <linux/spinlock.h>
 #include <linux/string.h>
@@ -618,6 +619,16 @@ static const struct file_operations wbcan_status_fops = {
 
 static struct net_device *wbcan_dev;
 static struct dentry *wbcan_dbg_root;
+static bool fail_debugfs;
+module_param(fail_debugfs, bool, 0400);
+MODULE_PARM_DESC(fail_debugfs, "fail debugfs setup to test init cleanup");
+
+static int wbcan_debugfs_err(const struct dentry *entry)
+{
+	if (IS_ERR(entry))
+		return PTR_ERR(entry);
+	return entry ? 0 : -ENODEV;
+}
 
 /*
  * Lifecycle is intentionally singleton-only: module load creates wbcan0 and
@@ -627,6 +638,7 @@ static struct dentry *wbcan_dbg_root;
 static int __init wbcan_init(void)
 {
 	struct wbcan_priv *priv;
+	struct dentry *entry;
 	int err;
 
 	/*
@@ -661,22 +673,49 @@ static int __init wbcan_init(void)
 	priv->can.state = CAN_STATE_STOPPED;
 
 	err = register_candev(wbcan_dev);
-	if (err) {
-		free_candev(wbcan_dev);
-		wbcan_dev = NULL;
-		return err;
-	}
+	if (err)
+		goto err_free;
 
 	wbcan_dbg_root = debugfs_create_dir(KBUILD_MODNAME, NULL);
+	err = wbcan_debugfs_err(wbcan_dbg_root);
+	if (err) {
+		wbcan_dbg_root = NULL;
+		goto err_unregister;
+	}
 	priv->dbg_dir = debugfs_create_dir(wbcan_dev->name, wbcan_dbg_root);
-	debugfs_create_file("inject", 0200, priv->dbg_dir, priv,
-			    &wbcan_inject_fops);
-	debugfs_create_file("status", 0444, priv->dbg_dir, priv,
-			    &wbcan_status_fops);
+	err = wbcan_debugfs_err(priv->dbg_dir);
+	if (err) {
+		priv->dbg_dir = NULL;
+		goto err_debugfs;
+	}
+	if (fail_debugfs) {
+		err = -EIO;
+		goto err_debugfs;
+	}
+	entry = debugfs_create_file("inject", 0200, priv->dbg_dir, priv,
+				    &wbcan_inject_fops);
+	err = wbcan_debugfs_err(entry);
+	if (err)
+		goto err_debugfs;
+	entry = debugfs_create_file("status", 0444, priv->dbg_dir, priv,
+				    &wbcan_status_fops);
+	err = wbcan_debugfs_err(entry);
+	if (err)
+		goto err_debugfs;
 
-	netdev_info(wbcan_dev, "registered; arm faults via debugfs %s/%s/inject\n",
+	netdev_info(wbcan_dev, "registered; fault plane ready at %s/%s/inject\n",
 		    KBUILD_MODNAME, wbcan_dev->name);
 	return 0;
+
+err_debugfs:
+	debugfs_remove_recursive(wbcan_dbg_root);
+	wbcan_dbg_root = NULL;
+err_unregister:
+	unregister_candev(wbcan_dev);
+err_free:
+	free_candev(wbcan_dev);
+	wbcan_dev = NULL;
+	return err;
 }
 
 static void __exit wbcan_exit(void)
@@ -685,6 +724,7 @@ static void __exit wbcan_exit(void)
 		return;
 
 	debugfs_remove_recursive(wbcan_dbg_root);
+	wbcan_dbg_root = NULL;
 	unregister_candev(wbcan_dev);
 	free_candev(wbcan_dev);
 	wbcan_dev = NULL;

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -41,6 +41,8 @@ def test_kernel_fault_suite_cannot_be_skipped_as_green() -> None:
     assert "FAIL" in summary_step
     assert "Fault-mode coverage" in summary_step
     assert "PASS (7/7 advertised modes)" in summary_step
+    assert "Fault-plane readiness" in summary_step
+    assert "NOT_EXECUTED" in summary_step
     assert 'test "$status" = PASS' in summary_step
     assert "GITHUB_STEP_SUMMARY" in summary_step
 
@@ -65,5 +67,6 @@ def test_kernel_module_unload_verifies_singleton_cleanup() -> None:
     assert "sudo ip link add wbcan0 type vcan" in load_step
     assert "name collision" in load_step
     assert "duplicate module insertion" in load_step
+    assert "fail_debugfs=1" in load_step
     assert "test ! -e /sys/class/net/wbcan0" in unload_step
     assert "test ! -e /sys/kernel/debug/wbcan" in unload_step


### PR DESCRIPTION
Closes #141

Depends on the #140 PR. Merge after it.

## Summary
- check every debugfs directory and file creation result
- fail module initialization and clean partial state when the fault plane is unavailable
- inject a debugfs setup failure in CI to prove cleanup
- report fault-plane readiness as PASS, NOT_EXECUTED, or FAIL

## Verification
- Linux 7.0 module build passed locally
- checkpatch: 0 errors, 0 warnings
- 4 release-workflow tests passed
- shell syntax and Task Packet validation passed
- privileged init-failure/runtime checks: NOT_EXECUTED locally; the GitHub kernel-module job is required evidence