### PR TITLE
fix(kernel): support current CAN MTU APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             "linux-headers-$(uname -r)" \
+            linux-headers-generic \
             "linux-modules-extra-$(uname -r)" \
             can-utils build-essential
       - name: Build and check wbcan.ko
         run: |
+          for headers in /usr/src/linux-headers-*-generic; do
+            make -C kernel/wbcan clean KDIR="$headers"
+            make -C kernel/wbcan KDIR="$headers"
+          done
+          make -C kernel/wbcan clean
           make -C kernel/wbcan
           make -C kernel/wbcan checkpatch
       - name: Load the module and bring the interface up

--- a/docs/task_packets/linux-wbcan-mtu-compatibility.json
+++ b/docs/task_packets/linux-wbcan-mtu-compatibility.json
@@ -1,0 +1,32 @@
+{
+  "issue": "135",
+  "human_owner": "Quchaosheng",
+  "objective": "Keep the classic-CAN-only wbcan module buildable across supported Linux CAN MTU APIs.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    ".github/workflows/ci.yml",
+    "tests/unit/test_release_workflow.py",
+    "docs/task_packets/linux-wbcan-mtu-compatibility.json"
+  ],
+  "read_only_paths": ["firmware/**", "interfaces/**", "AGENTS.md"],
+  "forbidden": ["robot/control/**", "firmware/**", "interfaces/**"],
+  "acceptance": [
+    "classic CAN MTU remains the only accepted MTU",
+    "MTU changes while the interface is running fail closed",
+    "the module builds against Linux 6.17 and 7.0 headers",
+    "CI builds against generic LTS and hosted-runner headers",
+    "checkpatch remains required"
+  ],
+  "commands": [
+    "make -C kernel/wbcan KDIR=/usr/src/linux-headers-6.17.0-40-generic",
+    "make -C kernel/wbcan KDIR=/usr/src/linux-headers-7.0.0-28-generic",
+    "make -C kernel/wbcan checkpatch",
+    "python -m pytest tests/unit/test_release_workflow.py -v"
+  ],
+  "evidence": ["dual-header module build output", "checkpatch output", "workflow regression test"],
+  "stop_conditions": [
+    "supporting CAN FD or CAN XL is required",
+    "firmware or interface changes are required",
+    "the supported kernel range must change"
+  ]
+}

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -355,11 +355,22 @@ static int wbcan_set_mode(struct net_device *dev, enum can_mode mode)
 	}
 }
 
+static int wbcan_change_mtu(struct net_device *dev, int new_mtu)
+{
+	if (dev->flags & IFF_UP)
+		return -EBUSY;
+	if (new_mtu != CAN_MTU)
+		return -EINVAL;
+
+	WRITE_ONCE(dev->mtu, new_mtu);
+	return 0;
+}
+
 static const struct net_device_ops wbcan_netdev_ops = {
 	.ndo_open	= wbcan_open,
 	.ndo_stop	= wbcan_stop,
 	.ndo_start_xmit	= wbcan_start_xmit,
-	.ndo_change_mtu	= can_change_mtu,
+	.ndo_change_mtu	= wbcan_change_mtu,
 };
 
 /* --------------------------------------------------------------- debugfs ABI

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -41,3 +41,15 @@ def test_kernel_fault_suite_cannot_be_skipped_as_green() -> None:
     assert "FAIL" in summary_step
     assert 'test "$status" = PASS' in summary_step
     assert "GITHUB_STEP_SUMMARY" in summary_step
+
+
+def test_kernel_module_builds_against_lts_and_runner_headers() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    kernel_job = workflow.split("  kernel-module:", maxsplit=1)[1].split("\n  mcu-qemu:", maxsplit=1)[0]
+    build_step = _step_block(kernel_job, "name: Build and check wbcan.ko")
+
+    assert "linux-headers-generic" in kernel_job
+    assert "/usr/src/linux-headers-*-generic" in build_step
+    assert 'KDIR="$headers"' in build_step
+    assert "make -C kernel/wbcan clean" in build_step
+    assert "make -C kernel/wbcan checkpatch" in build_step


### PR DESCRIPTION
Closes #135

Depends on #115. Merge after #115.

## Summary
- use a wbcan MTU handler compatible with current Linux CAN APIs
- accept classic CAN MTU only and reject changes while the interface is up
- build the module against both runner and generic kernel headers in CI

## Verification
- Linux 6.17 and Linux 7.0 module builds passed locally
- checkpatch: 0 errors, 0 warnings
- release-workflow regression tests passed
- Task Packet validation passed
- privileged runtime: NOT_EXECUTED locally; the GitHub kernel-module job is required evidence