### PR TITLE
fix(kernel): keep CAN evidence accounting truthful

### DIFF
--- a/docs/task_packets/linux-wbcan-rtr-accounting.json
+++ b/docs/task_packets/linux-wbcan-rtr-accounting.json
@@ -1,0 +1,31 @@
+{
+  "issue": "139",
+  "human_owner": "Quchaosheng",
+  "objective": "Keep RTR byte accounting and bit-flip evidence aligned with actual CAN payload changes.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/test_wbcan.sh",
+    "docs/task_packets/linux-wbcan-rtr-accounting.json"
+  ],
+  "read_only_paths": ["firmware/**", "interfaces/**", "AGENTS.md"],
+  "forbidden": ["robot/control/**", "firmware/**", "interfaces/**"],
+  "acceptance": [
+    "RTR frames contribute zero TX and RX payload bytes",
+    "zero-length, short, and RTR frames cannot consume an ineligible bit-flip shot",
+    "no-op bit flips do not increment injected evidence",
+    "the next eligible full payload consumes and records the shot",
+    "standard CAN payload helpers define byte accounting"
+  ],
+  "commands": [
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test"
+  ],
+  "evidence": ["module build output", "checkpatch output", "RTR and bit-flip runtime assertions"],
+  "stop_conditions": [
+    "CAN FD or CAN XL support is required",
+    "firmware or interface changes are required",
+    "physical bus timing must be modelled"
+  ]
+}

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -172,6 +172,32 @@ out=$(capture 300 & sleep 0.1; cansend "$IFACE" 400#F0; wait)
 check "bit-flip changes byte 0 bit 0" \
       "1" "$(grep -ci 'F1' <<<"$out")"
 
+clear_fault
+arm "bit-flip 1 0 any 7 0"
+before_injected=$(stat injected)
+cansend "$IFACE" 401#AA
+cansend "$IFACE" 401#R8
+cansend "$IFACE" 401#
+check "ineligible bit-flip keeps its shot" "1" "$(stat shots_left)"
+check "ineligible bit-flip is not counted" \
+      "$before_injected" "$(stat injected)"
+out=$(capture 300 & sleep 0.1; cansend "$IFACE" 401#0000000000000000; wait)
+check "bit-flip waits for an eligible payload" \
+      "1" "$(grep -ci '0000000000000001' <<<"$out")"
+check "eligible bit-flip consumes its shot" "0" "$(stat shots_left)"
+
+clear_fault
+before_tx_bytes=$(cat "/sys/class/net/$IFACE/statistics/tx_bytes")
+before_rx_bytes=$(cat "/sys/class/net/$IFACE/statistics/rx_bytes")
+out=$(capture 300 & sleep 0.1; cansend "$IFACE" 402#R8; wait)
+after_tx_bytes=$(cat "/sys/class/net/$IFACE/statistics/tx_bytes")
+after_rx_bytes=$(cat "/sys/class/net/$IFACE/statistics/rx_bytes")
+check "RTR frame is delivered" "1" "$(grep -ci '402.*R' <<<"$out")"
+check "RTR contributes zero TX payload bytes" \
+      "0" "$((after_tx_bytes - before_tx_bytes))"
+check "RTR contributes zero RX payload bytes" \
+      "0" "$((after_rx_bytes - before_rx_bytes))"
+
 # --- 6. id filter: only the matching id takes the fault -------------------
 clear_fault
 arm "drop-tx 5 0 123"          # only id 0x123

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -101,14 +101,20 @@ static canid_t wbcan_match_key(canid_t id)
 	return id & CAN_SFF_MASK;
 }
 
-static bool wbcan_should_inject(struct wbcan_priv *priv, canid_t id,
+static bool wbcan_should_inject(struct wbcan_priv *priv, struct sk_buff *skb,
 				enum wbcan_fault *fault, u8 *flip_byte,
 				u8 *flip_bit)
 {
+	struct can_frame *cf = (struct can_frame *)skb->data;
+
 	if (priv->fault == WBCAN_FAULT_NONE || priv->fault_count == 0)
 		return false;
 
-	if (!priv->match_any && wbcan_match_key(id) != priv->match_id)
+	if (!priv->match_any && wbcan_match_key(cf->can_id) != priv->match_id)
+		return false;
+	if (priv->fault == WBCAN_FAULT_BIT_FLIP &&
+	    ((cf->can_id & CAN_RTR_FLAG) ||
+	     priv->flip_byte >= can_skb_get_data_len(skb)))
 		return false;
 
 	priv->stat_seen++;
@@ -229,6 +235,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	u8 flip_byte = 0;
 	u8 flip_bit = 0;
 	bool loop;
+	unsigned int len;
 	unsigned long flags;
 
 	if (can_dev_dropped_skb(dev, skb))
@@ -253,10 +260,11 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		return NETDEV_TX_OK;
 	}
 
-	wbcan_should_inject(priv, cf->can_id, &fault, &flip_byte, &flip_bit);
+	wbcan_should_inject(priv, skb, &fault, &flip_byte, &flip_bit);
 
 	priv->stat_tx++;
 	spin_unlock_irqrestore(&priv->lock, flags);
+	len = can_skb_get_data_len(skb);
 
 	switch (fault) {
 	case WBCAN_FAULT_TX_FULL:
@@ -288,7 +296,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		 * failure for firmware: no error, no frame.
 		 */
 		dev->stats.tx_packets++;
-		dev->stats.tx_bytes += cf->len;
+		dev->stats.tx_bytes += len;
 		kfree_skb(skb);
 		return NETDEV_TX_OK;
 
@@ -297,7 +305,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	}
 
 	dev->stats.tx_packets++;
-	dev->stats.tx_bytes += cf->len;
+	dev->stats.tx_bytes += len;
 	loop = skb->pkt_type == PACKET_LOOPBACK;
 	if (!loop) {
 		consume_skb(skb);
@@ -339,7 +347,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		rx_skb->ip_summed = CHECKSUM_UNNECESSARY;
 		rx_skb->pkt_type = PACKET_BROADCAST;
 		dev->stats.rx_packets++;
-		dev->stats.rx_bytes += cf->len;
+		dev->stats.rx_bytes += len;
 
 		spin_lock_irqsave(&priv->lock, flags);
 		priv->stat_rx++;


### PR DESCRIPTION
Closes #139

Depends on the #137 PR. Merge after it.

## Summary
- account TX/RX bytes from the actual SocketCAN payload length
- count RTR frames as zero payload bytes
- keep bit-flip shots armed until a frame has the requested payload byte

## Verification
- Linux 7.0 module build passed locally
- checkpatch: 0 errors, 0 warnings
- shell syntax and Task Packet validation passed
- privileged RTR/runtime checks: NOT_EXECUTED locally; the GitHub kernel-module job is required evidence