### PR TITLE
fix(kernel): expose truthful wbcan lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,19 @@ jobs:
           sudo modprobe can_raw
           modinfo can-dev
           sudo modprobe can-dev
+          sudo modprobe vcan
+          sudo ip link add wbcan0 type vcan
+          if sudo insmod kernel/wbcan/wbcan.ko; then
+            echo "wbcan unexpectedly loaded across a name collision"
+            exit 1
+          fi
+          test ! -e /sys/kernel/debug/wbcan
+          sudo ip link del wbcan0
           sudo insmod kernel/wbcan/wbcan.ko
+          if sudo insmod kernel/wbcan/wbcan.ko; then
+            echo "wbcan unexpectedly allowed duplicate module insertion"
+            exit 1
+          fi
           sudo ip link set wbcan0 type can restart-ms 100
           sudo ip link set wbcan0 up
           ip -details link show wbcan0
@@ -116,6 +128,8 @@ jobs:
         run: |
           sudo ip link set wbcan0 down 2>/dev/null || true
           sudo rmmod wbcan 2>/dev/null || true
+          test ! -e /sys/class/net/wbcan0
+          test ! -e /sys/kernel/debug/wbcan
 
   mcu-qemu:
     runs-on: ubuntu-24.04

--- a/docs/task_packets/linux-wbcan-singleton-lifecycle.json
+++ b/docs/task_packets/linux-wbcan-singleton-lifecycle.json
@@ -17,7 +17,7 @@
     "the module no longer advertises an unimplemented RTNL link kind",
     "ip link add type wbcan is rejected without creating a second device",
     "module unload removes the singleton device and debugfs tree",
-    "name collision and duplicate module insertion fail without partial state",
+    "the fixed wbcan0 name makes collision and duplicate module insertion fail without partial state",
     "CI verifies cleanup after the runtime suite"
   ],
   "commands": [

--- a/docs/task_packets/linux-wbcan-singleton-lifecycle.json
+++ b/docs/task_packets/linux-wbcan-singleton-lifecycle.json
@@ -1,0 +1,41 @@
+{
+  "issue": "140",
+  "human_owner": "Quchaosheng",
+  "objective": "Advertise and verify the module-load singleton lifecycle that wbcan actually implements.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/Makefile",
+    "kernel/wbcan/test_wbcan.sh",
+    ".github/workflows/ci.yml",
+    "tests/unit/test_release_workflow.py",
+    "docs/task_packets/linux-wbcan-singleton-lifecycle.json"
+  ],
+  "read_only_paths": ["firmware/**", "interfaces/**", "AGENTS.md"],
+  "forbidden": ["robot/control/**", "firmware/**", "interfaces/**"],
+  "acceptance": [
+    "module load creates one documented wbcan device",
+    "the module no longer advertises an unimplemented RTNL link kind",
+    "ip link add type wbcan is rejected without creating a second device",
+    "module unload removes the singleton device and debugfs tree",
+    "name collision and duplicate module insertion fail without partial state",
+    "CI verifies cleanup after the runtime suite"
+  ],
+  "commands": [
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "python -m pytest tests/unit/test_release_workflow.py -v",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test"
+  ],
+  "evidence": [
+    "module build output",
+    "checkpatch output",
+    "RTNL rejection assertion",
+    "post-unload device and debugfs assertions"
+  ],
+  "stop_conditions": [
+    "multiple devices or network namespaces become a requirement",
+    "firmware or interface changes are required",
+    "the hosted runner cannot unload the module"
+  ]
+}

--- a/kernel/wbcan/Makefile
+++ b/kernel/wbcan/Makefile
@@ -57,9 +57,10 @@ checkpatch:
 
 help:
 	@echo "make           build wbcan.ko against $(KDIR)"
-	@echo "make load      insmod and bring up $(IFACE)"
+	@echo "make load      create and bring up the module-load singleton $(IFACE)"
 	@echo "make test      run the fault suite"
 	@echo "make checkpatch  kernel style check"
+	@echo "ip link add type wbcan is unsupported; unload before loading another"
 	@echo ""
 	@echo "Arm a fault by hand:"
 	@echo "  echo 'drop-tx 3' | sudo tee /sys/kernel/debug/wbcan/$(IFACE)/inject"

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -63,6 +63,21 @@ check() {
 	fi
 }
 
+# wbcan is a module-load singleton, not an RTNL-created link kind.
+if ip link add dev wbcan-test type wbcan 2>/dev/null; then
+	check "RTNL creation is rejected for singleton wbcan" "rejected" "accepted"
+	ip link del dev wbcan-test 2>/dev/null || true
+else
+	check "RTNL creation is rejected for singleton wbcan" "rejected" "rejected"
+fi
+if ip link show wbcan-test >/dev/null 2>&1; then
+	red "FAIL  RTNL probe left an unexpected wbcan-test device"
+	FAIL=$((FAIL + 1))
+else
+	green "PASS  RTNL probe leaves singleton lifecycle unchanged"
+	PASS=$((PASS + 1))
+fi
+
 restart_if_bus_off() {
 	if [ "$(stat state)" = "bus-off" ]; then
 		ip link set "$IFACE" down

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -646,7 +646,7 @@ static int __init wbcan_init(void)
 
 	wbcan_dev->netdev_ops = &wbcan_netdev_ops;
 	wbcan_dev->flags |= IFF_ECHO;
-	strscpy(wbcan_dev->name, "wbcan%d", IFNAMSIZ);
+	strscpy(wbcan_dev->name, "wbcan0", IFNAMSIZ);
 
 	/*
 	 * No real bit timing: there is no wire. Advertising fixed bitrate

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -619,6 +619,11 @@ static const struct file_operations wbcan_status_fops = {
 static struct net_device *wbcan_dev;
 static struct dentry *wbcan_dbg_root;
 
+/*
+ * Lifecycle is intentionally singleton-only: module load creates wbcan0 and
+ * module unload removes it. This is not an RTNL link kind, so `ip link add
+ * ... type wbcan` is intentionally unsupported.
+ */
 static int __init wbcan_init(void)
 {
 	struct wbcan_priv *priv;
@@ -690,4 +695,3 @@ module_exit(wbcan_exit);
 
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Virtual CAN device with programmable fault injection");
-MODULE_ALIAS_RTNL_LINK("wbcan");

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -55,3 +55,15 @@ def test_kernel_module_builds_against_lts_and_runner_headers() -> None:
     assert 'KDIR="$headers"' in build_step
     assert "make -C kernel/wbcan clean" in build_step
     assert "make -C kernel/wbcan checkpatch" in build_step
+
+
+def test_kernel_module_unload_verifies_singleton_cleanup() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    load_step = _step_block(workflow, "name: Load the module and bring the interface up")
+    unload_step = _step_block(workflow, "name: Unload")
+
+    assert "sudo ip link add wbcan0 type vcan" in load_step
+    assert "name collision" in load_step
+    assert "duplicate module insertion" in load_step
+    assert "test ! -e /sys/class/net/wbcan0" in unload_step
+    assert "test ! -e /sys/kernel/debug/wbcan" in unload_step


### PR DESCRIPTION
Closes #140

Depends on the #138 PR. Merge after it.

## Summary
- keep the implemented module-load singleton lifecycle
- remove the false RTNL link alias
- test RTNL creation rejection, name collision, and duplicate insertion
- verify device and debugfs cleanup after module unload

## Verification
- Linux 7.0 module build passed locally
- checkpatch: 0 errors, 0 warnings
- 4 release-workflow tests and Makefile help check passed
- shell syntax and Task Packet validation passed
- privileged lifecycle runtime: NOT_EXECUTED locally; the GitHub kernel-module job is required evidence