### PR TITLE
fix(kernel): preserve SocketCAN echo ownership

### DIFF
--- a/docs/task_packets/linux-wbcan-echo-semantics.json
+++ b/docs/task_packets/linux-wbcan-echo-semantics.json
@@ -1,0 +1,32 @@
+{
+  "issue": "136",
+  "human_owner": "Quchaosheng",
+  "objective": "Preserve standard SocketCAN local-loopback ownership and own-message semantics in wbcan.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/test_wbcan.sh",
+    "docs/task_packets/linux-wbcan-echo-semantics.json"
+  ],
+  "read_only_paths": ["firmware/**", "interfaces/**", "AGENTS.md"],
+  "forbidden": ["robot/control/**", "firmware/**", "interfaces/**"],
+  "acceptance": [
+    "the sender does not receive its own frame by default",
+    "a peer socket receives enabled local loopback",
+    "opted-in own frames carry standard confirmation flags",
+    "CAN_RAW_LOOPBACK disabled suppresses local delivery",
+    "bit-flip operates on a private receive copy",
+    "allocation failure drops exactly one receive copy"
+  ],
+  "commands": [
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test"
+  ],
+  "evidence": ["module build output", "checkpatch output", "privileged own-message runtime assertions"],
+  "stop_conditions": [
+    "firmware or interface changes are required",
+    "the target kernel lacks standard SocketCAN echo helpers",
+    "the privileged runtime suite cannot execute"
+  ]
+}

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -24,6 +24,7 @@ need() {
 }
 need cansend
 need candump
+need python3
 
 [ -d "$DBG" ] || { red "no debugfs dir at $DBG - is the module loaded?"; exit 1; }
 ip link show "$IFACE" >/dev/null 2>&1 || { red "no interface $IFACE"; exit 1; }
@@ -78,6 +79,54 @@ clear_fault
 out=$(capture 300 & sleep 0.1; cansend "$IFACE" 123#DEADBEEF; wait)
 check "baseline delivers frame" \
       "1" "$(grep -c 'DEADBEEF' <<<"$out")"
+
+# SocketCAN own-message and local-loopback options must keep their standard
+# meaning even though this driver performs the echo itself.
+read -r own_default peer_default own_confirm loopback_off < <(
+	python3 - "$IFACE" <<'PY'
+import select
+import socket
+import struct
+import sys
+
+iface = sys.argv[1]
+frame = struct.Struct("=IB3x8s")
+
+
+def raw_socket():
+    sock = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+    sock.bind((iface,))
+    return sock
+
+
+def readable(sock):
+    return bool(select.select([sock], [], [], 0.2)[0])
+
+
+sender = raw_socket()
+peer = raw_socket()
+sender.send(frame.pack(0x710, 1, b"\x01" + b"\0" * 7))
+peer_default = int(readable(peer))
+if peer_default:
+    peer.recv(frame.size)
+own_default = int(readable(sender))
+
+sender.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_RECV_OWN_MSGS, 1)
+sender.send(frame.pack(0x711, 1, b"\x02" + b"\0" * 7))
+peer.recv(frame.size)
+_, _, flags, _ = sender.recvmsg(frame.size)
+own_confirm = int(bool(flags & socket.MSG_CONFIRM))
+
+sender.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_LOOPBACK, 0)
+sender.send(frame.pack(0x712, 1, b"\x03" + b"\0" * 7))
+loopback_off = int(readable(peer) or readable(sender))
+print(own_default, peer_default, own_confirm, loopback_off)
+PY
+)
+check "sender does not receive own frame by default" "0" "$own_default"
+check "peer receives local loopback" "1" "$peer_default"
+check "opted-in own frame carries confirmation" "1" "$own_confirm"
+check "disabled local loopback delivers nothing" "0" "$loopback_off"
 
 # --- 2. drop-tx: accepted, counted, never delivered ------------------------
 # The nastiest failure mode for firmware: no error, no frame.

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -213,6 +213,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	struct can_frame *cf = (struct can_frame *)skb->data;
 	struct sk_buff *rx_skb;
 	enum wbcan_fault fault = WBCAN_FAULT_NONE;
+	bool loop;
 	unsigned long flags;
 
 	if (can_dev_dropped_skb(dev, skb))
@@ -283,14 +284,27 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 
 	dev->stats.tx_packets++;
 	dev->stats.tx_bytes += cf->len;
+	loop = skb->pkt_type == PACKET_LOOPBACK;
+	if (!loop) {
+		consume_skb(skb);
+		return NETDEV_TX_OK;
+	}
 
 	/*
-	 * Deliver to local sockets. skb_clone because the RX path consumes it
-	 * and the TX echo may still want the original.
+	 * Preserve the originating socket so CAN_RAW_RECV_OWN_MSGS and receive
+	 * confirmation flags retain their standard SocketCAN meaning. Bit-flip
+	 * needs a private data copy because packet taps may hold shared clones.
 	 */
-	rx_skb = skb_clone(skb, GFP_ATOMIC);
+	if (fault == WBCAN_FAULT_BIT_FLIP) {
+		rx_skb = skb_copy(skb, GFP_ATOMIC);
+		if (rx_skb)
+			can_skb_set_owner(rx_skb, skb->sk);
+		consume_skb(skb);
+	} else {
+		rx_skb = can_create_echo_skb(skb);
+	}
 	if (!rx_skb) {
-		kfree_skb(skb);
+		dev->stats.rx_dropped++;
 		return NETDEV_TX_OK;
 	}
 
@@ -322,7 +336,6 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		netif_rx(rx_skb);
 	}
 
-	consume_skb(skb);
 	return NETDEV_TX_OK;
 }
 


### PR DESCRIPTION
Closes #136

Depends on the #135 PR. Merge after it.

## Summary
- preserve SocketCAN source ownership and confirmation semantics
- respect CAN_RAW_LOOPBACK and CAN_RAW_RECV_OWN_MSGS
- keep bit-flip mutation on a private skb copy

## Verification
- Linux 7.0 module build passed locally
- checkpatch: 0 errors, 0 warnings
- shell syntax and Task Packet validation passed
- privileged SocketCAN runtime: NOT_EXECUTED locally; the GitHub kernel-module job is required evidence