### PR TITLE
feat(monitoring): add bounded health snapshot core (#169)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN printf 'Acquire::Retries "10";\nAcquire::http::Timeout "120";\nAcquire::http
 
 WORKDIR /app
 COPY pyproject.toml README.md README.zh-CN.md LICENSE NOTICE ./
+COPY libs/application ./libs/application
 COPY libs/contracts ./libs/contracts
 COPY libs/hardware ./libs/hardware
 COPY libs/kernel ./libs/kernel

--- a/docs/performance/monitoring-local-2026-08-19.md
+++ b/docs/performance/monitoring-local-2026-08-19.md
@@ -1,0 +1,34 @@
+# Monitoring collector local evidence (2026-08-19)
+
+Status: **local software measured; target hardware and physical sources NOT_EXECUTED**.
+
+The report was generated on Linux x86_64, Python 3.12.3, Intel Core
+i7-14650HX (24 logical CPUs). It is not Jetson Orin or physical robot release
+evidence.
+
+```bash
+python3 tools/scripts/benchmark_monitoring.py \
+  --iterations 10000 \
+  --output runs/performance/monitoring.json
+```
+
+| Measurement | Local result |
+|---|---:|
+| CPU per snapshot | 72,963 ns |
+| Wall time per snapshot | 72,979 ns |
+| RSS before / after | 16,195,584 / 16,207,872 bytes |
+| PSS after | 13,584,384 bytes |
+| Scheduler context switches during 10,000 snapshots | 7 |
+| Threads before / after | 1 / 1 |
+| Collector-owned periodic wakeups | 0 |
+| Snapshot JSON / Prometheus projection | 8,313 / 840 bytes |
+
+The generated synthetic projections were `healthy` for a complete fresh
+snapshot, `unknown` for missing and stale critical sources, and `fault` for an
+E-stop channel fault. The raw report stays under the ignored `runs/` path and
+can be regenerated with the command above.
+
+These numbers are a development-host regression reference only. Target-class
+Jetson CPU/RSS/wakeup/output measurements and calibrated E-stop, BMS, CAN,
+Nav2, Motion and perception source evidence remain **NOT_EXECUTED** and must
+not be inferred from these fixtures.

--- a/docs/task_packets/monitoring-health-snapshot-169.json
+++ b/docs/task_packets/monitoring-health-snapshot-169.json
@@ -3,7 +3,9 @@
   "human_owner": "zhangjia-1111",
   "objective": "Collect a bounded in-process robot health snapshot from fixed, injectable metric sources.",
   "allowed_paths": [
+    "Dockerfile",
     "libs/application/workbench/application/monitoring.py",
+    "tests/unit/test_container_baseline.py",
     "tests/unit/test_monitoring.py",
     "tools/scripts/benchmark_monitoring.py",
     "docs/performance/monitoring-local-2026-08-19.md",

--- a/docs/task_packets/monitoring-health-snapshot-169.json
+++ b/docs/task_packets/monitoring-health-snapshot-169.json
@@ -1,0 +1,68 @@
+{
+  "issue": 169,
+  "human_owner": "zhangjia-1111",
+  "objective": "Collect a bounded in-process robot health snapshot from fixed, injectable metric sources.",
+  "allowed_paths": [
+    "libs/application/workbench/application/monitoring.py",
+    "tests/unit/test_monitoring.py",
+    "tools/scripts/benchmark_monitoring.py",
+    "docs/performance/monitoring-local-2026-08-19.md",
+    "docs/task_packets/monitoring-health-snapshot-169.json",
+    "pyproject.toml"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "interfaces/**",
+    "services/**",
+    "firmware/**",
+    "robot/**",
+    "hardware/**"
+  ],
+  "forbidden": [
+    "Prometheus server",
+    "Grafana",
+    "OpenTelemetry collector",
+    "time-series database",
+    "cloud telemetry",
+    "background monitoring daemon",
+    "raw image or model-prompt metrics"
+  ],
+  "acceptance": [
+    "fixed metric names define type, unit, domain, freshness and criticality",
+    "unknown metrics, invalid values, incompatible clocks and unapproved labels fail closed",
+    "gauges/counters are thread-safe and bounded",
+    "histograms use fixed bucket aggregates and do not retain every sample",
+    "missing, stale and faulted critical inputs produce unknown or fault health",
+    "a complete fresh fixture produces a serializable healthy snapshot",
+    "collector and snapshot updates are safe under concurrent access",
+    "fixed sources, timestamp ordering and equal-time conflicts fail closed",
+    "Linux and component or ROS-diagnostic readers are injectable",
+    "local CPU, RSS, scheduler, thread and output-size evidence is reproducible",
+    "target-hardware and physical-source evidence remains NOT_EXECUTED when unavailable"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/monitoring-health-snapshot-169.json",
+    "python3 -m pytest tests/unit/test_monitoring.py -q",
+    "python3 tools/scripts/benchmark_monitoring.py --output runs/performance/monitoring.json",
+    "python3 -m ruff check libs/application/workbench/application/monitoring.py tests/unit/test_monitoring.py tools/scripts/benchmark_monitoring.py",
+    "python3 -m ruff format --check libs/application/workbench/application/monitoring.py tests/unit/test_monitoring.py tools/scripts/benchmark_monitoring.py",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "focused monitoring test output",
+    "full repository test output",
+    "fixed registry and bounded histogram assertions",
+    "healthy, missing, stale and fault snapshot projections",
+    "docs/performance/monitoring-local-2026-08-19.md with target and physical evidence marked NOT_EXECUTED"
+  ],
+  "stop_conditions": [
+    "interface schema change is required",
+    "a component needs a new control or safety authority",
+    "a source cannot provide a monotonic timestamp",
+    "a production design requires an unbounded buffer or external service",
+    "physical sensor or E-stop evidence is requested without a connected bench"
+  ]
+}

--- a/libs/application/workbench/application/monitoring.py
+++ b/libs/application/workbench/application/monitoring.py
@@ -1,36 +1,997 @@
-"""Prometheus metrics"""
+"""Bounded, in-process health metrics and snapshots.
 
-import logging
+The collector is deliberately pull-driven: an owner records samples from its
+existing component or OS adapter, then asks for a snapshot. There is no
+monitoring thread, network exporter, or unbounded time-series buffer here.
+"""
 
-logger = logging.getLogger("Monitoring")
+from __future__ import annotations
+
+import math
+import re
+import shutil
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+
+class MetricError(ValueError):
+    """Raised when a metric or sample violates the monitoring contract."""
+
+
+class MetricKind(StrEnum):
+    GAUGE = "gauge"
+    COUNTER = "counter"
+    HISTOGRAM = "histogram"
+
+
+class HealthStatus(StrEnum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    FAULT = "fault"
+    UNKNOWN = "unknown"
+
+
+def _matches(value: object, candidates: tuple[Any, ...]) -> bool:
+    return any(type(value) is type(candidate) and value == candidate for candidate in candidates)
+
+
+def _finite_number(value: object) -> bool:
+    if type(value) not in {int, float}:
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+def _elapsed(current: int | float, previous: int | float) -> float:
+    elapsed = current - previous
+    if not _finite_number(elapsed):
+        raise MetricError("monotonic time difference must be finite")
+    return float(elapsed)
+
+
+def _valid_type(value_type: str, value: object) -> bool:
+    if value_type == "bool":
+        return type(value) is bool
+    if value_type == "int":
+        return type(value) is int and -(2**63) <= value < 2**63
+    if value_type == "float":
+        return _finite_number(value)
+    return type(value) is str and bool(value) and len(value) <= 128 and "\n" not in value and "\r" not in value
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    name: str
+    kind: MetricKind
+    unit: str
+    domain: str
+    value_type: str
+    freshness_s: float
+    critical: bool = False
+    fault_values: tuple[Any, ...] = ()
+    degraded_values: tuple[Any, ...] = ()
+    allowed_values: tuple[Any, ...] = ()
+    minimum: float | None = None
+    maximum: float | None = None
+    allowed_labels: tuple[str, ...] = ()
+    source: str = "component"
+    value_pattern: str | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.name) is not str
+            or len(self.name) > 80
+            or not re.fullmatch(r"[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+", self.name)
+        ):
+            raise MetricError(f"invalid metric name: {self.name!r}")
+        if not isinstance(self.kind, MetricKind):
+            raise MetricError(f"invalid metric kind: {self.kind!r}")
+        if type(self.value_type) is not str or self.value_type not in {"bool", "int", "float", "str"}:
+            raise MetricError(f"unsupported metric value type: {self.value_type!r}")
+        if type(self.critical) is not bool:
+            raise MetricError(f"metric criticality must be boolean: {self.name!r}")
+        if self.kind is MetricKind.COUNTER and self.value_type != "int":
+            raise MetricError(f"counter metric {self.name!r} must use integer values")
+        if self.kind is MetricKind.HISTOGRAM and self.value_type not in {"int", "float"}:
+            raise MetricError(f"histogram metric {self.name!r} must use numeric values")
+        value_sets = (self.fault_values, self.degraded_values, self.allowed_values)
+        if any(type(values) is not tuple or len(values) > 32 for values in value_sets):
+            raise MetricError(f"metric {self.name!r} has an unbounded value set")
+        if (
+            any(
+                type(value) is not str or not re.fullmatch(r"[A-Za-z][A-Za-z0-9_.:-]{0,63}", value)
+                for value in (self.domain, self.unit, self.source)
+            )
+            or not _finite_number(self.freshness_s)
+            or not 0.1 <= self.freshness_s <= 86_400
+        ):
+            raise MetricError("metric domain, unit, source, and freshness_s must be bounded and non-empty")
+        configured_values = self.fault_values + self.degraded_values + self.allowed_values
+        if any(not _valid_type(self.value_type, value) for value in configured_values):
+            raise MetricError(f"configured values have the wrong type for metric {self.name!r}")
+        if type(self.allowed_labels) is not tuple or any(type(label) is not str for label in self.allowed_labels):
+            raise MetricError(f"invalid labels for metric {self.name!r}")
+        if len(set(self.allowed_labels)) != len(self.allowed_labels):
+            raise MetricError(f"duplicate labels for metric {self.name!r}")
+        if len(self.allowed_labels) > 4 or any(
+            not re.fullmatch(r"[a-z][a-z0-9_]{0,31}", label) or label in {"le", "value"}
+            for label in self.allowed_labels
+        ):
+            raise MetricError(f"invalid labels for metric {self.name!r}")
+        if (self.minimum is not None or self.maximum is not None) and self.value_type not in {"int", "float"}:
+            raise MetricError(f"non-numeric metric {self.name!r} cannot have a range")
+        if any(not _finite_number(limit) for limit in (self.minimum, self.maximum) if limit is not None):
+            raise MetricError(f"metric {self.name!r} has a non-finite range")
+        if self.minimum is not None and self.maximum is not None and self.minimum > self.maximum:
+            raise MetricError(f"invalid range for metric {self.name!r}")
+        if any(_matches(value, self.degraded_values) for value in self.fault_values):
+            raise MetricError(f"fault and degraded values overlap for metric {self.name!r}")
+        if self.allowed_values and any(
+            not _matches(value, self.allowed_values) for value in self.fault_values + self.degraded_values
+        ):
+            raise MetricError(f"health values must be allowed for metric {self.name!r}")
+        if self.value_pattern is not None:
+            if self.value_type != "str" or type(self.value_pattern) is not str or len(self.value_pattern) > 256:
+                raise MetricError(f"invalid value pattern for metric {self.name!r}")
+            try:
+                re.compile(self.value_pattern)
+            except re.error as exc:
+                raise MetricError(f"invalid value pattern for metric {self.name!r}") from exc
+        if self.value_type == "str" and not self.allowed_values and self.value_pattern is None:
+            raise MetricError(f"string metric {self.name!r} must use an enum or identifier pattern")
+
+
+@dataclass(frozen=True)
+class MetricSample:
+    name: str
+    value: bool | int | float | str
+    observed_at: float
+    source: str
+    labels: tuple[tuple[str, str], ...] = ()
+    clock_id: str = "monotonic"
+
+
+@dataclass(frozen=True)
+class MetricView:
+    name: str
+    value: bool | int | float | str | None
+    unit: str
+    expected_source: str
+    source: str | None
+    observed_at: float | None
+    age_s: float | None
+    state: str
+    source_status: str
+    missing: bool = False
+    stale: bool = False
+
+
+@dataclass(frozen=True)
+class DomainHealth:
+    status: HealthStatus
+    metrics: tuple[MetricView, ...]
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    collected_at: float
+    clock_id: str
+    overall: HealthStatus
+    domains: tuple[tuple[str, DomainHealth], ...]
+
+    def domain(self, name: str) -> DomainHealth:
+        for domain, health in self.domains:
+            if domain == name:
+                return health
+        raise KeyError(name)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "collected_at": self.collected_at,
+            "clock_id": self.clock_id,
+            "overall": self.overall.value,
+            "domains": {
+                domain: {
+                    "status": health.status.value,
+                    "metrics": [asdict(metric) for metric in health.metrics],
+                }
+                for domain, health in self.domains
+            },
+        }
+
+
+def _validate_value(spec: MetricSpec, value: object) -> bool | int | float | str:
+    if not _valid_type(spec.value_type, value):
+        raise MetricError(f"{spec.name} expects a finite {spec.value_type}")
+    if spec.allowed_values and not _matches(value, spec.allowed_values):
+        raise MetricError(f"{spec.name} has an unsupported value")
+    if spec.value_pattern is not None and not re.fullmatch(spec.value_pattern, value):  # type: ignore[arg-type]
+        raise MetricError(f"{spec.name} has an invalid string value")
+    if spec.minimum is not None and float(value) < spec.minimum:
+        raise MetricError(f"{spec.name} is below its minimum")
+    if spec.maximum is not None and float(value) > spec.maximum:
+        raise MetricError(f"{spec.name} is above its maximum")
+    return value  # type: ignore[return-value]
+
+
+def _labels(spec: MetricSpec, labels: Mapping[str, str] | None) -> tuple[tuple[str, str], ...]:
+    if labels is not None and not isinstance(labels, Mapping):
+        raise MetricError(f"labels for {spec.name} must be a mapping")
+    values = {} if labels is None else dict(labels)
+    unknown = set(values) - set(spec.allowed_labels)
+    if unknown:
+        raise MetricError(f"unknown labels for {spec.name}: {sorted(unknown)}")
+    if len(values) > 4 or any(type(key) is not str or type(value) is not str for key, value in values.items()):
+        raise MetricError(f"labels for {spec.name} must be a bounded string mapping")
+    if any(
+        not re.fullmatch(r"[a-z][a-z0-9_]{0,31}", key) or not value or len(value) > 64 or "\n" in value or "\r" in value
+        for key, value in values.items()
+    ):
+        raise MetricError(f"labels for {spec.name} contain an invalid value")
+    return tuple(sorted(values.items()))
+
+
+DEFAULT_SPECS = (
+    MetricSpec(
+        "app.readiness",
+        MetricKind.GAUGE,
+        "bool",
+        "application",
+        "bool",
+        5.0,
+        degraded_values=(False,),
+        source="application",
+    ),
+    MetricSpec(
+        "app.uptime_seconds", MetricKind.GAUGE, "seconds", "application", "float", 10.0, minimum=0, source="application"
+    ),
+    MetricSpec(
+        "app.restart_count", MetricKind.COUNTER, "restarts", "application", "int", 60.0, minimum=0, source="supervisor"
+    ),
+    MetricSpec(
+        "app.queue_depth", MetricKind.GAUGE, "items", "application", "int", 10.0, minimum=0, source="application"
+    ),
+    MetricSpec(
+        "app.last_successful_cycle_age_seconds",
+        MetricKind.GAUGE,
+        "seconds",
+        "application",
+        "float",
+        10.0,
+        minimum=0,
+        source="application",
+    ),
+    MetricSpec(
+        "compute.cpu_percent",
+        MetricKind.GAUGE,
+        "percent",
+        "compute",
+        "float",
+        10.0,
+        minimum=0,
+        maximum=100,
+        source="linux.proc",
+    ),
+    MetricSpec(
+        "compute.memory_percent",
+        MetricKind.GAUGE,
+        "percent",
+        "compute",
+        "float",
+        10.0,
+        minimum=0,
+        maximum=100,
+        source="linux.proc",
+    ),
+    MetricSpec(
+        "compute.disk_free_bytes",
+        MetricKind.GAUGE,
+        "bytes",
+        "compute",
+        "int",
+        30.0,
+        minimum=0,
+        source="linux.statvfs",
+    ),
+    MetricSpec(
+        "compute.disk_growth_bytes",
+        MetricKind.GAUGE,
+        "bytes",
+        "compute",
+        "int",
+        30.0,
+        source="linux.statvfs",
+    ),
+    MetricSpec("compute.load_1m", MetricKind.GAUGE, "load", "compute", "float", 10.0, minimum=0, source="linux.proc"),
+    MetricSpec(
+        "compute.temperature_celsius",
+        MetricKind.GAUGE,
+        "celsius",
+        "compute",
+        "float",
+        30.0,
+        source="linux.sysfs",
+    ),
+    MetricSpec(
+        "safety.estop_channels_ok",
+        MetricKind.GAUGE,
+        "bool",
+        "safety",
+        "bool",
+        1.0,
+        True,
+        (False,),
+        source="safety_mcu",
+    ),
+    MetricSpec(
+        "safety.mcu_watchdog_ok",
+        MetricKind.GAUGE,
+        "bool",
+        "safety",
+        "bool",
+        1.0,
+        True,
+        (False,),
+        source="safety_mcu",
+    ),
+    MetricSpec(
+        "safety.contactor_permission",
+        MetricKind.GAUGE,
+        "bool",
+        "safety",
+        "bool",
+        1.0,
+        True,
+        source="safety_mcu",
+    ),
+    MetricSpec(
+        "power.bms_state",
+        MetricKind.GAUGE,
+        "state",
+        "power",
+        "str",
+        5.0,
+        True,
+        ("FAULT_LATCHED",),
+        ("DERATE",),
+        ("OFF", "SELF_TEST", "STANDBY", "PRECHARGE", "RUN", "CHARGE", "DERATE", "FAULT_LATCHED", "SERVICE"),
+        source="bms",
+    ),
+    MetricSpec(
+        "power.soc_percent",
+        MetricKind.GAUGE,
+        "percent",
+        "power",
+        "float",
+        30.0,
+        minimum=0,
+        maximum=100,
+        source="bms",
+    ),
+    MetricSpec(
+        "power.pack_voltage_volts",
+        MetricKind.GAUGE,
+        "volts",
+        "power",
+        "float",
+        10.0,
+        minimum=0,
+        source="bms",
+    ),
+    MetricSpec("power.pack_current_amperes", MetricKind.GAUGE, "amperes", "power", "float", 10.0, source="bms"),
+    MetricSpec("power.pack_temperature_celsius", MetricKind.GAUGE, "celsius", "power", "float", 10.0, source="bms"),
+    MetricSpec("can.link_ok", MetricKind.GAUGE, "bool", "communication", "bool", 1.0, True, (False,), source="can"),
+    MetricSpec(
+        "can.bus_state",
+        MetricKind.GAUGE,
+        "state",
+        "communication",
+        "str",
+        1.0,
+        True,
+        ("bus-off", "error"),
+        ("warning",),
+        ("active", "warning", "bus-off", "error"),
+        source="can",
+    ),
+    MetricSpec("can.error_count", MetricKind.COUNTER, "errors", "communication", "int", 10.0, minimum=0, source="can"),
+    MetricSpec(
+        "can.last_frame_age_seconds",
+        MetricKind.GAUGE,
+        "seconds",
+        "communication",
+        "float",
+        1.0,
+        minimum=0,
+        source="can",
+    ),
+    MetricSpec(
+        "event_store.integrity_ok",
+        MetricKind.GAUGE,
+        "bool",
+        "communication",
+        "bool",
+        5.0,
+        True,
+        (False,),
+        source="event_store",
+    ),
+    MetricSpec(
+        "backend.available",
+        MetricKind.GAUGE,
+        "bool",
+        "communication",
+        "bool",
+        5.0,
+        degraded_values=(False,),
+        source="backend",
+    ),
+    MetricSpec("nav.localization_ok", MetricKind.GAUGE, "bool", "robot", "bool", 1.0, True, (False,), source="nav2"),
+    MetricSpec("motion.controller_ok", MetricKind.GAUGE, "bool", "robot", "bool", 1.0, True, (False,), source="motion"),
+    MetricSpec(
+        "motion.stop_state",
+        MetricKind.GAUGE,
+        "state",
+        "robot",
+        "str",
+        1.0,
+        True,
+        ("fault",),
+        ("requested",),
+        ("idle", "requested", "confirmed", "fault"),
+        source="motion",
+    ),
+    MetricSpec("perception.fresh", MetricKind.GAUGE, "bool", "robot", "bool", 1.0, True, (False,), source="perception"),
+    MetricSpec("task.active", MetricKind.GAUGE, "bool", "task", "bool", 10.0, source="agent_runtime"),
+    MetricSpec(
+        "task.run_id",
+        MetricKind.GAUGE,
+        "id",
+        "task",
+        "str",
+        10.0,
+        source="agent_runtime",
+        value_pattern=r"[A-Za-z0-9][A-Za-z0-9._:-]{0,63}",
+    ),
+    MetricSpec(
+        "task.action_id",
+        MetricKind.GAUGE,
+        "id",
+        "task",
+        "str",
+        10.0,
+        source="agent_runtime",
+        value_pattern=r"[A-Za-z0-9][A-Za-z0-9._:-]{0,63}",
+    ),
+    MetricSpec(
+        "task.verification_state",
+        MetricKind.GAUGE,
+        "state",
+        "task",
+        "str",
+        10.0,
+        allowed_values=("none", "running", "confirmed", "refuted", "insufficient_evidence"),
+        source="world_model",
+    ),
+    MetricSpec(
+        "task.timeout_count",
+        MetricKind.COUNTER,
+        "timeouts",
+        "task",
+        "int",
+        60.0,
+        minimum=0,
+        source="agent_runtime",
+    ),
+    MetricSpec(
+        "task.fault_count",
+        MetricKind.COUNTER,
+        "faults",
+        "task",
+        "int",
+        60.0,
+        minimum=0,
+        source="agent_runtime",
+    ),
+)
+
+
+class MetricRegistry:
+    """Fixed metric definitions; no dynamic production registration."""
+
+    def __init__(self, specs: tuple[MetricSpec, ...] = DEFAULT_SPECS) -> None:
+        if (
+            type(specs) is not tuple
+            or not 1 <= len(specs) <= 256
+            or any(not isinstance(spec, MetricSpec) for spec in specs)
+        ):
+            raise MetricError("registry must contain between 1 and 256 metric specifications")
+        names = [spec.name for spec in specs]
+        if len(names) != len(set(names)):
+            raise MetricError("duplicate metric registration")
+        projected = [name.replace(".", "_") for name in names]
+        if len(projected) != len(set(projected)):
+            raise MetricError("metric names collide in Prometheus projection")
+        self._specs = {spec.name: spec for spec in specs}
+
+    def get(self, name: str) -> MetricSpec:
+        try:
+            return self._specs[name]
+        except KeyError:
+            raise MetricError(f"unknown metric: {name!r}") from None
+
+    def specs(self) -> tuple[MetricSpec, ...]:
+        return tuple(self._specs.values())
 
 
 class SystemMetrics:
-    """Prometheus-compatible metrics collection"""
+    """Thread-safe bounded metric storage with a Prometheus text projection."""
 
-    def __init__(self):
-        self.counters = {}
-        self.gauges = {}
-        self.histograms = {}
+    def __init__(
+        self,
+        registry: MetricRegistry | None = None,
+        *,
+        histogram_buckets: tuple[float, ...] = (0.01, 0.05, 0.1, 0.5, 1.0),
+        max_series: int = 256,
+    ) -> None:
+        if (
+            type(histogram_buckets) is not tuple
+            or not 1 <= len(histogram_buckets) <= 64
+            or any(not _finite_number(bucket) or bucket <= 0 for bucket in histogram_buckets)
+            or any(left >= right for left, right in pairwise(histogram_buckets))
+        ):
+            raise MetricError("histogram buckets must be positive finite values")
+        if type(max_series) is not int or not 1 <= max_series <= 1024:
+            raise MetricError("max_series must be between 1 and 1024")
+        self.registry = registry or MetricRegistry()
+        self.histogram_buckets = histogram_buckets
+        self.max_series = max_series
+        self._samples: dict[tuple[str, tuple[tuple[str, str], ...]], MetricSample] = {}
+        self._histograms: dict[tuple[str, tuple[tuple[str, str], ...]], tuple[int, float, list[int]]] = {}
+        self._conflicts: set[tuple[str, tuple[tuple[str, str], ...]]] = set()
+        self._lock = threading.RLock()
 
-    def increment_counter(self, name: str, value: int = 1) -> None:
-        self.counters[name] = self.counters.get(name, 0) + value
+    def _make_sample(
+        self,
+        name: str,
+        value: object,
+        *,
+        source: str,
+        observed_at: float,
+        labels: Mapping[str, str] | None,
+    ) -> MetricSample:
+        spec = self.registry.get(name)
+        if source != spec.source:
+            raise MetricError(f"{name} expects source {spec.source!r}")
+        if not _finite_number(observed_at):
+            raise MetricError("observed_at must be finite")
+        return MetricSample(name, _validate_value(spec, value), float(observed_at), source, _labels(spec, labels))
 
-    def set_gauge(self, name: str, value: float) -> None:
-        self.gauges[name] = value
+    def _record(
+        self,
+        name: str,
+        value: object,
+        *,
+        source: str,
+        observed_at: float,
+        labels: Mapping[str, str] | None,
+        allow_same_timestamp_update: bool = False,
+    ) -> MetricSample:
+        spec = self.registry.get(name)
+        sample = self._make_sample(name, value, source=source, observed_at=observed_at, labels=labels)
+        with self._lock:
+            key = (name, sample.labels)
+            if key not in self._samples and len(self._samples) >= self.max_series:
+                raise MetricError("metric series limit reached")
+            current = self._samples.get(key)
+            if current is not None:
+                if sample.observed_at < current.observed_at:
+                    raise MetricError("metric timestamp regressed")
+                if (
+                    sample.observed_at == current.observed_at
+                    and not allow_same_timestamp_update
+                    and not _matches(sample.value, (current.value,))
+                ):
+                    self._conflicts.add(key)
+                    raise MetricError("metric values conflict at the same timestamp")
+                if spec.kind is MetricKind.COUNTER and sample.value < current.value:  # type: ignore[operator]
+                    raise MetricError("counter value regressed")
+                if sample.observed_at > current.observed_at:
+                    self._conflicts.discard(key)
+            self._samples[key] = sample
+        return sample
 
-    def record_histogram(self, name: str, value: float) -> None:
-        if name not in self.histograms:
-            self.histograms[name] = []
-        self.histograms[name].append(value)
+    def set_gauge(
+        self,
+        name: str,
+        value: object,
+        *,
+        source: str | None = None,
+        observed_at: float | None = None,
+        labels: Mapping[str, str] | None = None,
+    ) -> None:
+        spec = self.registry.get(name)
+        if spec.kind is not MetricKind.GAUGE:
+            raise MetricError(f"{name} is not a gauge")
+        self._record(
+            name,
+            value,
+            source=spec.source if source is None else source,
+            observed_at=time.monotonic() if observed_at is None else observed_at,
+            labels=labels,
+        )
+
+    def increment_counter(
+        self,
+        name: str,
+        value: int = 1,
+        *,
+        source: str | None = None,
+        observed_at: float | None = None,
+        labels: Mapping[str, str] | None = None,
+    ) -> None:
+        spec = self.registry.get(name)
+        if spec.kind is not MetricKind.COUNTER or type(value) is not int or value < 0:
+            raise MetricError(f"{name} is not a non-negative integer counter")
+        normalized_labels = _labels(spec, labels)
+        key = (name, normalized_labels)
+        with self._lock:
+            current = self._samples.get(key)
+            total = int(current.value) if current else 0
+            self._record(
+                name,
+                total + value,
+                source=spec.source if source is None else source,
+                observed_at=time.monotonic() if observed_at is None else observed_at,
+                labels=dict(normalized_labels),
+                allow_same_timestamp_update=True,
+            )
+
+    def set_counter(
+        self,
+        name: str,
+        value: object,
+        *,
+        source: str | None = None,
+        observed_at: float | None = None,
+        labels: Mapping[str, str] | None = None,
+    ) -> None:
+        spec = self.registry.get(name)
+        if spec.kind is not MetricKind.COUNTER or type(value) is not int or value < 0:
+            raise MetricError(f"{name} is not a non-negative integer counter")
+        self._record(
+            name,
+            value,
+            source=spec.source if source is None else source,
+            observed_at=time.monotonic() if observed_at is None else observed_at,
+            labels=labels,
+        )
+
+    def record_histogram(
+        self,
+        name: str,
+        value: object,
+        *,
+        source: str | None = None,
+        observed_at: float | None = None,
+        labels: Mapping[str, str] | None = None,
+    ) -> None:
+        spec = self.registry.get(name)
+        if spec.kind is not MetricKind.HISTOGRAM:
+            raise MetricError(f"{name} is not a finite histogram")
+        sample = self._make_sample(
+            name,
+            value,
+            source=spec.source if source is None else source,
+            observed_at=time.monotonic() if observed_at is None else observed_at,
+            labels=labels,
+        )
+        key = (name, sample.labels)
+        with self._lock:
+            if key not in self._samples and len(self._samples) >= self.max_series:
+                raise MetricError("metric series limit reached")
+            current = self._samples.get(key)
+            if current is not None and sample.observed_at < current.observed_at:
+                raise MetricError("metric timestamp regressed")
+            numeric_value = float(sample.value)
+            count, total, buckets = self._histograms.get(key, (0, 0.0, [0] * len(self.histogram_buckets)))
+            if count >= 2**63 - 1:
+                raise MetricError("histogram count limit reached")
+            new_total = total + numeric_value
+            if not math.isfinite(new_total):
+                raise MetricError("histogram aggregate is not finite")
+            buckets = buckets.copy()
+            for index, bucket in enumerate(self.histogram_buckets):
+                if numeric_value <= bucket:
+                    buckets[index] += 1
+            self._samples[key] = sample
+            self._histograms[key] = (count + 1, new_total, buckets)
+
+    def samples(self) -> tuple[MetricSample, ...]:
+        with self._lock:
+            return tuple(self._samples.values())
+
+    def current_state(
+        self,
+    ) -> tuple[tuple[MetricSample, ...], frozenset[tuple[str, tuple[tuple[str, str], ...]]]]:
+        with self._lock:
+            return tuple(self._samples.values()), frozenset(self._conflicts)
 
     def export_prometheus(self) -> str:
-        lines = []
-        for name, value in self.counters.items():
-            lines.append(f"{name} {value}")
-        for name, value in self.gauges.items():
-            lines.append(f"{name} {value}")
-        return "\n".join(lines)
+        with self._lock:
+            samples = tuple(self._samples.values())
+            conflicts = frozenset(self._conflicts)
+            histograms = {
+                key: (count, total, tuple(buckets)) for key, (count, total, buckets) in self._histograms.items()
+            }
+        lines: list[str] = []
+        for sample in sorted(samples, key=lambda item: (item.name, item.labels)):
+            if (sample.name, sample.labels) in conflicts:
+                continue
+            spec = self.registry.get(sample.name)
+            name = sample.name.replace(".", "_")
+            labels = _format_labels(sample.labels)
+            if spec.kind is MetricKind.HISTOGRAM:
+                count, total, counts = histograms[(sample.name, sample.labels)]
+                for bucket, bucket_count in zip(self.histogram_buckets, counts, strict=True):
+                    lines.append(f"{name}_bucket{_format_labels((*sample.labels, ('le', str(bucket))))} {bucket_count}")
+                lines.append(f'{name}_bucket{_format_labels((*sample.labels, ("le", "+Inf")))} {count}')
+                lines.append(f"{name}_count{labels} {count}")
+                lines.append(f"{name}_sum{labels} {total}")
+            else:
+                if type(sample.value) is str:
+                    if spec.allowed_values:
+                        lines.append(f"{name}{_format_labels((*sample.labels, ('value', sample.value)))} 1")
+                else:
+                    value = int(sample.value) if type(sample.value) is bool else sample.value
+                    lines.append(f"{name}{labels} {value}")
+        return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _format_labels(labels: tuple[tuple[str, str], ...]) -> str:
+    if not labels:
+        return ""
+    encoded = []
+    for key, value in sorted(labels):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        encoded.append(f'{key}="{escaped}"')
+    return "{" + ",".join(encoded) + "}"
+
+
+class HealthSnapshotCollector:
+    """Evaluate current fixed-registry samples without owning a scheduler."""
+
+    def __init__(
+        self,
+        metrics: SystemMetrics | None = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        sampling_interval_s: float = 1.0,
+    ) -> None:
+        if not _finite_number(sampling_interval_s) or not 0.1 <= sampling_interval_s <= 3_600:
+            raise MetricError("sampling_interval_s must be between 0.1 and 3600 seconds")
+        self.metrics = metrics or SystemMetrics()
+        if any(spec.allowed_labels for spec in self.metrics.registry.specs()):
+            raise MetricError("health snapshots require one unlabelled series per metric")
+        self.clock = clock
+        self.sampling_interval_s = float(sampling_interval_s)
+
+    def is_due(self, last_collected_at: float | None, *, now: float | None = None) -> bool:
+        current = self.clock() if now is None else now
+        if not _finite_number(current):
+            raise MetricError("current monotonic time must be finite")
+        if last_collected_at is None:
+            return True
+        if not _finite_number(last_collected_at):
+            raise MetricError("last collected monotonic time must be finite")
+        if current < last_collected_at:
+            raise MetricError("monotonic clock regressed")
+        return _elapsed(current, last_collected_at) >= self.sampling_interval_s
+
+    def record(
+        self,
+        name: str,
+        value: object,
+        *,
+        source: str,
+        observed_at: float | None = None,
+        clock_id: str = "monotonic",
+        labels: Mapping[str, str] | None = None,
+    ) -> None:
+        if clock_id != "monotonic":
+            raise MetricError("only monotonic samples can be compared")
+        spec = self.metrics.registry.get(name)
+        timestamp = self.clock() if observed_at is None else observed_at
+        if spec.kind is MetricKind.GAUGE:
+            self.metrics.set_gauge(name, value, source=source, observed_at=timestamp, labels=labels)
+        elif spec.kind is MetricKind.COUNTER:
+            self.metrics.set_counter(name, value, source=source, observed_at=timestamp, labels=labels)
+        else:
+            self.metrics.record_histogram(name, value, source=source, observed_at=timestamp, labels=labels)
+
+    def snapshot(self, *, collected_at: float | None = None) -> HealthSnapshot:
+        now = self.clock() if collected_at is None else collected_at
+        if not _finite_number(now):
+            raise MetricError("collected_at must be finite")
+        current_samples, conflicts = self.metrics.current_state()
+        samples = {(sample.name, sample.labels): sample for sample in current_samples}
+        domains: dict[str, list[MetricView]] = {}
+        domain_states: dict[str, list[HealthStatus]] = {}
+        for spec in self.metrics.registry.specs():
+            sample = samples.get((spec.name, ()))
+            views = domains.setdefault(spec.domain, [])
+            states = domain_states.setdefault(spec.domain, [])
+            if sample is None:
+                view = MetricView(spec.name, None, spec.unit, spec.source, None, None, None, "missing", "missing", True)
+                states.append(HealthStatus.UNKNOWN if spec.critical else HealthStatus.DEGRADED)
+            else:
+                age = _elapsed(now, sample.observed_at)
+                stale = age < 0 or sample.clock_id != "monotonic" or age > spec.freshness_s
+                conflict = (spec.name, ()) in conflicts
+                fault = _matches(sample.value, spec.fault_values)
+                degraded = _matches(sample.value, spec.degraded_values)
+                state = (
+                    "conflict"
+                    if conflict
+                    else "fault"
+                    if fault
+                    else "stale"
+                    if stale
+                    else "degraded"
+                    if degraded
+                    else "fresh"
+                )
+                view = MetricView(
+                    spec.name,
+                    None if conflict else sample.value,
+                    spec.unit,
+                    spec.source,
+                    sample.source,
+                    sample.observed_at,
+                    age,
+                    state,
+                    "conflict" if conflict else "stale" if stale else "available",
+                    stale=stale,
+                )
+                states.append(
+                    HealthStatus.FAULT
+                    if (conflict and spec.critical) or fault
+                    else HealthStatus.UNKNOWN
+                    if stale and spec.critical
+                    else HealthStatus.DEGRADED
+                    if conflict or stale or degraded
+                    else HealthStatus.HEALTHY
+                )
+            views.append(view)
+        result = []
+        for domain in sorted(domains):
+            result.append((domain, DomainHealth(_worst(domain_states[domain]), tuple(domains[domain]))))
+        return HealthSnapshot(float(now), "monotonic", _worst([health.status for _, health in result]), tuple(result))
+
+
+def _worst(states: list[HealthStatus]) -> HealthStatus:
+    for status in (HealthStatus.FAULT, HealthStatus.UNKNOWN, HealthStatus.DEGRADED, HealthStatus.HEALTHY):
+        if status in states:
+            return status
+    return HealthStatus.UNKNOWN
+
+
+class LinuxHealthAdapter:
+    """Pull bounded host metrics from injectable procfs/sysfs readers."""
+
+    def __init__(
+        self,
+        *,
+        read_text: Callable[[str], str] | None = None,
+        disk_usage: Callable[[str], tuple[int, int, int]] = shutil.disk_usage,
+        disk_path: str = "/",
+        thermal_path: str = "/sys/class/thermal/thermal_zone0/temp",
+    ) -> None:
+        self.read_text = read_text or (lambda path: Path(path).read_text(encoding="utf-8"))
+        self.disk_usage = disk_usage
+        self.disk_path = disk_path
+        self.thermal_path = thermal_path
+        self._cpu_ticks: tuple[int, int] | None = None
+        self._disk_used: int | None = None
+        self._lock = threading.Lock()
+
+    def collect(self, collector: HealthSnapshotCollector, *, observed_at: float | None = None) -> tuple[str, ...]:
+        timestamp = collector.clock() if observed_at is None else observed_at
+        collected: list[str] = []
+
+        def record(name: str, value: object, source: str) -> None:
+            collector.record(name, value, source=source, observed_at=timestamp)
+            collected.append(name)
+
+        try:
+            values = {
+                line.split(":", 1)[0]: int(line.split()[1])
+                for line in self.read_text("/proc/meminfo").splitlines()
+                if ":" in line and len(line.split()) >= 2
+            }
+            memory_percent = 100.0 * (values["MemTotal"] - values["MemAvailable"]) / values["MemTotal"]
+            record("compute.memory_percent", memory_percent, "linux.proc")
+        except (OSError, TypeError, ValueError, KeyError, ZeroDivisionError):
+            pass
+
+        try:
+            record("compute.load_1m", float(self.read_text("/proc/loadavg").split()[0]), "linux.proc")
+        except (OSError, TypeError, ValueError, IndexError):
+            pass
+
+        try:
+            fields = [int(value) for value in self.read_text("/proc/stat").splitlines()[0].split()[1:9]]
+            total, idle = sum(fields), fields[3] + fields[4]
+            with self._lock:
+                previous = self._cpu_ticks
+                self._cpu_ticks = (total, idle)
+            if previous is not None and total > previous[0]:
+                cpu_percent = 100.0 * (1.0 - (idle - previous[1]) / (total - previous[0]))
+                record("compute.cpu_percent", min(100.0, max(0.0, cpu_percent)), "linux.proc")
+        except (OSError, TypeError, ValueError, IndexError):
+            pass
+
+        try:
+            _total, used, free = self.disk_usage(self.disk_path)
+            with self._lock:
+                previous_used = self._disk_used
+                self._disk_used = used
+            record("compute.disk_free_bytes", free, "linux.statvfs")
+            if previous_used is not None:
+                record("compute.disk_growth_bytes", used - previous_used, "linux.statvfs")
+        except (OSError, TypeError, ValueError):
+            pass
+
+        try:
+            temperature = float(self.read_text(self.thermal_path).strip())
+            record(
+                "compute.temperature_celsius",
+                temperature / 1_000,
+                "linux.sysfs",
+            )
+        except (OSError, TypeError, ValueError):
+            pass
+
+        return tuple(collected)
+
+
+class ComponentHealthAdapter:
+    """Pull a bounded set of component or ROS-diagnostic readers."""
+
+    def __init__(self, source: str, readers: Mapping[str, Callable[[], object]]) -> None:
+        if type(source) is not str or not re.fullmatch(r"[A-Za-z][A-Za-z0-9_.:-]{0,63}", source):
+            raise MetricError("adapter source must be a bounded identifier")
+        if not isinstance(readers, Mapping) or not 1 <= len(readers) <= 32:
+            raise MetricError("adapter requires between 1 and 32 readers")
+        if any(type(name) is not str or not callable(reader) for name, reader in readers.items()):
+            raise MetricError("adapter readers must map metric names to callables")
+        self.source = source
+        self.readers = tuple(sorted(readers.items()))
+        self._lock = threading.Lock()
+
+    def collect(self, collector: HealthSnapshotCollector, *, observed_at: float | None = None) -> tuple[str, ...]:
+        timestamp = collector.clock() if observed_at is None else observed_at
+        collected = []
+        with self._lock:
+            for name, reader in self.readers:
+                spec = collector.metrics.registry.get(name)
+                if spec.source != self.source:
+                    raise MetricError(f"{name} does not belong to source {self.source!r}")
+                try:
+                    value = reader()
+                except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError):
+                    continue
+                collector.record(name, value, source=self.source, observed_at=timestamp)
+                collected.append(name)
+        return tuple(collected)
 
 
 system_metrics = SystemMetrics()

--- a/libs/application/workbench/application/monitoring.py
+++ b/libs/application/workbench/application/monitoring.py
@@ -743,7 +743,7 @@ class SystemMetrics:
                 count, total, counts = histograms[(sample.name, sample.labels)]
                 for bucket, bucket_count in zip(self.histogram_buckets, counts, strict=True):
                     lines.append(f"{name}_bucket{_format_labels((*sample.labels, ('le', str(bucket))))} {bucket_count}")
-                lines.append(f'{name}_bucket{_format_labels((*sample.labels, ("le", "+Inf")))} {count}')
+                lines.append(f"{name}_bucket{_format_labels((*sample.labels, ('le', '+Inf')))} {count}")
                 lines.append(f"{name}_count{labels} {count}")
                 lines.append(f"{name}_sum{labels} {total}")
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ docs = [
 
 [tool.setuptools]
 packages = [
+  "workbench.application",
   "workbench.hardware",
   "workbench.kernel",
   "workbench_agent_runtime",
@@ -35,6 +36,7 @@ packages = [
 ]
 
 [tool.setuptools.package-dir]
+"workbench.application" = "libs/application/workbench/application"
 "workbench.hardware" = "libs/hardware/workbench/hardware"
 "workbench.kernel" = "libs/kernel/workbench/kernel"
 workbench_agent_runtime = "services/agent_runtime/workbench_agent_runtime"

--- a/tests/unit/test_container_baseline.py
+++ b/tests/unit/test_container_baseline.py
@@ -15,6 +15,7 @@ def test_runtime_container_copies_installable_workbench_packages_before_install(
     install_offset = dockerfile.index("python -m pip install --no-compile .")
 
     for package_copy in (
+        "COPY libs/application ./libs/application",
         "COPY libs/hardware ./libs/hardware",
         "COPY libs/kernel ./libs/kernel",
     ):

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,323 @@
+import sys
+import threading
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "application"))
+sys.path.insert(0, str(ROOT / "tools" / "scripts"))
+
+from benchmark_monitoring import benchmark
+from workbench.application.monitoring import (
+    DEFAULT_SPECS,
+    ComponentHealthAdapter,
+    HealthSnapshotCollector,
+    HealthStatus,
+    LinuxHealthAdapter,
+    MetricError,
+    MetricKind,
+    MetricRegistry,
+    MetricSpec,
+    SystemMetrics,
+)
+
+
+def record(collector: HealthSnapshotCollector, name: str, value: object, *, observed_at: float | None = None) -> None:
+    collector.record(
+        name,
+        value,
+        source=collector.metrics.registry.get(name).source,
+        observed_at=observed_at,
+    )
+
+
+def complete(collector: HealthSnapshotCollector, now: float = 100.0) -> None:
+    values = {
+        "app.readiness": True,
+        "app.uptime_seconds": 60.0,
+        "app.restart_count": 0,
+        "app.queue_depth": 0,
+        "app.last_successful_cycle_age_seconds": 0.1,
+        "compute.cpu_percent": 12.0,
+        "compute.memory_percent": 25.0,
+        "compute.disk_free_bytes": 10_000_000,
+        "compute.temperature_celsius": 40.0,
+        "compute.disk_growth_bytes": 0,
+        "compute.load_1m": 0.5,
+        "safety.estop_channels_ok": True,
+        "safety.mcu_watchdog_ok": True,
+        "safety.contactor_permission": True,
+        "power.bms_state": "RUN",
+        "power.soc_percent": 80.0,
+        "power.pack_voltage_volts": 48.0,
+        "power.pack_current_amperes": 0.0,
+        "power.pack_temperature_celsius": 30.0,
+        "can.link_ok": True,
+        "can.bus_state": "active",
+        "can.error_count": 0,
+        "can.last_frame_age_seconds": 0.1,
+        "event_store.integrity_ok": True,
+        "backend.available": True,
+        "nav.localization_ok": True,
+        "motion.controller_ok": True,
+        "motion.stop_state": "idle",
+        "perception.fresh": True,
+        "task.active": False,
+        "task.run_id": "none",
+        "task.action_id": "none",
+        "task.verification_state": "none",
+        "task.timeout_count": 0,
+        "task.fault_count": 0,
+    }
+    for name, value in values.items():
+        record(collector, name, value, observed_at=now)
+
+
+class MonitoringTests(unittest.TestCase):
+    def test_complete_snapshot_is_healthy_and_serializable(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 100.0)
+        complete(collector)
+
+        snapshot = collector.snapshot()
+
+        self.assertEqual(snapshot.overall, HealthStatus.HEALTHY)
+        self.assertEqual(snapshot.domain("safety").status, HealthStatus.HEALTHY)
+        self.assertEqual(snapshot.as_dict()["domains"]["power"]["status"], "healthy")
+
+    def test_missing_stale_and_faulted_critical_inputs_fail_closed(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 100.0)
+        record(collector, "safety.estop_channels_ok", True, observed_at=98.0)
+        record(collector, "safety.mcu_watchdog_ok", False, observed_at=99.9)
+
+        snapshot = collector.snapshot()
+
+        self.assertEqual(snapshot.overall, HealthStatus.FAULT)
+        self.assertEqual(snapshot.domain("safety").status, HealthStatus.FAULT)
+        safety = {metric.name: metric for metric in snapshot.domain("safety").metrics}
+        self.assertEqual(safety["safety.estop_channels_ok"].state, "stale")
+        self.assertEqual(safety["safety.estop_channels_ok"].missing, False)
+        self.assertEqual(safety["safety.mcu_watchdog_ok"].state, "fault")
+
+        record(collector, "safety.mcu_watchdog_ok", True, observed_at=100.0)
+        recovered = collector.snapshot()
+        self.assertEqual(recovered.domain("safety").status, HealthStatus.UNKNOWN)
+        self.assertEqual(recovered.overall, HealthStatus.UNKNOWN)
+
+    def test_metric_contract_rejects_unknown_nonfinite_and_unbounded_labels(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 1.0)
+        with self.assertRaises(MetricError):
+            collector.record("unknown.metric", 1, source="fixture")
+        with self.assertRaises(MetricError):
+            record(collector, "compute.cpu_percent", float("nan"))
+        with self.assertRaises(MetricError):
+            collector.record("compute.cpu_percent", 1.0, source="linux.proc", labels={"host": "not-allowed"})
+        with self.assertRaises(MetricError):
+            collector.record("compute.cpu_percent", 1.0, source="linux.proc", labels={"host": "line\nbreak"})
+        with self.assertRaises(MetricError):
+            collector.record("compute.cpu_percent", 1.0, source="linux.proc", clock_id="wall")
+        with self.assertRaises(MetricError):
+            collector.record("safety.estop_channels_ok", True, source="spoof")
+
+    def test_histogram_uses_fixed_aggregates_not_sample_history(self) -> None:
+        registry = MetricRegistry(
+            (
+                MetricSpec(
+                    "motion.latency_seconds",
+                    MetricKind.HISTOGRAM,
+                    "seconds",
+                    "robot",
+                    "float",
+                    5.0,
+                ),
+            )
+        )
+        metrics = SystemMetrics(registry, histogram_buckets=(0.1, 1.0))
+        collector = HealthSnapshotCollector(metrics, clock=lambda: 10.0)
+        for value in range(300):
+            collector.record("motion.latency_seconds", value / 100, source="component", observed_at=10.0)
+
+        exported = metrics.export_prometheus()
+
+        self.assertIn("motion_latency_seconds_count 300", exported)
+        self.assertIn('motion_latency_seconds_bucket{le="0.1"} 11', exported)
+        self.assertIn('motion_latency_seconds_bucket{le="1.0"} 101', exported)
+        self.assertIn('motion_latency_seconds_bucket{le="+Inf"} 300', exported)
+        self.assertLessEqual(len(metrics._histograms[("motion.latency_seconds", ())][2]), 2)
+
+    def test_updates_and_snapshots_are_thread_safe(self) -> None:
+        metrics = SystemMetrics()
+        collector = HealthSnapshotCollector(metrics, clock=lambda: 10.0)
+
+        def writer() -> None:
+            for _ in range(500):
+                metrics.increment_counter("app.restart_count")
+
+        threads = [threading.Thread(target=writer) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for _ in range(100):
+            collector.snapshot(collected_at=10.0)
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(len(metrics.samples()), 1)
+        self.assertEqual(metrics.samples()[0].value, 2_000)
+
+    def test_older_and_conflicting_samples_fail_closed(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 100.0)
+        record(collector, "safety.estop_channels_ok", False, observed_at=100.0)
+        with self.assertRaisesRegex(MetricError, "timestamp regressed"):
+            record(collector, "safety.estop_channels_ok", True, observed_at=99.9)
+        self.assertEqual(collector.snapshot().domain("safety").metrics[0].state, "fault")
+
+        conflict = HealthSnapshotCollector(clock=lambda: 100.0)
+        record(conflict, "safety.estop_channels_ok", True, observed_at=100.0)
+        with self.assertRaisesRegex(MetricError, "conflict"):
+            record(conflict, "safety.estop_channels_ok", False, observed_at=100.0)
+        view = conflict.snapshot().domain("safety").metrics[0]
+        self.assertEqual((view.state, view.source_status, view.value), ("conflict", "conflict", None))
+        self.assertEqual(conflict.snapshot().domain("safety").status, HealthStatus.FAULT)
+
+    def test_default_registry_is_fixed_and_documented(self) -> None:
+        names = {spec.name for spec in MetricRegistry().specs()}
+        self.assertEqual(len(names), len(DEFAULT_SPECS))
+        self.assertIn("safety.estop_channels_ok", names)
+        self.assertIn("perception.fresh", names)
+
+    def test_normal_false_and_degraded_values_are_not_faults(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 100.0)
+        complete(collector, now=99.9)
+        record(collector, "safety.contactor_permission", False, observed_at=100.0)
+        record(collector, "app.readiness", False, observed_at=100.0)
+        self.assertEqual(collector.snapshot().domain("safety").status, HealthStatus.HEALTHY)
+        self.assertEqual(collector.snapshot().domain("application").status, HealthStatus.DEGRADED)
+
+    def test_bms_and_stop_state_severity_is_explicit(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 100.0)
+        record(collector, "power.bms_state", "DERATE", observed_at=100.0)
+        record(collector, "motion.stop_state", "fault", observed_at=100.0)
+        self.assertEqual(collector.snapshot().domain("power").status, HealthStatus.DEGRADED)
+        self.assertEqual(collector.snapshot().domain("robot").status, HealthStatus.FAULT)
+
+    def test_contract_ranges_enum_and_counters_are_checked(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 100.0)
+        with self.assertRaises(MetricError):
+            record(collector, "compute.cpu_percent", 101.0)
+        with self.assertRaises(MetricError):
+            record(collector, "power.bms_state", "bogus")
+        with self.assertRaises(MetricError):
+            record(collector, "app.restart_count", -1)
+        with self.assertRaises(MetricError):
+            record(collector, "app.restart_count", False)
+        with self.assertRaises(MetricError):
+            record(collector, "task.run_id", "recipient@example.com")
+        with self.assertRaises(MetricError):
+            record(collector, "compute.cpu_percent", 10**400)
+        with self.assertRaises(MetricError):
+            record(collector, "compute.cpu_percent", 1.0, observed_at=10**400)
+
+    def test_health_values_require_the_declared_type(self) -> None:
+        with self.assertRaises(MetricError):
+            MetricRegistry(
+                (
+                    MetricSpec(
+                        "metric.strict",
+                        MetricKind.GAUGE,
+                        "items",
+                        "compute",
+                        "int",
+                        1.0,
+                        fault_values=(False,),
+                    ),
+                )
+            )
+        with self.assertRaises(MetricError):
+            MetricSpec("metric.secret", MetricKind.GAUGE, "value", "compute", "str", 1.0)
+        with self.assertRaises(MetricError):
+            MetricSpec("metric.type", MetricKind.GAUGE, "value", "compute", [], 1.0)  # type: ignore[arg-type]
+        with self.assertRaises(MetricError):
+            MetricSpec("metric.critical", MetricKind.GAUGE, "value", "compute", "int", 1.0, 1)  # type: ignore[arg-type]
+
+    def test_sampling_interval_is_bounded_and_clock_regression_fails(self) -> None:
+        collector = HealthSnapshotCollector(clock=lambda: 10.0, sampling_interval_s=2.0)
+        self.assertFalse(collector.is_due(9.0))
+        self.assertTrue(collector.is_due(8.0))
+        with self.assertRaises(MetricError):
+            collector.is_due(11.0)
+        with self.assertRaises(MetricError):
+            HealthSnapshotCollector(sampling_interval_s=0.01)
+        with self.assertRaisesRegex(MetricError, "difference"):
+            HealthSnapshotCollector(clock=lambda: 1e308).is_due(-1e308)
+
+        overflow = HealthSnapshotCollector(clock=lambda: 1e308)
+        record(overflow, "safety.estop_channels_ok", True, observed_at=-1e308)
+        with self.assertRaisesRegex(MetricError, "difference"):
+            overflow.snapshot()
+
+    def test_series_limit_and_histogram_validation_are_atomic(self) -> None:
+        registry = MetricRegistry(
+            (
+                MetricSpec(
+                    "metric.histogram",
+                    MetricKind.HISTOGRAM,
+                    "seconds",
+                    "compute",
+                    "float",
+                    5.0,
+                    allowed_labels=("channel",),
+                ),
+            )
+        )
+        metrics = SystemMetrics(registry, max_series=1, histogram_buckets=(1.0,))
+        metrics.record_histogram("metric.histogram", 0.5, source="component", labels={"channel": "a"})
+        with self.assertRaises(MetricError):
+            metrics.record_histogram("metric.histogram", float("nan"), source="component")
+        with self.assertRaises(MetricError):
+            metrics.record_histogram("metric.histogram", 0.5, source="component", labels={"channel": "b"})
+        self.assertIn('metric_histogram_count{channel="a"} 1', metrics.export_prometheus())
+        self.assertNotIn('channel="b"', metrics.export_prometheus())
+
+    def test_linux_adapter_uses_injected_bounded_sources(self) -> None:
+        files = {
+            "/proc/meminfo": "MemTotal:       1000 kB\nMemAvailable:    250 kB\n",
+            "/proc/loadavg": "0.25 0.10 0.05 1/10 1\n",
+            "/sys/class/thermal/thermal_zone0/temp": "500\n",
+        }
+        cpu = iter(("cpu  100 0 0 80 0 0 0 0 0 0\n", "cpu  200 0 0 130 0 0 0 0 0 0\n"))
+
+        def read_text(path: str) -> str:
+            return next(cpu) if path == "/proc/stat" else files[path]
+
+        adapter = LinuxHealthAdapter(read_text=read_text, disk_usage=lambda _: (100, 60, 40))
+        collector = HealthSnapshotCollector(clock=lambda: 10.0)
+        names = adapter.collect(collector, observed_at=10.0)
+        self.assertIn("compute.memory_percent", names)
+        self.assertNotIn("app.uptime_seconds", names)
+        self.assertNotIn("compute.disk_growth_bytes", names)
+        second = adapter.collect(collector, observed_at=11.0)
+        self.assertIn("compute.cpu_percent", second)
+        self.assertIn("compute.disk_growth_bytes", second)
+        samples = {sample.name: sample.value for sample in collector.metrics.samples()}
+        self.assertEqual(samples["compute.temperature_celsius"], 0.5)
+        self.assertTrue(all(sample.source.startswith("linux.") for sample in collector.metrics.samples()))
+
+    def test_component_and_ros_diagnostic_readers_are_injectable(self) -> None:
+        diagnostic = {"localization_ok": True}
+        adapter = ComponentHealthAdapter("nav2", {"nav.localization_ok": lambda: diagnostic["localization_ok"]})
+        collector = HealthSnapshotCollector(clock=lambda: 10.0)
+        self.assertEqual(adapter.collect(collector), ("nav.localization_ok",))
+        self.assertEqual(collector.metrics.samples()[0].source, "nav2")
+
+    def test_resource_report_is_bounded_and_marks_physical_work_unexecuted(self) -> None:
+        report = benchmark(10)
+        self.assertEqual(report["evidence_class"], "local_software")
+        self.assertEqual(report["target_hardware_measurement"], "NOT_EXECUTED")
+        self.assertEqual(report["physical_source_validation"], "NOT_EXECUTED")
+        self.assertEqual(report["resources"]["threads_before"], report["resources"]["threads_after"])
+        self.assertLess(report["output"]["snapshot_json_bytes"], 16_384)
+        self.assertEqual(report["snapshots"]["complete_synthetic"]["overall"], "healthy")
+        self.assertEqual(report["snapshots"]["fault_synthetic"]["overall"], "fault")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/benchmark_monitoring.py
+++ b/tools/scripts/benchmark_monitoring.py
@@ -5,12 +5,16 @@ import argparse
 import json
 import os
 import platform
-import resource
 import sys
 import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+
+try:
+    import resource
+except ImportError:
+    resource = None
 
 from _paths import ROOT
 
@@ -44,10 +48,13 @@ def _complete(collector: HealthSnapshotCollector, observed_at: float) -> None:
 
 def _proc_status() -> dict[str, int]:
     values: dict[str, int] = {}
-    for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
-        name, _, raw = line.partition(":")
-        if name in {"VmRSS", "voluntary_ctxt_switches", "nonvoluntary_ctxt_switches"}:
-            values[name] = int(raw.split()[0]) * (1_024 if name == "VmRSS" else 1)
+    try:
+        for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+            name, _, raw = line.partition(":")
+            if name in {"VmRSS", "voluntary_ctxt_switches", "nonvoluntary_ctxt_switches"}:
+                values[name] = int(raw.split()[0]) * (1_024 if name == "VmRSS" else 1)
+    except OSError:
+        pass
     try:
         for line in Path("/proc/self/smaps_rollup").read_text(encoding="utf-8").splitlines():
             if line.startswith("Pss:"):
@@ -97,9 +104,11 @@ def benchmark(iterations: int) -> dict:
     assert snapshot is not None
     snapshot_json = json.dumps(snapshot.as_dict(), separators=(",", ":"), allow_nan=False).encode()
     prometheus = collector.metrics.export_prometheus().encode()
-    max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    if platform.system() == "Linux":
-        max_rss *= 1_024
+    max_rss = None
+    if resource is not None:
+        max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if platform.system() == "Linux":
+            max_rss *= 1_024
     context_before = before.get("voluntary_ctxt_switches", 0) + before.get("nonvoluntary_ctxt_switches", 0)
     context_after = after.get("voluntary_ctxt_switches", 0) + after.get("nonvoluntary_ctxt_switches", 0)
     cpu_model = "unknown"

--- a/tools/scripts/benchmark_monitoring.py
+++ b/tools/scripts/benchmark_monitoring.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Measure bounded collector cost and emit synthetic snapshot evidence."""
+
+import argparse
+import json
+import os
+import platform
+import resource
+import sys
+import threading
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from _paths import ROOT
+
+sys.path.insert(0, str(ROOT / "libs" / "application"))
+
+from workbench.application.monitoring import HealthSnapshotCollector, MetricSpec
+
+
+def _matches(value: object, candidates: tuple[object, ...]) -> bool:
+    return any(type(value) is type(candidate) and value == candidate for candidate in candidates)
+
+
+def _healthy_value(spec: MetricSpec) -> bool | int | float | str:
+    for value in spec.allowed_values:
+        if not _matches(value, spec.fault_values + spec.degraded_values):
+            return value
+    if spec.value_type == "bool":
+        return not _matches(True, spec.fault_values + spec.degraded_values)
+    if spec.value_type == "str":
+        return "none"
+    value = max(0, spec.minimum) if spec.minimum is not None else 0
+    if spec.maximum is not None:
+        value = min(value, spec.maximum)
+    return int(value) if spec.value_type == "int" else float(value)
+
+
+def _complete(collector: HealthSnapshotCollector, observed_at: float) -> None:
+    for spec in collector.metrics.registry.specs():
+        collector.record(spec.name, _healthy_value(spec), source=spec.source, observed_at=observed_at)
+
+
+def _proc_status() -> dict[str, int]:
+    values: dict[str, int] = {}
+    for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+        name, _, raw = line.partition(":")
+        if name in {"VmRSS", "voluntary_ctxt_switches", "nonvoluntary_ctxt_switches"}:
+            values[name] = int(raw.split()[0]) * (1_024 if name == "VmRSS" else 1)
+    try:
+        for line in Path("/proc/self/smaps_rollup").read_text(encoding="utf-8").splitlines():
+            if line.startswith("Pss:"):
+                values["Pss"] = int(line.split()[1]) * 1_024
+                break
+    except OSError:
+        pass
+    return values
+
+
+def _snapshot_evidence(now: float) -> dict[str, dict]:
+    complete = HealthSnapshotCollector(clock=lambda: now)
+    _complete(complete, now)
+    missing = HealthSnapshotCollector(clock=lambda: now)
+    stale = HealthSnapshotCollector(clock=lambda: now)
+    _complete(stale, now - 86_401)
+    fault = HealthSnapshotCollector(clock=lambda: now)
+    _complete(fault, now - 0.01)
+    fault.record("safety.estop_channels_ok", False, source="safety_mcu", observed_at=now)
+    return {
+        "complete_synthetic": complete.snapshot().as_dict(),
+        "missing_synthetic": missing.snapshot().as_dict(),
+        "stale_synthetic": stale.snapshot().as_dict(),
+        "fault_synthetic": fault.snapshot().as_dict(),
+    }
+
+
+def benchmark(iterations: int) -> dict:
+    if not 1 <= iterations <= 1_000_000:
+        raise ValueError("iterations must be between 1 and 1000000")
+    now = time.monotonic()
+    collector = HealthSnapshotCollector(clock=lambda: now)
+    _complete(collector, now)
+    for _ in range(min(iterations, 100)):
+        collector.snapshot()
+
+    before = _proc_status()
+    threads_before = threading.active_count()
+    cpu_started = time.process_time_ns()
+    wall_started = time.perf_counter_ns()
+    snapshot = None
+    for _ in range(iterations):
+        snapshot = collector.snapshot()
+    wall_ns = time.perf_counter_ns() - wall_started
+    cpu_ns = time.process_time_ns() - cpu_started
+    after = _proc_status()
+    assert snapshot is not None
+    snapshot_json = json.dumps(snapshot.as_dict(), separators=(",", ":"), allow_nan=False).encode()
+    prometheus = collector.metrics.export_prometheus().encode()
+    max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if platform.system() == "Linux":
+        max_rss *= 1_024
+    context_before = before.get("voluntary_ctxt_switches", 0) + before.get("nonvoluntary_ctxt_switches", 0)
+    context_after = after.get("voluntary_ctxt_switches", 0) + after.get("nonvoluntary_ctxt_switches", 0)
+    cpu_model = "unknown"
+    try:
+        cpu_model = next(
+            line.partition(":")[2].strip()
+            for line in Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines()
+            if line.startswith("model name")
+        )
+    except (OSError, StopIteration):
+        pass
+    return {
+        "schema_version": 1,
+        "captured_at": datetime.now(UTC).isoformat(),
+        "evidence_class": "local_software",
+        "result": "MEASURED_NO_TARGET_BUDGET",
+        "provenance": "Local development host; not target Jetson or physical robot evidence.",
+        "environment": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "cpu_count": os.cpu_count(),
+            "cpu_model": cpu_model,
+        },
+        "iterations": iterations,
+        "resources": {
+            "cpu_total_ns": cpu_ns,
+            "cpu_ns_per_snapshot": cpu_ns / iterations,
+            "wall_total_ns": wall_ns,
+            "wall_ns_per_snapshot": wall_ns / iterations,
+            "rss_before_bytes": before.get("VmRSS"),
+            "rss_after_bytes": after.get("VmRSS"),
+            "rss_peak_bytes": max_rss,
+            "pss_after_bytes": after.get("Pss"),
+            "scheduler_context_switches": context_after - context_before,
+            "threads_before": threads_before,
+            "threads_after": threading.active_count(),
+            "periodic_wakeups_owned": 0,
+        },
+        "output": {
+            "snapshot_json_bytes": len(snapshot_json),
+            "prometheus_text_bytes": len(prometheus),
+        },
+        "snapshots": _snapshot_evidence(now),
+        "target_hardware_measurement": "NOT_EXECUTED",
+        "physical_source_validation": "NOT_EXECUTED",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=10_000)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = benchmark(args.iterations)
+    encoded = json.dumps(report, indent=2, allow_nan=False) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Related Issue

Partially addresses #169. This PR intentionally uses `Refs #169`, not `Closes #169`: target Jetson measurements and calibrated physical-source validation are still `NOT_EXECUTED`.

## What changed

- replaces the unbounded monitoring dictionaries with a fixed 35-metric registry carrying type, unit, domain, expected source, freshness, criticality and bounded value rules;
- adds thread-safe bounded gauges/counters and constant-memory histogram buckets with Prometheus text projection;
- adds immutable `healthy/degraded/fault/unknown` snapshots that fail closed for missing/stale critical sources, source spoofing, timestamp regression, equal-time conflicts and non-finite clocks;
- adds injectable Linux `/proc`/`/sys` and component/ROS-diagnostic reader adapters without a background thread or new dependency;
- adds a reproducible local resource/snapshot evidence script, Task Packet, package mapping and focused tests.

## Interfaces affected

No `interfaces/`, control, firmware or public HTTP API changes. `workbench.application` is now included in the Python wheel.

## Tests and commands

- `make check PYTHON=<python3.12>` — 349 passed; Ruff, format, contracts, scenarios, golden set, context, scripted demo and offline demo passed.
- `python3 -m pytest tests/unit/test_monitoring.py -q` — 16 passed.
- `python3 tools/scripts/check_task_packet.py docs/task_packets/monitoring-health-snapshot-169.json` — passed.
- isolated wheel build/install/import — 35 monitoring specs imported from the built wheel.
- `python3 -m mkdocs build --strict` — passed.
- `python3 tools/scripts/benchmark_monitoring.py --iterations 10000 --output runs/performance/monitoring.json` — completed.

## Evidence

- Task Packet: `docs/task_packets/monitoring-health-snapshot-169.json`
- Local evidence: `docs/performance/monitoring-local-2026-08-19.md`
- x86_64 local result: ~72.96 microseconds CPU per snapshot; 1 -> 1 threads; 8,313-byte JSON snapshot; 840-byte Prometheus projection.
- Synthetic projections: complete=`healthy`, missing=`unknown`, stale=`unknown`, E-stop fault=`fault`.

This is local software evidence only. It does **not** prove live ROS, E-stop, BMS, CAN, Nav2, Motion or perception integration. Target-class hardware measurement and physical-source validation remain `NOT_EXECUTED`, so #169 must stay open until that evidence is attached or its scope is changed by the human owner.

## Risks and rollback

The stricter fixed registry deliberately rejects unknown metric names, wrong sources and incompatible timestamps. Existing callers that relied on arbitrary dictionary keys must migrate to an approved metric. Rollback is the single commit in this PR; no persisted data or external schema is changed.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.
