### PR TITLE
feat(mcu): add strict CAN Wire V1 frame codec

### DIFF
--- a/docs/architecture/mcu-wire-v1.md
+++ b/docs/architecture/mcu-wire-v1.md
@@ -1,0 +1,147 @@
+# MCU CAN Wire V1
+
+Status: **firmware-owned binary contract** for Issue #54.
+
+This document maps the frozen logical MCU protocol v1.0 into one Classic CAN
+data frame. The logical contract remains normative for frame meaning. Wire V1
+defines only transport encoding and does not change
+`interfaces/json_schema/mcu_protocol.schema.json` or the exported Pydantic
+models.
+
+## Transport boundary
+
+- Classic CAN 2.0 data frames with standard 11-bit identifiers.
+- DLC is exactly 8 for every frame kind. Remote, extended-ID and CAN FD frames
+  are outside this codec.
+- Multi-byte integers use network byte order (big-endian).
+- Byte 0 is the compact protocol version. Logical version `"1.0"` is `0x10`.
+- CAN's frame CRC is the transport integrity check; Wire V1 adds no payload
+  checksum.
+
+The logical `frame_id`, `sent_at_us` and `clock_id` fields are adapter/evidence
+metadata and are not transmitted in the eight-byte CAN payload. A bridge owns
+their local generation and retention. They are never reconstructed as remote
+timestamps or used as cross-device freshness evidence.
+
+## Arbitration identifiers
+
+| CAN ID | Frame kind | Direction | Priority rationale |
+| --- | --- | --- | --- |
+| `0x080` | `stop` | host to MCU | Highest protocol priority. |
+| `0x081` | `stop_ack` | MCU to host | Correlated safety response. |
+| `0x100` | `command` | host to MCU | Ordinary command traffic. |
+| `0x101` | `ack` | MCU to host | Ordinary correlated response. |
+| `0x180` | `telemetry` | MCU to host | Lowest protocol priority. |
+
+Lower identifiers win CAN arbitration. The ID selects exactly one frame kind;
+all other standard identifiers are rejected by the codec.
+
+## Payload layouts
+
+All offsets are zero-based and every reserved byte must be `0x00`.
+
+### Command and STOP
+
+| Byte | Field |
+| --- | --- |
+| 0 | version (`0x10`) |
+| 1..2 | `command_id`, unsigned 16-bit big-endian |
+| 3 | opcode |
+| 4 | `retry_count` |
+| 5..7 | reserved zero |
+
+`command` accepts IDs `0x0000..0x7fff` and ordinary opcodes only. `stop`
+accepts IDs `0x8000..0xffff` and opcode `stop` only.
+
+### ACK and STOP_ACK
+
+| Byte | Field |
+| --- | --- |
+| 0 | version (`0x10`) |
+| 1..2 | `command_id`, unsigned 16-bit big-endian |
+| 3 | opcode |
+| 4 | echoed `retry_count` |
+| 5 | `result_code` |
+| 6 | `fault_code` |
+| 7 | `device_mode` |
+
+`ack` accepts the ordinary ID/opcode partition. `stop_ack` accepts the STOP
+partition and opcode. Result, fault and mode combinations must satisfy the
+frozen logical protocol; encoding a numeric enum value is not sufficient.
+
+### Telemetry
+
+| Byte | Field |
+| --- | --- |
+| 0 | version (`0x10`) |
+| 1..4 | `sequence_no`, unsigned 32-bit big-endian |
+| 5 | `fault_code` |
+| 6 | `device_mode` |
+| 7 | reserved zero |
+
+Telemetry has no command ID, opcode, retry count or result code and never
+confirms a command.
+
+## Numeric registries
+
+| Opcode | Value |
+| --- | --- |
+| reserved | `0x00` |
+| `move` | `0x01` |
+| `grip_open` | `0x02` |
+| `grip_close` | `0x03` |
+| `hold` | `0x04` |
+| `stop` | `0x05` |
+| `heartbeat` | `0x06` |
+
+| Result | Value |
+| --- | --- |
+| accepted | `0x00` |
+| rejected | `0x01` |
+
+| Fault | Value | Valid MCU frame |
+| --- | --- | --- |
+| `none` | `0x00` | ACK, STOP_ACK, telemetry as constrained by result/mode |
+| `ack_timeout` | `0x01` | never; host-only diagnostic |
+| `stop_timeout` | `0x02` | never; host-only diagnostic |
+| `stop_rejected` | `0x03` | failed STOP_ACK only |
+| `link_lost` | `0x04` | fault telemetry only |
+| `duplicate_frame` | `0x05` | failed ordinary ACK only |
+| `watchdog_expired` | `0x06` | fault telemetry only |
+| `malformed_frame` | `0x07` | failed ordinary ACK only |
+
+| Device mode | Value |
+| --- | --- |
+| `idle` | `0x00` |
+| `moving` | `0x01` |
+| `holding` | `0x02` |
+| `stopped` | `0x03` |
+| `faulted` | `0x04` |
+
+All unlisted enum values are reserved and invalid.
+
+## Canonical golden vector
+
+The committed `interfaces/examples/mcu-frame-stop-ack.json` describes a
+successful STOP acknowledgement with command ID 32769 (`0x8001`), zero retry,
+no fault and stopped mode. Its Wire V1 representation is:
+
+```text
+CAN ID: 0x081
+DLC:    8
+DATA:   10 80 01 05 00 00 00 03
+```
+
+The JSON `frame_id`, `sent_at_us` and `clock_id` remain adapter metadata as
+defined above. The shared Host/QEMU C test corpus pins this byte vector.
+
+## Fail-closed behavior and limits
+
+The decoder rejects the complete frame before publishing output when the ID,
+DLC, version, reserved bytes, enum values, ID partition or cross-field result
+semantics are invalid. The encoder validates the complete logical wire object
+and destination capacity before writing any output byte.
+
+Wire V1 does not implement command deduplication, watchdog scheduling, host
+transport dispatch, CAN controller registers, bus-off recovery or electrical
+validation. Those remain separate issues and hardware evidence gates.

--- a/docs/task_packets/issue-54-mcu-frame-codec.json
+++ b/docs/task_packets/issue-54-mcu-frame-codec.json
@@ -17,15 +17,10 @@
   "read_only_paths": [
     "AGENTS.md",
     "docs/architecture/mcu-protocol-v1.md",
-    "interfaces/json_schema/mcu_protocol.schema.json",
-    "interfaces/examples/mcu-frame-stop-ack.json",
     "firmware/mcu/core/hal.h",
     "firmware/mcu/core/state_machine.h",
     "firmware/mcu/core/state_machine.c",
-    "firmware/mcu/hal/qemu/hal_qemu.c",
-    "firmware/virtual_mcu/**",
-    "libs/contracts/**",
-    "robot/control/**"
+    "firmware/mcu/hal/qemu/hal_qemu.c"
   ],
   "forbidden": [
     "interfaces/**",

--- a/docs/task_packets/issue-54-mcu-frame-codec.json
+++ b/docs/task_packets/issue-54-mcu-frame-codec.json
@@ -17,10 +17,15 @@
   "read_only_paths": [
     "AGENTS.md",
     "docs/architecture/mcu-protocol-v1.md",
+    "interfaces/json_schema/mcu_protocol.schema.json",
+    "interfaces/examples/mcu-frame-stop-ack.json",
     "firmware/mcu/core/hal.h",
     "firmware/mcu/core/state_machine.h",
     "firmware/mcu/core/state_machine.c",
-    "firmware/mcu/hal/qemu/hal_qemu.c"
+    "firmware/mcu/hal/qemu/hal_qemu.c",
+    "firmware/virtual_mcu/**",
+    "libs/contracts/**",
+    "robot/control/**"
   ],
   "forbidden": [
     "interfaces/**",

--- a/docs/task_packets/issue-54-mcu-frame-codec.json
+++ b/docs/task_packets/issue-54-mcu-frame-codec.json
@@ -1,0 +1,77 @@
+{
+  "issue": 54,
+  "human_owner": "TH3478",
+  "objective": "Implement the allocation-free MCU CAN Wire V1 codec for the frozen logical command, ack, telemetry, stop and stop_ack frames, including strict identifier, length, field and reserved-byte validation.",
+  "allowed_paths": [
+    "firmware/mcu/core/frame_codec.h",
+    "firmware/mcu/core/frame_codec.c",
+    "firmware/mcu/Makefile",
+    "firmware/mcu/hal/qemu/main_qemu.c",
+    "firmware/mcu/tests/frame_codec_tests.h",
+    "firmware/mcu/tests/frame_codec_tests.c",
+    "firmware/mcu/tests/main_host.c",
+    "firmware/mcu/README.md",
+    "docs/architecture/mcu-wire-v1.md",
+    "docs/task_packets/issue-54-mcu-frame-codec.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "docs/architecture/mcu-protocol-v1.md",
+    "interfaces/json_schema/mcu_protocol.schema.json",
+    "interfaces/examples/mcu-frame-stop-ack.json",
+    "firmware/mcu/core/hal.h",
+    "firmware/mcu/core/state_machine.h",
+    "firmware/mcu/core/state_machine.c",
+    "firmware/mcu/hal/qemu/hal_qemu.c",
+    "firmware/virtual_mcu/**",
+    "libs/contracts/**",
+    "robot/control/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/mcu/hal/ch32v307/**",
+    "robot/control/**",
+    "hardware/**",
+    "services/**",
+    "firmware/virtual_mcu/**"
+  ],
+  "acceptance": [
+    "Wire V1 uses standard 11-bit CAN identifiers, fixed DLC 8, big-endian multi-byte fields and documented ID priority/order.",
+    "Each logical frame kind has one exact identifier and byte layout; command IDs enforce ordinary 0..32767 versus STOP 32768..65535 partitions.",
+    "Reserved bytes, reserved opcode values, unknown fault/mode/result values, invalid kind combinations and malformed lengths fail closed.",
+    "The decoder validates the supplied length before reading payload bytes and the encoder validates destination capacity before writing.",
+    "Command/STOP and ACK/STOP_ACK correlation fields round-trip without allocation or platform-specific code.",
+    "The canonical interfaces/examples/mcu-frame-stop-ack.json fields map to a committed golden stop_ack byte vector.",
+    "Shared codec tests run unchanged on Host and QEMU, including deterministic boundary/property cases.",
+    "The host sanitizer target runs the codec corpus and bounded malformed-input fuzz loop under AddressSanitizer and UndefinedBehaviorSanitizer.",
+    "The core contains no vendor headers, platform conditionals, floating point or dynamic allocation."
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-54-mcu-frame-codec.json",
+    "make -C firmware/mcu test-host",
+    "make -C firmware/mcu test-host-sanitize",
+    "make -C firmware/mcu test-qemu",
+    "make -C firmware/mcu verify-no-fp",
+    "make -C firmware/mcu size-check",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "Wire V1 layout and reserved-field table in docs/architecture/mcu-wire-v1.md.",
+    "Host and QEMU shared golden-vector and malformed-input test output.",
+    "Sanitizer output from test-host-sanitize with the bounded property corpus.",
+    "verify-no-fp and size-check output for the QEMU firmware image.",
+    "Repository test, contract, scenario and context-check output.",
+    "Final git diff --check and changed-path review proving the Task Packet boundary."
+  ],
+  "stop_conditions": [
+    "The implementation requires changing the frozen JSON Schema, Pydantic models or logical protocol semantics.",
+    "The chosen Wire V1 layout cannot represent the canonical stop_ack fields or requires CAN FD fragmentation.",
+    "Implementation requires retry deduplication, watchdog timing, host transport dispatch, vendor registers or physical CAN validation.",
+    "The same codec and test source cannot compile unchanged for Host and QEMU.",
+    "A sanitizer finding cannot be reduced to a codec or test defect within the allowed paths."
+  ]
+}

--- a/firmware/mcu/Makefile
+++ b/firmware/mcu/Makefile
@@ -16,7 +16,7 @@ HOSTCC  ?= cc
 
 BUILD   := build
 CORE    := $(wildcard core/*.c)
-SHARED_TESTS := tests/state_machine_tests.c
+SHARED_TESTS := tests/state_machine_tests.c tests/frame_codec_tests.c
 HOST_TESTS := $(SHARED_TESTS) tests/main_host.c
 
 # rv32imac: no FPU. -mabi=ilp32 (not ilp32f/d) so a stray double is a link error
@@ -26,13 +26,14 @@ RVFLAGS := $(RVARCH) -Os -g -ffreestanding -nostdlib -nostartfiles \
            -ffunction-sections -fdata-sections -Wl,--gc-sections \
            -fno-builtin -Wall -Wextra -Werror -Icore
 HOSTFLAGS := -O1 -g -Wall -Wextra -Werror -Icore -Itests -Ihal/host -DMCU_HOST_BUILD
+HOSTSANFLAGS := $(HOSTFLAGS) -fsanitize=address,undefined -fno-omit-frame-pointer
 
 # Size budget, enforced by FW16. Generous on purpose: 256KB flash / 64KB RAM.
 # Blowing it means the design drifted, not that the part is too small.
 MAX_TEXT := 32768
 MAX_BSS  := 8192
 
-.PHONY: all host qemu board test-host test-qemu size-check verify-no-fp clean
+.PHONY: all host host-sanitize qemu board test-host test-host-sanitize test-qemu size-check verify-no-fp clean
 
 all: host qemu
 
@@ -45,6 +46,17 @@ $(BUILD)/host/test-runner: $(CORE) $(HOST_TESTS)
 
 test-host: host
 	@$(BUILD)/host/test-runner
+
+host-sanitize: $(BUILD)/host/test-runner-sanitize
+
+$(BUILD)/host/test-runner-sanitize: $(CORE) $(HOST_TESTS)
+	@mkdir -p $(BUILD)/host
+	$(HOSTCC) $(HOSTSANFLAGS) $(CORE) $(wildcard hal/host/*.c) $(HOST_TESTS) -o $@
+
+test-host-sanitize: host-sanitize
+	@ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 \
+	 UBSAN_OPTIONS=halt_on_error=1 \
+	 $(BUILD)/host/test-runner-sanitize
 
 # ---------------------------------------------------------------- qemu target
 qemu: $(BUILD)/qemu/mcu.elf

--- a/firmware/mcu/README.md
+++ b/firmware/mcu/README.md
@@ -27,7 +27,10 @@ been violated.
 ## Authority boundary
 
 The C safety state machine under `core/` and its shared Host/QEMU transition
-suite are authoritative for MCU safety behavior. `firmware/virtual_mcu/` is
+suite are authoritative for MCU safety behavior. The allocation-free Wire V1
+codec under `core/frame_codec.[ch]`, its binary contract in
+`docs/architecture/mcu-wire-v1.md`, and the shared Host/QEMU golden vectors are
+authoritative for the Classic CAN payload encoding. `firmware/virtual_mcu/` is
 retired as a safety reference and parity oracle. It remains only as a legacy
 compatibility stub for earlier Python consumers and is not evidence of C
 protocol, firmware, or physical safety behavior. Changes to that model require
@@ -53,11 +56,13 @@ make qemu        # rv32imac ELF for QEMU
 make board       # rv32imac ELF to flash (P3)
 
 make test-host   # logic tests, seconds
+make test-host-sanitize  # Host corpus under ASan and UBSan
 make test-qemu   # fault suite in QEMU, what CI runs
 ```
 
 ## Status
 
-The platform-independent C safety state machine is implemented and verified by
-Issue #53. The strict frame codec, watchdog timing path, and deduplication
-remain separate follow-up tasks.
+The platform-independent C safety state machine is implemented by Issue #53.
+Issue #54 adds the strict Classic CAN Wire V1 codec and shared Host/QEMU golden
+vectors. The HAL CAN driver, watchdog timing path, command deduplication and
+physical CAN validation remain separate follow-up tasks.

--- a/firmware/mcu/core/frame_codec.c
+++ b/firmware/mcu/core/frame_codec.c
@@ -1,0 +1,295 @@
+#include "frame_codec.h"
+
+#include <stdbool.h>
+
+static bool is_ordinary_opcode(mcu_wire_opcode_t opcode)
+{
+    return opcode == MCU_WIRE_OPCODE_MOVE || opcode == MCU_WIRE_OPCODE_GRIP_OPEN ||
+           opcode == MCU_WIRE_OPCODE_GRIP_CLOSE || opcode == MCU_WIRE_OPCODE_HOLD ||
+           opcode == MCU_WIRE_OPCODE_HEARTBEAT;
+}
+
+static bool is_non_faulted_mode(mcu_wire_device_mode_t mode)
+{
+    return mode >= MCU_WIRE_MODE_IDLE && mode <= MCU_WIRE_MODE_STOPPED;
+}
+
+static bool absent_command_fields_are_zero(const mcu_wire_frame_t *frame)
+{
+    return frame->command_id == 0u && frame->opcode == MCU_WIRE_OPCODE_RESERVED &&
+           frame->retry_count == 0u && frame->result_code == MCU_WIRE_RESULT_ACCEPTED;
+}
+
+static bool absent_response_fields_are_zero(const mcu_wire_frame_t *frame)
+{
+    return frame->sequence_no == 0u && frame->result_code == MCU_WIRE_RESULT_ACCEPTED &&
+           frame->fault_code == MCU_WIRE_FAULT_NONE && frame->device_mode == MCU_WIRE_MODE_IDLE;
+}
+
+static bool ordinary_ack_is_valid(const mcu_wire_frame_t *frame)
+{
+    if (frame->result_code == MCU_WIRE_RESULT_ACCEPTED) {
+        return frame->fault_code == MCU_WIRE_FAULT_NONE && is_non_faulted_mode(frame->device_mode);
+    }
+    if (frame->result_code != MCU_WIRE_RESULT_REJECTED || frame->device_mode != MCU_WIRE_MODE_FAULTED) {
+        return false;
+    }
+    return frame->fault_code == MCU_WIRE_FAULT_DUPLICATE_FRAME ||
+           frame->fault_code == MCU_WIRE_FAULT_MALFORMED_FRAME;
+}
+
+static bool stop_ack_is_valid(const mcu_wire_frame_t *frame)
+{
+    if (frame->result_code == MCU_WIRE_RESULT_ACCEPTED) {
+        return frame->fault_code == MCU_WIRE_FAULT_NONE && frame->device_mode == MCU_WIRE_MODE_STOPPED;
+    }
+    return frame->result_code == MCU_WIRE_RESULT_REJECTED &&
+           frame->fault_code == MCU_WIRE_FAULT_STOP_REJECTED &&
+           frame->device_mode == MCU_WIRE_MODE_FAULTED;
+}
+
+static bool telemetry_is_valid(const mcu_wire_frame_t *frame)
+{
+    if (!absent_command_fields_are_zero(frame)) {
+        return false;
+    }
+    if (frame->fault_code == MCU_WIRE_FAULT_NONE) {
+        return is_non_faulted_mode(frame->device_mode);
+    }
+    return (frame->fault_code == MCU_WIRE_FAULT_LINK_LOST ||
+            frame->fault_code == MCU_WIRE_FAULT_WATCHDOG_EXPIRED) &&
+           frame->device_mode == MCU_WIRE_MODE_FAULTED;
+}
+
+static bool frame_is_valid(const mcu_wire_frame_t *frame)
+{
+    switch (frame->kind) {
+    case MCU_WIRE_FRAME_COMMAND:
+        return frame->command_id <= MCU_COMMAND_ID_MAX && is_ordinary_opcode(frame->opcode) &&
+               absent_response_fields_are_zero(frame);
+    case MCU_WIRE_FRAME_ACK:
+        return frame->command_id <= MCU_COMMAND_ID_MAX && is_ordinary_opcode(frame->opcode) &&
+               frame->sequence_no == 0u && ordinary_ack_is_valid(frame);
+    case MCU_WIRE_FRAME_TELEMETRY:
+        return telemetry_is_valid(frame);
+    case MCU_WIRE_FRAME_STOP:
+        return frame->command_id >= MCU_STOP_ID_MIN && frame->opcode == MCU_WIRE_OPCODE_STOP &&
+               absent_response_fields_are_zero(frame);
+    case MCU_WIRE_FRAME_STOP_ACK:
+        return frame->command_id >= MCU_STOP_ID_MIN && frame->opcode == MCU_WIRE_OPCODE_STOP &&
+               frame->sequence_no == 0u && stop_ack_is_valid(frame);
+    case MCU_WIRE_FRAME_KIND_COUNT:
+    default:
+        return false;
+    }
+}
+
+static uint16_t frame_kind_to_id(mcu_wire_frame_kind_t kind)
+{
+    switch (kind) {
+    case MCU_WIRE_FRAME_COMMAND:
+        return MCU_CAN_ID_COMMAND;
+    case MCU_WIRE_FRAME_ACK:
+        return MCU_CAN_ID_ACK;
+    case MCU_WIRE_FRAME_TELEMETRY:
+        return MCU_CAN_ID_TELEMETRY;
+    case MCU_WIRE_FRAME_STOP:
+        return MCU_CAN_ID_STOP;
+    case MCU_WIRE_FRAME_STOP_ACK:
+        return MCU_CAN_ID_STOP_ACK;
+    case MCU_WIRE_FRAME_KIND_COUNT:
+    default:
+        return 0xffffu;
+    }
+}
+
+static bool id_to_frame_kind(uint16_t arbitration_id, mcu_wire_frame_kind_t *kind)
+{
+    switch (arbitration_id) {
+    case MCU_CAN_ID_COMMAND:
+        *kind = MCU_WIRE_FRAME_COMMAND;
+        return true;
+    case MCU_CAN_ID_ACK:
+        *kind = MCU_WIRE_FRAME_ACK;
+        return true;
+    case MCU_CAN_ID_TELEMETRY:
+        *kind = MCU_WIRE_FRAME_TELEMETRY;
+        return true;
+    case MCU_CAN_ID_STOP:
+        *kind = MCU_WIRE_FRAME_STOP;
+        return true;
+    case MCU_CAN_ID_STOP_ACK:
+        *kind = MCU_WIRE_FRAME_STOP_ACK;
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void write_u16_be(uint8_t *destination, uint16_t value)
+{
+    destination[0] = (uint8_t)(value >> 8);
+    destination[1] = (uint8_t)value;
+}
+
+static void write_u32_be(uint8_t *destination, uint32_t value)
+{
+    destination[0] = (uint8_t)(value >> 24);
+    destination[1] = (uint8_t)(value >> 16);
+    destination[2] = (uint8_t)(value >> 8);
+    destination[3] = (uint8_t)value;
+}
+
+static uint16_t read_u16_be(const uint8_t *source)
+{
+    return (uint16_t)(((uint16_t)source[0] << 8) | source[1]);
+}
+
+static uint32_t read_u32_be(const uint8_t *source)
+{
+    return ((uint32_t)source[0] << 24) | ((uint32_t)source[1] << 16) |
+           ((uint32_t)source[2] << 8) | source[3];
+}
+
+static void clear_frame(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_COMMAND;
+    frame->command_id = 0u;
+    frame->sequence_no = 0u;
+    frame->opcode = MCU_WIRE_OPCODE_RESERVED;
+    frame->retry_count = 0u;
+    frame->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    frame->fault_code = MCU_WIRE_FAULT_NONE;
+    frame->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void copy_frame(mcu_wire_frame_t *destination, const mcu_wire_frame_t *source)
+{
+    destination->kind = source->kind;
+    destination->command_id = source->command_id;
+    destination->sequence_no = source->sequence_no;
+    destination->opcode = source->opcode;
+    destination->retry_count = source->retry_count;
+    destination->result_code = source->result_code;
+    destination->fault_code = source->fault_code;
+    destination->device_mode = source->device_mode;
+}
+
+mcu_codec_status_t mcu_frame_encode(const mcu_wire_frame_t *frame,
+                                    uint16_t *arbitration_id,
+                                    uint8_t *destination,
+                                    uint8_t destination_capacity,
+                                    uint8_t *encoded_length)
+{
+    uint8_t encoded[MCU_WIRE_DLC] = {0u};
+    uint16_t encoded_id;
+    unsigned i;
+
+    if (frame == 0 || arbitration_id == 0 || destination == 0 || encoded_length == 0) {
+        return MCU_CODEC_INVALID_ARGUMENT;
+    }
+    if (destination_capacity < MCU_WIRE_DLC) {
+        return MCU_CODEC_BUFFER_TOO_SMALL;
+    }
+    if (!frame_is_valid(frame)) {
+        return MCU_CODEC_INVALID_FIELD;
+    }
+
+    encoded_id = frame_kind_to_id(frame->kind);
+    encoded[0] = MCU_WIRE_VERSION_V1;
+    switch (frame->kind) {
+    case MCU_WIRE_FRAME_COMMAND:
+    case MCU_WIRE_FRAME_STOP:
+        write_u16_be(&encoded[1], frame->command_id);
+        encoded[3] = (uint8_t)frame->opcode;
+        encoded[4] = frame->retry_count;
+        break;
+    case MCU_WIRE_FRAME_ACK:
+    case MCU_WIRE_FRAME_STOP_ACK:
+        write_u16_be(&encoded[1], frame->command_id);
+        encoded[3] = (uint8_t)frame->opcode;
+        encoded[4] = frame->retry_count;
+        encoded[5] = (uint8_t)frame->result_code;
+        encoded[6] = (uint8_t)frame->fault_code;
+        encoded[7] = (uint8_t)frame->device_mode;
+        break;
+    case MCU_WIRE_FRAME_TELEMETRY:
+        write_u32_be(&encoded[1], frame->sequence_no);
+        encoded[5] = (uint8_t)frame->fault_code;
+        encoded[6] = (uint8_t)frame->device_mode;
+        break;
+    case MCU_WIRE_FRAME_KIND_COUNT:
+    default:
+        return MCU_CODEC_INVALID_FIELD;
+    }
+
+    for (i = 0u; i < MCU_WIRE_DLC; i++) {
+        destination[i] = encoded[i];
+    }
+    *arbitration_id = encoded_id;
+    *encoded_length = MCU_WIRE_DLC;
+    return MCU_CODEC_OK;
+}
+
+mcu_codec_status_t mcu_frame_decode(uint16_t arbitration_id,
+                                    const uint8_t *source,
+                                    uint8_t encoded_length,
+                                    mcu_wire_frame_t *frame)
+{
+    mcu_wire_frame_t decoded;
+
+    if (frame == 0) {
+        return MCU_CODEC_INVALID_ARGUMENT;
+    }
+    if (encoded_length != MCU_WIRE_DLC) {
+        return MCU_CODEC_INVALID_LENGTH;
+    }
+    if (source == 0) {
+        return MCU_CODEC_INVALID_ARGUMENT;
+    }
+    clear_frame(&decoded);
+    if (!id_to_frame_kind(arbitration_id, &decoded.kind)) {
+        return MCU_CODEC_UNSUPPORTED_ID;
+    }
+    if (source[0] != MCU_WIRE_VERSION_V1) {
+        return MCU_CODEC_INVALID_VERSION;
+    }
+
+    switch (decoded.kind) {
+    case MCU_WIRE_FRAME_COMMAND:
+    case MCU_WIRE_FRAME_STOP:
+        if (source[5] != 0u || source[6] != 0u || source[7] != 0u) {
+            return MCU_CODEC_NONZERO_RESERVED;
+        }
+        decoded.command_id = read_u16_be(&source[1]);
+        decoded.opcode = (mcu_wire_opcode_t)source[3];
+        decoded.retry_count = source[4];
+        break;
+    case MCU_WIRE_FRAME_ACK:
+    case MCU_WIRE_FRAME_STOP_ACK:
+        decoded.command_id = read_u16_be(&source[1]);
+        decoded.opcode = (mcu_wire_opcode_t)source[3];
+        decoded.retry_count = source[4];
+        decoded.result_code = (mcu_wire_result_t)source[5];
+        decoded.fault_code = (mcu_wire_fault_t)source[6];
+        decoded.device_mode = (mcu_wire_device_mode_t)source[7];
+        break;
+    case MCU_WIRE_FRAME_TELEMETRY:
+        if (source[7] != 0u) {
+            return MCU_CODEC_NONZERO_RESERVED;
+        }
+        decoded.sequence_no = read_u32_be(&source[1]);
+        decoded.fault_code = (mcu_wire_fault_t)source[5];
+        decoded.device_mode = (mcu_wire_device_mode_t)source[6];
+        break;
+    case MCU_WIRE_FRAME_KIND_COUNT:
+    default:
+        return MCU_CODEC_UNSUPPORTED_ID;
+    }
+
+    if (!frame_is_valid(&decoded)) {
+        return MCU_CODEC_INVALID_FIELD;
+    }
+    copy_frame(frame, &decoded);
+    return MCU_CODEC_OK;
+}

--- a/firmware/mcu/core/frame_codec.h
+++ b/firmware/mcu/core/frame_codec.h
@@ -1,0 +1,112 @@
+#ifndef MCU_FRAME_CODEC_H
+#define MCU_FRAME_CODEC_H
+
+#include <stdint.h>
+
+/* Firmware-owned CAN Wire V1.  The logical protocol remains version 1.0;
+ * 0x10 is its compact on-wire representation. */
+#define MCU_WIRE_VERSION_V1 0x10u
+#define MCU_WIRE_DLC 8u
+
+/* Lower CAN identifiers win arbitration, so STOP traffic has priority over
+ * ordinary command, acknowledgement and telemetry traffic. */
+#define MCU_CAN_ID_STOP 0x080u
+#define MCU_CAN_ID_STOP_ACK 0x081u
+#define MCU_CAN_ID_COMMAND 0x100u
+#define MCU_CAN_ID_ACK 0x101u
+#define MCU_CAN_ID_TELEMETRY 0x180u
+
+#define MCU_COMMAND_ID_MAX 0x7fffu
+#define MCU_STOP_ID_MIN 0x8000u
+
+typedef enum {
+    MCU_WIRE_FRAME_COMMAND = 0,
+    MCU_WIRE_FRAME_ACK,
+    MCU_WIRE_FRAME_TELEMETRY,
+    MCU_WIRE_FRAME_STOP,
+    MCU_WIRE_FRAME_STOP_ACK,
+    MCU_WIRE_FRAME_KIND_COUNT
+} mcu_wire_frame_kind_t;
+
+/* Zero is reserved so an uninitialised/zero-filled opcode cannot execute. */
+typedef enum {
+    MCU_WIRE_OPCODE_RESERVED = 0,
+    MCU_WIRE_OPCODE_MOVE = 1,
+    MCU_WIRE_OPCODE_GRIP_OPEN = 2,
+    MCU_WIRE_OPCODE_GRIP_CLOSE = 3,
+    MCU_WIRE_OPCODE_HOLD = 4,
+    MCU_WIRE_OPCODE_STOP = 5,
+    MCU_WIRE_OPCODE_HEARTBEAT = 6,
+    MCU_WIRE_OPCODE_COUNT
+} mcu_wire_opcode_t;
+
+typedef enum {
+    MCU_WIRE_RESULT_ACCEPTED = 0,
+    MCU_WIRE_RESULT_REJECTED = 1,
+    MCU_WIRE_RESULT_COUNT
+} mcu_wire_result_t;
+
+/* Values follow the frozen logical fault registry. ACK_TIMEOUT and
+ * STOP_TIMEOUT are host-only diagnostics and are rejected in decoded MCU
+ * frames even though their numeric values remain reserved here. */
+typedef enum {
+    MCU_WIRE_FAULT_NONE = 0,
+    MCU_WIRE_FAULT_ACK_TIMEOUT = 1,
+    MCU_WIRE_FAULT_STOP_TIMEOUT = 2,
+    MCU_WIRE_FAULT_STOP_REJECTED = 3,
+    MCU_WIRE_FAULT_LINK_LOST = 4,
+    MCU_WIRE_FAULT_DUPLICATE_FRAME = 5,
+    MCU_WIRE_FAULT_WATCHDOG_EXPIRED = 6,
+    MCU_WIRE_FAULT_MALFORMED_FRAME = 7,
+    MCU_WIRE_FAULT_COUNT
+} mcu_wire_fault_t;
+
+typedef enum {
+    MCU_WIRE_MODE_IDLE = 0,
+    MCU_WIRE_MODE_MOVING = 1,
+    MCU_WIRE_MODE_HOLDING = 2,
+    MCU_WIRE_MODE_STOPPED = 3,
+    MCU_WIRE_MODE_FAULTED = 4,
+    MCU_WIRE_MODE_COUNT
+} mcu_wire_device_mode_t;
+
+typedef enum {
+    MCU_CODEC_OK = 0,
+    MCU_CODEC_INVALID_ARGUMENT,
+    MCU_CODEC_BUFFER_TOO_SMALL,
+    MCU_CODEC_INVALID_LENGTH,
+    MCU_CODEC_UNSUPPORTED_ID,
+    MCU_CODEC_INVALID_VERSION,
+    MCU_CODEC_NONZERO_RESERVED,
+    MCU_CODEC_INVALID_FIELD
+} mcu_codec_status_t;
+
+/* Fields absent from a frame kind must remain zero.  This makes accidental
+ * reuse of a struct fail closed instead of silently dropping stale fields. */
+typedef struct {
+    mcu_wire_frame_kind_t kind;
+    uint16_t command_id;
+    uint32_t sequence_no;
+    mcu_wire_opcode_t opcode;
+    uint8_t retry_count;
+    mcu_wire_result_t result_code;
+    mcu_wire_fault_t fault_code;
+    mcu_wire_device_mode_t device_mode;
+} mcu_wire_frame_t;
+
+/* Outputs are not modified on failure.  The encoder validates capacity before
+ * writing and always emits exactly MCU_WIRE_DLC bytes on success. */
+mcu_codec_status_t mcu_frame_encode(const mcu_wire_frame_t *frame,
+                                    uint16_t *arbitration_id,
+                                    uint8_t *destination,
+                                    uint8_t destination_capacity,
+                                    uint8_t *encoded_length);
+
+/* The decoder validates encoded_length before reading source and publishes a
+ * frame only after every byte and cross-field invariant has passed. */
+mcu_codec_status_t mcu_frame_decode(uint16_t arbitration_id,
+                                    const uint8_t *source,
+                                    uint8_t encoded_length,
+                                    mcu_wire_frame_t *frame);
+
+#endif /* MCU_FRAME_CODEC_H */

--- a/firmware/mcu/hal/qemu/main_qemu.c
+++ b/firmware/mcu/hal/qemu/main_qemu.c
@@ -16,6 +16,7 @@
  *   - mtime advances, so FW5's watchdog has a clock to trust
  */
 #include "hal.h"
+#include "frame_codec_tests.h"
 #include "state_machine_tests.h"
 
 /* Deliberately uninitialised: if crt0 skipped the .bss loop this is garbage
@@ -92,6 +93,21 @@ static int run_state_machine_tests(void)
     return report.failures == 0u ? 0 : 4;
 }
 
+static int run_frame_codec_tests(void)
+{
+    mcu_test_report_t report;
+
+    mcu_frame_codec_run_tests(&report);
+    hal_puts("[mcu] frame-codec assertions=");
+    hal_put_u32(report.assertions);
+    hal_puts(" failures=");
+    hal_put_u32(report.failures);
+    hal_puts(" first_failure=");
+    hal_put_u32(report.first_failure);
+    hal_putc('\n');
+    return report.failures == 0u ? 0 : 5;
+}
+
 int main(void)
 {
     hal_puts("\n[mcu] FW1/FW2 smoke test\n");
@@ -101,6 +117,7 @@ int main(void)
     rc |= check_clock_advances();
     rc |= check_stack_sane();
     rc |= run_state_machine_tests();
+    rc |= run_frame_codec_tests();
 
     /* CAN is deliberately not checked: hal_can_init returns false until FW10,
      * and a smoke test that skipped over that would be misleading. */

--- a/firmware/mcu/tests/frame_codec_tests.c
+++ b/firmware/mcu/tests/frame_codec_tests.c
@@ -1,0 +1,616 @@
+#include "frame_codec_tests.h"
+
+#include <stdbool.h>
+
+#include "frame_codec.h"
+
+typedef struct {
+    mcu_wire_frame_t frame;
+    uint16_t arbitration_id;
+    uint8_t data[MCU_WIRE_DLC];
+} golden_vector_t;
+
+static const golden_vector_t golden_vectors[] = {
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_COMMAND,
+            .command_id = 32767u,
+            .opcode = MCU_WIRE_OPCODE_HEARTBEAT,
+            .retry_count = 255u,
+        },
+        .arbitration_id = MCU_CAN_ID_COMMAND,
+        .data = {0x10u, 0x7fu, 0xffu, 0x06u, 0xffu, 0x00u, 0x00u, 0x00u},
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_ACK,
+            .command_id = 19u,
+            .opcode = MCU_WIRE_OPCODE_HOLD,
+            .retry_count = 1u,
+            .result_code = MCU_WIRE_RESULT_ACCEPTED,
+            .fault_code = MCU_WIRE_FAULT_NONE,
+            .device_mode = MCU_WIRE_MODE_HOLDING,
+        },
+        .arbitration_id = MCU_CAN_ID_ACK,
+        .data = {0x10u, 0x00u, 0x13u, 0x04u, 0x01u, 0x00u, 0x00u, 0x02u},
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_ACK,
+            .command_id = 20u,
+            .opcode = MCU_WIRE_OPCODE_GRIP_CLOSE,
+            .result_code = MCU_WIRE_RESULT_REJECTED,
+            .fault_code = MCU_WIRE_FAULT_MALFORMED_FRAME,
+            .device_mode = MCU_WIRE_MODE_FAULTED,
+        },
+        .arbitration_id = MCU_CAN_ID_ACK,
+        .data = {0x10u, 0x00u, 0x14u, 0x03u, 0x00u, 0x01u, 0x07u, 0x04u},
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_TELEMETRY,
+            .sequence_no = 0xffffffffu,
+            .fault_code = MCU_WIRE_FAULT_NONE,
+            .device_mode = MCU_WIRE_MODE_IDLE,
+        },
+        .arbitration_id = MCU_CAN_ID_TELEMETRY,
+        .data = {0x10u, 0xffu, 0xffu, 0xffu, 0xffu, 0x00u, 0x00u, 0x00u},
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_TELEMETRY,
+            .sequence_no = 0u,
+            .fault_code = MCU_WIRE_FAULT_WATCHDOG_EXPIRED,
+            .device_mode = MCU_WIRE_MODE_FAULTED,
+        },
+        .arbitration_id = MCU_CAN_ID_TELEMETRY,
+        .data = {0x10u, 0x00u, 0x00u, 0x00u, 0x00u, 0x06u, 0x04u, 0x00u},
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_STOP,
+            .command_id = 32768u,
+            .opcode = MCU_WIRE_OPCODE_STOP,
+        },
+        .arbitration_id = MCU_CAN_ID_STOP,
+        .data = {0x10u, 0x80u, 0x00u, 0x05u, 0x00u, 0x00u, 0x00u, 0x00u},
+    },
+    {
+        /* interfaces/examples/mcu-frame-stop-ack.json */
+        .frame = {
+            .kind = MCU_WIRE_FRAME_STOP_ACK,
+            .command_id = 32769u,
+            .opcode = MCU_WIRE_OPCODE_STOP,
+            .result_code = MCU_WIRE_RESULT_ACCEPTED,
+            .fault_code = MCU_WIRE_FAULT_NONE,
+            .device_mode = MCU_WIRE_MODE_STOPPED,
+        },
+        .arbitration_id = MCU_CAN_ID_STOP_ACK,
+        .data = {0x10u, 0x80u, 0x01u, 0x05u, 0x00u, 0x00u, 0x00u, 0x03u},
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_STOP_ACK,
+            .command_id = 65535u,
+            .opcode = MCU_WIRE_OPCODE_STOP,
+            .retry_count = 2u,
+            .result_code = MCU_WIRE_RESULT_REJECTED,
+            .fault_code = MCU_WIRE_FAULT_STOP_REJECTED,
+            .device_mode = MCU_WIRE_MODE_FAULTED,
+        },
+        .arbitration_id = MCU_CAN_ID_STOP_ACK,
+        .data = {0x10u, 0xffu, 0xffu, 0x05u, 0x02u, 0x01u, 0x03u, 0x04u},
+    },
+};
+
+static void check(mcu_test_report_t *report, bool condition)
+{
+    report->assertions++;
+    if (!condition) {
+        report->failures++;
+        if (report->first_failure == 0u) {
+            report->first_failure = report->assertions;
+        }
+    }
+}
+
+static bool bytes_equal(const uint8_t *left, const uint8_t *right, unsigned length)
+{
+    unsigned i;
+
+    for (i = 0u; i < length; i++) {
+        if (left[i] != right[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void copy_bytes(uint8_t *destination, const uint8_t *source, unsigned length)
+{
+    unsigned i;
+
+    for (i = 0u; i < length; i++) {
+        destination[i] = source[i];
+    }
+}
+
+static bool frames_equal(const mcu_wire_frame_t *left, const mcu_wire_frame_t *right)
+{
+    return left->kind == right->kind && left->command_id == right->command_id &&
+           left->sequence_no == right->sequence_no && left->opcode == right->opcode &&
+           left->retry_count == right->retry_count && left->result_code == right->result_code &&
+           left->fault_code == right->fault_code && left->device_mode == right->device_mode;
+}
+
+static void copy_frame(mcu_wire_frame_t *destination, const mcu_wire_frame_t *source)
+{
+    destination->kind = source->kind;
+    destination->command_id = source->command_id;
+    destination->sequence_no = source->sequence_no;
+    destination->opcode = source->opcode;
+    destination->retry_count = source->retry_count;
+    destination->result_code = source->result_code;
+    destination->fault_code = source->fault_code;
+    destination->device_mode = source->device_mode;
+}
+
+static void clear_frame(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_COMMAND;
+    frame->command_id = 0u;
+    frame->sequence_no = 0u;
+    frame->opcode = MCU_WIRE_OPCODE_RESERVED;
+    frame->retry_count = 0u;
+    frame->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    frame->fault_code = MCU_WIRE_FAULT_NONE;
+    frame->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void set_sentinel_frame(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_KIND_COUNT;
+    frame->command_id = 0xa55au;
+    frame->sequence_no = 0x5aa55aa5u;
+    frame->opcode = MCU_WIRE_OPCODE_COUNT;
+    frame->retry_count = 0xa5u;
+    frame->result_code = MCU_WIRE_RESULT_COUNT;
+    frame->fault_code = MCU_WIRE_FAULT_COUNT;
+    frame->device_mode = MCU_WIRE_MODE_COUNT;
+}
+
+static void expect_decode_status(mcu_test_report_t *report,
+                                 uint16_t arbitration_id,
+                                 const uint8_t *data,
+                                 uint8_t length,
+                                 mcu_codec_status_t expected)
+{
+    mcu_wire_frame_t decoded;
+    mcu_wire_frame_t before;
+    mcu_codec_status_t status;
+
+    set_sentinel_frame(&decoded);
+    copy_frame(&before, &decoded);
+    status = mcu_frame_decode(arbitration_id, data, length, &decoded);
+
+    check(report, status == expected);
+    if (expected != MCU_CODEC_OK) {
+        check(report, frames_equal(&decoded, &before));
+    }
+}
+
+static void test_golden_vectors(mcu_test_report_t *report)
+{
+    unsigned vector_index;
+
+    check(report, MCU_CAN_ID_STOP < MCU_CAN_ID_COMMAND);
+    check(report, MCU_CAN_ID_STOP_ACK < MCU_CAN_ID_ACK);
+    check(report, MCU_WIRE_DLC == 8u);
+
+    for (vector_index = 0u; vector_index < sizeof(golden_vectors) / sizeof(golden_vectors[0]);
+         vector_index++) {
+        const golden_vector_t *vector = &golden_vectors[vector_index];
+        uint8_t encoded[MCU_WIRE_DLC] = {0u};
+        uint8_t encoded_length = 0u;
+        uint16_t arbitration_id = 0u;
+        mcu_wire_frame_t decoded;
+
+        set_sentinel_frame(&decoded);
+
+        check(report,
+              mcu_frame_encode(&vector->frame,
+                               &arbitration_id,
+                               encoded,
+                               sizeof(encoded),
+                               &encoded_length) == MCU_CODEC_OK);
+        check(report, arbitration_id == vector->arbitration_id);
+        check(report, encoded_length == MCU_WIRE_DLC);
+        check(report, bytes_equal(encoded, vector->data, MCU_WIRE_DLC));
+        check(report,
+              mcu_frame_decode(arbitration_id, encoded, encoded_length, &decoded) == MCU_CODEC_OK);
+        check(report, frames_equal(&decoded, &vector->frame));
+    }
+}
+
+static void test_decode_rejects_bad_envelope_without_reads(mcu_test_report_t *report)
+{
+    uint8_t one_byte = MCU_WIRE_VERSION_V1;
+    mcu_wire_frame_t decoded;
+    unsigned length;
+
+    set_sentinel_frame(&decoded);
+
+    for (length = 0u; length < MCU_WIRE_DLC; length++) {
+        expect_decode_status(report,
+                             MCU_CAN_ID_COMMAND,
+                             &one_byte,
+                             (uint8_t)length,
+                             MCU_CODEC_INVALID_LENGTH);
+    }
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, &one_byte, 9u, MCU_CODEC_INVALID_LENGTH);
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, 0, MCU_WIRE_DLC, MCU_CODEC_INVALID_ARGUMENT);
+    expect_decode_status(report,
+                         0x7ffu,
+                         golden_vectors[0].data,
+                         MCU_WIRE_DLC,
+                         MCU_CODEC_UNSUPPORTED_ID);
+    check(report,
+          mcu_frame_decode(MCU_CAN_ID_COMMAND,
+                           golden_vectors[0].data,
+                           MCU_WIRE_DLC,
+                           0) == MCU_CODEC_INVALID_ARGUMENT);
+    check(report, decoded.kind == MCU_WIRE_FRAME_KIND_COUNT);
+}
+
+static void test_decode_rejects_malformed_payloads(mcu_test_report_t *report)
+{
+    uint8_t data[MCU_WIRE_DLC];
+
+    copy_bytes(data, golden_vectors[0].data, MCU_WIRE_DLC);
+    data[0] = 0x11u;
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_VERSION);
+
+    copy_bytes(data, golden_vectors[0].data, MCU_WIRE_DLC);
+    data[5] = 1u;
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, data, MCU_WIRE_DLC, MCU_CODEC_NONZERO_RESERVED);
+
+    copy_bytes(data, golden_vectors[3].data, MCU_WIRE_DLC);
+    data[7] = 1u;
+    expect_decode_status(report, MCU_CAN_ID_TELEMETRY, data, MCU_WIRE_DLC, MCU_CODEC_NONZERO_RESERVED);
+
+    copy_bytes(data, golden_vectors[0].data, MCU_WIRE_DLC);
+    data[1] = 0x80u;
+    data[2] = 0x00u;
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[5].data, MCU_WIRE_DLC);
+    data[1] = 0x7fu;
+    data[2] = 0xffu;
+    expect_decode_status(report, MCU_CAN_ID_STOP, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[0].data, MCU_WIRE_DLC);
+    data[3] = MCU_WIRE_OPCODE_RESERVED;
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[3] = MCU_WIRE_OPCODE_STOP;
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[3] = 0xffu;
+    expect_decode_status(report, MCU_CAN_ID_COMMAND, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[5].data, MCU_WIRE_DLC);
+    data[3] = MCU_WIRE_OPCODE_HOLD;
+    expect_decode_status(report, MCU_CAN_ID_STOP, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[1].data, MCU_WIRE_DLC);
+    data[5] = 2u;
+    expect_decode_status(report, MCU_CAN_ID_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[5] = MCU_WIRE_RESULT_ACCEPTED;
+    data[6] = MCU_WIRE_FAULT_MALFORMED_FRAME;
+    expect_decode_status(report, MCU_CAN_ID_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[6] = MCU_WIRE_FAULT_NONE;
+    data[7] = MCU_WIRE_MODE_FAULTED;
+    expect_decode_status(report, MCU_CAN_ID_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[2].data, MCU_WIRE_DLC);
+    data[6] = MCU_WIRE_FAULT_NONE;
+    expect_decode_status(report, MCU_CAN_ID_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[6] = MCU_WIRE_FAULT_ACK_TIMEOUT;
+    expect_decode_status(report, MCU_CAN_ID_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[6] = MCU_WIRE_FAULT_COUNT;
+    expect_decode_status(report, MCU_CAN_ID_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[6].data, MCU_WIRE_DLC);
+    data[7] = MCU_WIRE_MODE_IDLE;
+    expect_decode_status(report, MCU_CAN_ID_STOP_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[7].data, MCU_WIRE_DLC);
+    data[6] = MCU_WIRE_FAULT_STOP_TIMEOUT;
+    expect_decode_status(report, MCU_CAN_ID_STOP_ACK, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+
+    copy_bytes(data, golden_vectors[3].data, MCU_WIRE_DLC);
+    data[5] = MCU_WIRE_FAULT_NONE;
+    data[6] = MCU_WIRE_MODE_FAULTED;
+    expect_decode_status(report, MCU_CAN_ID_TELEMETRY, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[5] = MCU_WIRE_FAULT_LINK_LOST;
+    data[6] = MCU_WIRE_MODE_MOVING;
+    expect_decode_status(report, MCU_CAN_ID_TELEMETRY, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[5] = MCU_WIRE_FAULT_DUPLICATE_FRAME;
+    data[6] = MCU_WIRE_MODE_FAULTED;
+    expect_decode_status(report, MCU_CAN_ID_TELEMETRY, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+    data[5] = 0xffu;
+    expect_decode_status(report, MCU_CAN_ID_TELEMETRY, data, MCU_WIRE_DLC, MCU_CODEC_INVALID_FIELD);
+}
+
+static void check_encode_failure(mcu_test_report_t *report,
+                                 const mcu_wire_frame_t *frame,
+                                 mcu_codec_status_t expected)
+{
+    uint8_t destination[MCU_WIRE_DLC];
+    uint8_t before[MCU_WIRE_DLC];
+    uint8_t encoded_length = 0xa5u;
+    uint16_t arbitration_id = 0xa55au;
+    unsigned i;
+
+    for (i = 0u; i < MCU_WIRE_DLC; i++) {
+        destination[i] = (uint8_t)(0xa0u + i);
+        before[i] = destination[i];
+    }
+    check(report,
+          mcu_frame_encode(frame,
+                           &arbitration_id,
+                           destination,
+                           sizeof(destination),
+                           &encoded_length) == expected);
+    check(report, arbitration_id == 0xa55au);
+    check(report, encoded_length == 0xa5u);
+    check(report, bytes_equal(destination, before, MCU_WIRE_DLC));
+}
+
+static void test_encoder_bounds_and_strict_fields(mcu_test_report_t *report)
+{
+    mcu_wire_frame_t invalid;
+    uint8_t guarded[MCU_WIRE_DLC] = {0xa5u, 0xa5u, 0xa5u, 0xa5u, 0xa5u, 0xa5u, 0xa5u, 0xa5u};
+    uint8_t encoded_length = 0x5au;
+    uint16_t arbitration_id = 0x5aa5u;
+
+    check(report,
+          mcu_frame_encode(&golden_vectors[0].frame,
+                           &arbitration_id,
+                           guarded,
+                           MCU_WIRE_DLC - 1u,
+                           &encoded_length) == MCU_CODEC_BUFFER_TOO_SMALL);
+    check(report, arbitration_id == 0x5aa5u);
+    check(report, encoded_length == 0x5au);
+    check(report, guarded[0] == 0xa5u && guarded[MCU_WIRE_DLC - 1u] == 0xa5u);
+
+    check(report,
+          mcu_frame_encode(0,
+                           &arbitration_id,
+                           guarded,
+                           sizeof(guarded),
+                           &encoded_length) == MCU_CODEC_INVALID_ARGUMENT);
+    check(report,
+          mcu_frame_encode(&golden_vectors[0].frame,
+                           0,
+                           guarded,
+                           sizeof(guarded),
+                           &encoded_length) == MCU_CODEC_INVALID_ARGUMENT);
+    check(report,
+          mcu_frame_encode(&golden_vectors[0].frame,
+                           &arbitration_id,
+                           0,
+                           sizeof(guarded),
+                           &encoded_length) == MCU_CODEC_INVALID_ARGUMENT);
+    check(report,
+          mcu_frame_encode(&golden_vectors[0].frame,
+                           &arbitration_id,
+                           guarded,
+                           sizeof(guarded),
+                           0) == MCU_CODEC_INVALID_ARGUMENT);
+
+    copy_frame(&invalid, &golden_vectors[0].frame);
+    invalid.command_id = MCU_STOP_ID_MIN;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+    copy_frame(&invalid, &golden_vectors[0].frame);
+    invalid.sequence_no = 1u;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+    copy_frame(&invalid, &golden_vectors[0].frame);
+    invalid.fault_code = MCU_WIRE_FAULT_MALFORMED_FRAME;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+    copy_frame(&invalid, &golden_vectors[3].frame);
+    invalid.command_id = 1u;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+    copy_frame(&invalid, &golden_vectors[5].frame);
+    invalid.opcode = MCU_WIRE_OPCODE_MOVE;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+    copy_frame(&invalid, &golden_vectors[1].frame);
+    invalid.result_code = MCU_WIRE_RESULT_REJECTED;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+    copy_frame(&invalid, &golden_vectors[6].frame);
+    invalid.fault_code = MCU_WIRE_FAULT_STOP_REJECTED;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+    copy_frame(&invalid, &golden_vectors[0].frame);
+    invalid.kind = MCU_WIRE_FRAME_KIND_COUNT;
+    check_encode_failure(report, &invalid, MCU_CODEC_INVALID_FIELD);
+}
+
+static uint32_t next_random(uint32_t *state)
+{
+    uint32_t value = *state;
+
+    value ^= value << 13;
+    value ^= value >> 17;
+    value ^= value << 5;
+    *state = value;
+    return value;
+}
+
+static mcu_wire_opcode_t random_ordinary_opcode(uint32_t value)
+{
+    static const mcu_wire_opcode_t opcodes[] = {
+        MCU_WIRE_OPCODE_MOVE,
+        MCU_WIRE_OPCODE_GRIP_OPEN,
+        MCU_WIRE_OPCODE_GRIP_CLOSE,
+        MCU_WIRE_OPCODE_HOLD,
+        MCU_WIRE_OPCODE_HEARTBEAT,
+    };
+
+    return opcodes[value % (sizeof(opcodes) / sizeof(opcodes[0]))];
+}
+
+static void random_valid_frame(uint32_t *state, mcu_wire_frame_t *frame)
+{
+    uint32_t value = next_random(state);
+
+    clear_frame(frame);
+    frame->kind = (mcu_wire_frame_kind_t)(value % MCU_WIRE_FRAME_KIND_COUNT);
+    switch (frame->kind) {
+    case MCU_WIRE_FRAME_COMMAND:
+        frame->command_id = (uint16_t)(next_random(state) & MCU_COMMAND_ID_MAX);
+        frame->opcode = random_ordinary_opcode(next_random(state));
+        frame->retry_count = (uint8_t)next_random(state);
+        break;
+    case MCU_WIRE_FRAME_ACK:
+        frame->command_id = (uint16_t)(next_random(state) & MCU_COMMAND_ID_MAX);
+        frame->opcode = random_ordinary_opcode(next_random(state));
+        frame->retry_count = (uint8_t)next_random(state);
+        if ((next_random(state) & 1u) == 0u) {
+            frame->device_mode = (mcu_wire_device_mode_t)(next_random(state) % MCU_WIRE_MODE_FAULTED);
+        } else {
+            frame->result_code = MCU_WIRE_RESULT_REJECTED;
+            frame->fault_code = (next_random(state) & 1u) == 0u
+                                    ? MCU_WIRE_FAULT_DUPLICATE_FRAME
+                                    : MCU_WIRE_FAULT_MALFORMED_FRAME;
+            frame->device_mode = MCU_WIRE_MODE_FAULTED;
+        }
+        break;
+    case MCU_WIRE_FRAME_TELEMETRY:
+        frame->sequence_no = next_random(state);
+        if ((next_random(state) & 1u) == 0u) {
+            frame->device_mode = (mcu_wire_device_mode_t)(next_random(state) % MCU_WIRE_MODE_FAULTED);
+        } else {
+            frame->fault_code = (next_random(state) & 1u) == 0u
+                                    ? MCU_WIRE_FAULT_LINK_LOST
+                                    : MCU_WIRE_FAULT_WATCHDOG_EXPIRED;
+            frame->device_mode = MCU_WIRE_MODE_FAULTED;
+        }
+        break;
+    case MCU_WIRE_FRAME_STOP:
+        frame->command_id = (uint16_t)(next_random(state) | MCU_STOP_ID_MIN);
+        frame->opcode = MCU_WIRE_OPCODE_STOP;
+        frame->retry_count = (uint8_t)next_random(state);
+        break;
+    case MCU_WIRE_FRAME_STOP_ACK:
+        frame->command_id = (uint16_t)(next_random(state) | MCU_STOP_ID_MIN);
+        frame->opcode = MCU_WIRE_OPCODE_STOP;
+        frame->retry_count = (uint8_t)next_random(state);
+        if ((next_random(state) & 1u) == 0u) {
+            frame->device_mode = MCU_WIRE_MODE_STOPPED;
+        } else {
+            frame->result_code = MCU_WIRE_RESULT_REJECTED;
+            frame->fault_code = MCU_WIRE_FAULT_STOP_REJECTED;
+            frame->device_mode = MCU_WIRE_MODE_FAULTED;
+        }
+        break;
+    case MCU_WIRE_FRAME_KIND_COUNT:
+    default:
+        break;
+    }
+}
+
+static uint16_t fuzz_arbitration_id(uint32_t value)
+{
+    static const uint16_t ids[] = {
+        MCU_CAN_ID_COMMAND,
+        MCU_CAN_ID_ACK,
+        MCU_CAN_ID_TELEMETRY,
+        MCU_CAN_ID_STOP,
+        MCU_CAN_ID_STOP_ACK,
+        0x000u,
+        0x7ffu,
+    };
+
+    return ids[value % (sizeof(ids) / sizeof(ids[0]))];
+}
+
+static void test_bounded_properties_and_malformed_fuzz(mcu_test_report_t *report)
+{
+    uint32_t random_state = 0x54c0dec1u;
+    unsigned iteration;
+
+    for (iteration = 0u; iteration < 4096u; iteration++) {
+        mcu_wire_frame_t original;
+        mcu_wire_frame_t decoded;
+        uint8_t encoded[MCU_WIRE_DLC];
+        uint8_t encoded_length = 0u;
+        uint16_t arbitration_id = 0u;
+
+        random_valid_frame(&random_state, &original);
+        set_sentinel_frame(&decoded);
+
+        check(report,
+              mcu_frame_encode(&original,
+                               &arbitration_id,
+                               encoded,
+                               sizeof(encoded),
+                               &encoded_length) == MCU_CODEC_OK);
+        check(report,
+              mcu_frame_decode(arbitration_id, encoded, encoded_length, &decoded) == MCU_CODEC_OK);
+        check(report, frames_equal(&original, &decoded));
+    }
+
+    for (iteration = 0u; iteration < 8192u; iteration++) {
+        mcu_wire_frame_t decoded;
+        mcu_wire_frame_t before;
+        uint8_t data[MCU_WIRE_DLC];
+        uint8_t length;
+        uint16_t arbitration_id;
+        mcu_codec_status_t status;
+        unsigned byte_index;
+
+        set_sentinel_frame(&decoded);
+        copy_frame(&before, &decoded);
+        for (byte_index = 0u; byte_index < MCU_WIRE_DLC; byte_index++) {
+            data[byte_index] = (uint8_t)next_random(&random_state);
+        }
+        arbitration_id = fuzz_arbitration_id(next_random(&random_state));
+        length = (next_random(&random_state) & 3u) == 0u
+                     ? MCU_WIRE_DLC
+                     : (uint8_t)(next_random(&random_state) % 11u);
+        status = mcu_frame_decode(arbitration_id, data, length, &decoded);
+
+        if (status == MCU_CODEC_OK) {
+            uint8_t reencoded[MCU_WIRE_DLC];
+            uint8_t reencoded_length = 0u;
+            uint16_t reencoded_id = 0u;
+
+            check(report,
+                  mcu_frame_encode(&decoded,
+                                   &reencoded_id,
+                                   reencoded,
+                                   sizeof(reencoded),
+                                   &reencoded_length) == MCU_CODEC_OK);
+            check(report, reencoded_id == arbitration_id);
+            check(report, reencoded_length == MCU_WIRE_DLC);
+            check(report, bytes_equal(reencoded, data, MCU_WIRE_DLC));
+        } else {
+            check(report, frames_equal(&decoded, &before));
+        }
+    }
+}
+
+void mcu_frame_codec_run_tests(mcu_test_report_t *report)
+{
+    if (report == 0) {
+        return;
+    }
+
+    report->assertions = 0u;
+    report->failures = 0u;
+    report->first_failure = 0u;
+
+    test_golden_vectors(report);
+    test_decode_rejects_bad_envelope_without_reads(report);
+    test_decode_rejects_malformed_payloads(report);
+    test_encoder_bounds_and_strict_fields(report);
+    test_bounded_properties_and_malformed_fuzz(report);
+}

--- a/firmware/mcu/tests/frame_codec_tests.h
+++ b/firmware/mcu/tests/frame_codec_tests.h
@@ -1,0 +1,8 @@
+#ifndef MCU_FRAME_CODEC_TESTS_H
+#define MCU_FRAME_CODEC_TESTS_H
+
+#include "state_machine_tests.h"
+
+void mcu_frame_codec_run_tests(mcu_test_report_t *report);
+
+#endif /* MCU_FRAME_CODEC_TESTS_H */

--- a/firmware/mcu/tests/main_host.c
+++ b/firmware/mcu/tests/main_host.c
@@ -1,15 +1,23 @@
 #include <stdio.h>
 
+#include "frame_codec_tests.h"
 #include "state_machine_tests.h"
 
 int main(void)
 {
-    mcu_test_report_t report;
+    mcu_test_report_t state_machine_report;
+    mcu_test_report_t frame_codec_report;
 
-    mcu_state_machine_run_tests(&report);
+    mcu_state_machine_run_tests(&state_machine_report);
     printf("[mcu-host] state-machine assertions=%u failures=%u first_failure=%u\n",
-           (unsigned)report.assertions,
-           (unsigned)report.failures,
-           (unsigned)report.first_failure);
-    return report.failures == 0u ? 0 : 1;
+           (unsigned)state_machine_report.assertions,
+           (unsigned)state_machine_report.failures,
+           (unsigned)state_machine_report.first_failure);
+
+    mcu_frame_codec_run_tests(&frame_codec_report);
+    printf("[mcu-host] frame-codec assertions=%u failures=%u first_failure=%u\n",
+           (unsigned)frame_codec_report.assertions,
+           (unsigned)frame_codec_report.failures,
+           (unsigned)frame_codec_report.first_failure);
+    return state_machine_report.failures == 0u && frame_codec_report.failures == 0u ? 0 : 1;
 }


### PR DESCRIPTION
## Related Issue

Closes #54.

## What changed

- Implements a fixed-size MCU CAN Wire V1 codec without dynamic allocation or floating-point dependencies.
- Supports COMMAND, ACK, TELEMETRY, STOP, and STOP_ACK over Classic CAN standard 11-bit IDs with DLC 8 and big-endian integers.
- Fails closed on unknown IDs/versions/enums/opcodes, nonzero reserved fields, and invalid field combinations.
- Adds shared host/QEMU codec tests, a STOP_ACK golden vector, sanitizer and size/symbol checks, architecture documentation, and the Issue #54 Task Packet.
- Restores the MCU schema/example, virtual MCU, contract, and robot-control references as read-only Task Packet inputs; this does not grant write authority to those paths.

## Verification

```text
host state-machine: 436 assertions, 0 failures
host codec: 20,637 assertions, 0 failures
ASan/UBSan codec: 20,637 assertions, 0 failures and no sanitizer finding
```

All seven GitHub checks pass at final head `ee570ef`, including MCU QEMU, foundation, container, kernel module, dependency review, and CodeQL.

## Scope

This PR does not implement the HAL CAN driver, deduplication window, watchdog/STOP timing, bus-off recovery, or physical CAN validation. It does not change the frozen JSON/Pydantic protocol contract and does not claim hardware evidence.

## Rollback

Revert this PR.
