### PR TITLE
fix(agent-runtime): validate tool schemas on registration

### DIFF
--- a/docs/task_packets/issue-48-tool-schema-registration.json
+++ b/docs/task_packets/issue-48-tool-schema-registration.json
@@ -1,0 +1,45 @@
+{
+  "issue": 48,
+  "human_owner": "Quchaosheng",
+  "objective": "Reject malformed tool schemas atomically at the ToolRegistry registration boundary.",
+  "allowed_paths": [
+    "services/agent_runtime/workbench_agent_runtime/tool_registry.py",
+    "tests/unit/test_tool_registry.py",
+    "docs/task_packets/issue-48-tool-schema-registration.json"
+  ],
+  "read_only_paths": [
+    "services/agent_runtime/workbench_agent_runtime/tool_schemas.py",
+    "interfaces/**",
+    "libs/contracts/**"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "robot/control/**",
+    "services/world_model/**"
+  ],
+  "acceptance": [
+    "registration rejects missing and unknown schema keys",
+    "required_params and optional_params are disjoint string sets",
+    "every allowed parameter has exactly one explicitly supported type",
+    "target_id_required is a bool",
+    "invalid registration leaves the registry unchanged",
+    "every accepted schema can be validated without an internal exception",
+    "default six-tool registration passes"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_tool_registry.py -v",
+    "make test",
+    "make contract",
+    "make context-check"
+  ],
+  "evidence": [
+    "tool registry regression test output",
+    "full test output",
+    "contract and context check output"
+  ],
+  "stop_conditions": [
+    "interface or contract change is required",
+    "a write outside allowed_paths is required",
+    "a supported parameter type must be added"
+  ]
+}

--- a/services/agent_runtime/workbench_agent_runtime/tool_registry.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_registry.py
@@ -93,8 +93,11 @@ class ToolRegistry:
             raise ValueError(f"action_type must be an ActionType enum member, got {type(action_type).__name__!r}")
         if action_type in self._tool_param_schemas:
             raise ValueError(f"ActionType '{action_type.value}' is already registered")
-        _validate_schema(schema)
-        self._tool_param_schemas[action_type] = _freeze_mapping(schema)
+        if not isinstance(schema, Mapping):
+            raise ValueError(f"schema must be a mapping, got {type(schema).__name__!r}")
+        frozen_schema = _freeze_mapping(schema)
+        _validate_schema(frozen_schema)
+        self._tool_param_schemas[action_type] = frozen_schema
 
     def get(self, action_type: ActionType) -> Mapping[str, object]:
         """Return the schema for *action_type*.
@@ -334,6 +337,8 @@ def _validate_schema(schema: Mapping[str, object]) -> None:
         raise ValueError(f"schema must be a mapping, got {type(schema).__name__!r}")
 
     actual_keys = set(schema)
+    if any(not isinstance(key, str) for key in actual_keys):
+        raise ValueError("schema keys must be strings")
     missing_keys = _SCHEMA_KEYS - actual_keys
     unknown_keys = actual_keys - _SCHEMA_KEYS
     if missing_keys:
@@ -358,6 +363,8 @@ def _validate_schema(schema: Mapping[str, object]) -> None:
         raise ValueError("schema 'param_types' must be a mapping")
     allowed = required | optional
     declared = set(param_types)
+    if any(not isinstance(key, str) for key in declared):
+        raise ValueError("schema 'param_types' keys must be strings")
     missing_types = allowed - declared
     unknown_types = declared - allowed
     if missing_types:

--- a/services/agent_runtime/workbench_agent_runtime/tool_registry.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_registry.py
@@ -21,6 +21,10 @@ from . import tool_schemas as _schemas
 # ---------------------------------------------------------------------------
 
 _TARGET_REQUIRED_ACTIONS: frozenset[ActionType] = frozenset({ActionType.GRASP, ActionType.PLACE})
+_SCHEMA_KEYS: frozenset[str] = frozenset(
+    {"description", "target_id_required", "required_params", "optional_params", "param_types"}
+)
+_SUPPORTED_PARAM_TYPES: frozenset[type] = frozenset({str, int, float, bool, list})
 
 
 @dataclass(frozen=True)
@@ -89,6 +93,7 @@ class ToolRegistry:
             raise ValueError(f"action_type must be an ActionType enum member, got {type(action_type).__name__!r}")
         if action_type in self._tool_param_schemas:
             raise ValueError(f"ActionType '{action_type.value}' is already registered")
+        _validate_schema(schema)
         self._tool_param_schemas[action_type] = _freeze_mapping(schema)
 
     def get(self, action_type: ActionType) -> Mapping[str, object]:
@@ -321,6 +326,61 @@ class ToolRegistry:
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
+
+def _validate_schema(schema: Mapping[str, object]) -> None:
+    """Reject schemas that could make :meth:`ToolRegistry.validate` raise."""
+    if not isinstance(schema, Mapping):
+        raise ValueError(f"schema must be a mapping, got {type(schema).__name__!r}")
+
+    actual_keys = set(schema)
+    missing_keys = _SCHEMA_KEYS - actual_keys
+    unknown_keys = actual_keys - _SCHEMA_KEYS
+    if missing_keys:
+        raise ValueError(f"schema is missing keys: {sorted(missing_keys)}")
+    if unknown_keys:
+        raise ValueError(f"schema has unknown keys: {sorted(unknown_keys)}")
+
+    description = schema["description"]
+    if not isinstance(description, str):
+        raise ValueError("schema 'description' must be a string")
+    if not isinstance(schema["target_id_required"], bool):
+        raise ValueError("schema 'target_id_required' must be a bool")
+
+    required = _validate_param_set("required_params", schema["required_params"])
+    optional = _validate_param_set("optional_params", schema["optional_params"])
+    overlap = required & optional
+    if overlap:
+        raise ValueError(f"required_params and optional_params overlap: {sorted(overlap)}")
+
+    param_types = schema["param_types"]
+    if not isinstance(param_types, Mapping):
+        raise ValueError("schema 'param_types' must be a mapping")
+    allowed = required | optional
+    declared = set(param_types)
+    missing_types = allowed - declared
+    unknown_types = declared - allowed
+    if missing_types:
+        raise ValueError(f"param_types is missing allowed parameters: {sorted(missing_types)}")
+    if unknown_types:
+        raise ValueError(f"param_types contains unknown parameters: {sorted(unknown_types)}")
+    unsupported = {
+        name: value
+        for name, value in param_types.items()
+        if not any(value is supported_type for supported_type in _SUPPORTED_PARAM_TYPES)
+    }
+    if unsupported:
+        labels = {name: _type_name(value) for name, value in unsupported.items()}
+        raise ValueError(f"param_types contains unsupported types: {labels}")
+
+
+def _validate_param_set(name: str, value: object) -> frozenset[str]:
+    if not isinstance(value, set | frozenset):
+        raise ValueError(f"schema '{name}' must be a set or frozenset of strings")
+    non_strings = [item for item in value if not isinstance(item, str)]
+    if non_strings:
+        raise ValueError(f"schema '{name}' must contain only strings")
+    return frozenset(value)
 
 
 def _type_label(value: object) -> str:

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -108,6 +108,8 @@ class ToolRegistryRegistrationTests(unittest.TestCase):
 
     def test_register_defensively_copies_caller_schema(self) -> None:
         schema = {
+            "description": "Stop with a reason.",
+            "target_id_required": False,
             "required_params": {"reason"},
             "optional_params": set(),
             "param_types": {"reason": str},
@@ -119,6 +121,75 @@ class ToolRegistryRegistrationTests(unittest.TestCase):
 
         self.assertFalse(registry.validate(_action(ActionType.STOP)).is_valid)
         self.assertTrue(registry.validate(_action(ActionType.STOP, parameters={"reason": "operator"})).is_valid)
+
+    def test_register_rejects_empty_schema_without_mutating_registry(self) -> None:
+        registry = ToolRegistry(load_defaults=False)
+
+        with self.assertRaisesRegex(ValueError, "missing keys"):
+            registry.register(ActionType.STOP, {})
+
+        self.assertEqual(registry.list_all(), ())
+
+    def test_register_rejects_unknown_schema_key(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["unexpected"] = True
+
+        with self.assertRaisesRegex(ValueError, "unknown keys"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_register_rejects_overlapping_parameter_sets(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["required_params"] = {"reason"}
+
+        with self.assertRaisesRegex(ValueError, "overlap"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_register_rejects_non_string_parameter_names(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["optional_params"] = {"reason", 42}
+
+        with self.assertRaisesRegex(ValueError, "only strings"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_register_rejects_missing_parameter_type(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["param_types"] = {}
+
+        with self.assertRaisesRegex(ValueError, "missing allowed parameters"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_register_rejects_unsupported_parameter_type(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["param_types"] = {"reason": []}
+
+        with self.assertRaisesRegex(ValueError, "unsupported types"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_register_rejects_truthy_non_bool_target_requirement(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["target_id_required"] = 1
+
+        with self.assertRaisesRegex(ValueError, "must be a bool"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_rejected_schema_mutation_does_not_change_registry(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["param_types"] = {}
+        registry = ToolRegistry(load_defaults=False)
+
+        with self.assertRaises(ValueError):
+            registry.register(ActionType.STOP, schema)
+        schema["param_types"]["reason"] = str
+
+        self.assertEqual(registry.list_all(), ())
+
+    def test_every_accepted_schema_can_be_validated_without_raising(self) -> None:
+        registry = ToolRegistry(load_defaults=False)
+        registry.register(ActionType.STOP, TOOL_SCHEMAS[ActionType.STOP])
+
+        result = registry.validate(_action(ActionType.STOP, parameters={"reason": object()}))
+
+        self.assertFalse(result.is_valid)
 
     def test_get_rejects_non_action_type(self) -> None:
         with self.assertRaises(ValueError):

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -45,6 +45,27 @@ def _action(
     )
 
 
+class _ChangingSchema(Mapping):
+    def __init__(self) -> None:
+        valid = dict(TOOL_SCHEMAS[ActionType.STOP])
+        changed = dict(valid)
+        changed["optional_params"] = frozenset({"reason", "untyped"})
+        self._versions = (valid, changed)
+        self._current = valid
+        self._iterations = 0
+
+    def __getitem__(self, key: object) -> object:
+        return self._current[key]
+
+    def __iter__(self):
+        self._current = self._versions[min(self._iterations, 1)]
+        self._iterations += 1
+        return iter(self._current)
+
+    def __len__(self) -> int:
+        return len(self._current)
+
+
 # ---------------------------------------------------------------------------
 # tests
 # ---------------------------------------------------------------------------
@@ -182,6 +203,19 @@ class ToolRegistryRegistrationTests(unittest.TestCase):
         schema["param_types"]["reason"] = str
 
         self.assertEqual(registry.list_all(), ())
+
+    def test_register_validates_the_same_snapshot_it_stores(self) -> None:
+        registry = ToolRegistry(load_defaults=False)
+        registry.register(ActionType.STOP, _ChangingSchema())
+
+        self.assertFalse(registry.validate(_action(ActionType.STOP, parameters={"untyped": object()})).is_valid)
+
+    def test_register_rejects_non_string_schema_keys(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema.update({1: object(), "unexpected": object()})
+
+        with self.assertRaisesRegex(ValueError, "keys must be strings"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
 
     def test_every_accepted_schema_can_be_validated_without_raising(self) -> None:
         registry = ToolRegistry(load_defaults=False)


### PR DESCRIPTION
## Related Issue

Closes #48.

## What changed

- Validates tool schemas before registration and leaves registry state unchanged on rejection.
- Freezes one detached schema snapshot, then validates and stores that same snapshot, eliminating mutation/TOCTOU gaps.
- Requires exact top-level keys, disjoint string parameter sets, one supported type per parameter, and a real boolean `target_id_required`.
- Rejects heterogeneous or non-string unknown keys with stable `ValueError` diagnostics.
- Keeps all six built-in tool schemas compatible.
- Adds malformed, caller-mutation, and changing-`Mapping` regression tests plus the Issue #48 Task Packet.

## Verification

```text
python -m pytest tests/unit/test_tool_registry.py -q
# 53 passed
```

All seven GitHub checks pass at final head `d4f5035`, including foundation, container, MCU QEMU, kernel module, dependency review, and CodeQL.

## Scope

No files under `interfaces/`, `libs/contracts/`, robot control, or firmware changed. Malformed custom schemas now fail at registration instead of leaking internal exceptions or failing open during validation.

## Rollback

Revert this PR.
