### PR TITLE
fix(agent): keep TaskGraph step IDs unique

### DIFF
--- a/docs/task_packets/agent-unique-step-ids.json
+++ b/docs/task_packets/agent-unique-step-ids.json
@@ -1,0 +1,44 @@
+{
+  "issue": 188,
+  "human_owner": "Quchaosheng",
+  "objective": "Keep generated kitting and inspection TaskGraph step IDs unique after readable entity-ID normalization.",
+  "allowed_paths": [
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "tests/unit/test_agent_runtime.py",
+    "docs/task_packets/agent-unique-step-ids.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "robot/control/**",
+    "services/world_model/**",
+    "services/backend/**"
+  ],
+  "acceptance": [
+    "distinct accepted entity IDs always produce unique step IDs",
+    "normalization collisions receive deterministic readable suffixes",
+    "dependencies reference the generated step IDs",
+    "ordinary existing entity IDs retain their current step IDs"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_agent_runtime.py -v",
+    "python -m ruff check services/agent_runtime/workbench_agent_runtime/planner.py tests/unit/test_agent_runtime.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/agent-unique-step-ids.json",
+    "make contract",
+    "make context-check"
+  ],
+  "evidence": [
+    "focused collision regression output",
+    "Agent Runtime unit-test output",
+    "Task Packet boundary validation",
+    "contract and context validation output"
+  ],
+  "stop_conditions": [
+    "an interface or canonical contract change is required",
+    "a write outside allowed_paths is required",
+    "generated plans no longer pass the existing tool registry"
+  ]
+}

--- a/services/agent_runtime/workbench_agent_runtime/planner.py
+++ b/services/agent_runtime/workbench_agent_runtime/planner.py
@@ -170,10 +170,11 @@ def build_kitting_plan(
 ) -> TaskGraph:
     part_ids = _validate_entity_ids(part_ids, "kitting")
     tray_id = _validate_identifier(tray_id, "tray_id")
+    step_tokens = _unique_step_tokens(part_ids)
     steps: list[TaskStep] = []
     action_index = 1
     for part_id in part_ids:
-        suffix = part_id.replace("_", "-")
+        suffix = step_tokens[part_id]
         observe_step = f"observe-{suffix}"
         grasp_step = f"grasp-{suffix}"
         steps.extend(
@@ -217,9 +218,10 @@ def build_inspection_plan(
     entity_ids: Sequence[str] = DEFAULT_INSPECTION_ENTITIES,
 ) -> TaskGraph:
     entity_ids = _validate_entity_ids(entity_ids, "inspection")
+    step_tokens = _unique_step_tokens(entity_ids)
     steps = [
         TaskStep(
-            step_id=f"inspect-{entity_id.replace('_', '-')}",
+            step_id=f"inspect-{step_tokens[entity_id]}",
             action=SemanticAction(
                 action_id=f"act-{index:03d}",
                 action_type=ActionType.OBSERVE,

--- a/services/agent_runtime/workbench_agent_runtime/planner.py
+++ b/services/agent_runtime/workbench_agent_runtime/planner.py
@@ -66,16 +66,21 @@ def _validate_entity_ids(values: Sequence[str], label: str) -> tuple[str, ...]:
     return normalized
 
 
-def _unique_step_tokens(entity_ids: Sequence[str]) -> dict[str, str]:
+def _unique_step_tokens(entity_ids: Sequence[str], *, preserve_legacy_tokens: bool = False) -> dict[str, str]:
     """Create readable, deterministic tokens without collapsing distinct IDs."""
     tokens: dict[str, str] = {}
     used: set[str] = set()
     for index, entity_id in enumerate(entity_ids, start=1):
-        base = re.sub(r"[^a-z0-9]+", "-", entity_id.lower()).strip("-") or f"entity-{index}"
+        base = (
+            entity_id.replace("_", "-")
+            if preserve_legacy_tokens
+            else re.sub(r"[^a-z0-9]+", "-", entity_id.lower()).strip("-")
+        ) or f"entity-{index}"
         token = base
         suffix = 2
         while token in used:
-            token = f"{base}-{suffix}"
+            collision_base = re.sub(r"[^a-z0-9]+", "-", entity_id.lower()).strip("-") or f"entity-{index}"
+            token = f"{collision_base}-{suffix}"
             suffix += 1
         tokens[entity_id] = token
         used.add(token)
@@ -170,7 +175,7 @@ def build_kitting_plan(
 ) -> TaskGraph:
     part_ids = _validate_entity_ids(part_ids, "kitting")
     tray_id = _validate_identifier(tray_id, "tray_id")
-    step_tokens = _unique_step_tokens(part_ids)
+    step_tokens = _unique_step_tokens(part_ids, preserve_legacy_tokens=True)
     steps: list[TaskStep] = []
     action_index = 1
     for part_id in part_ids:
@@ -218,7 +223,7 @@ def build_inspection_plan(
     entity_ids: Sequence[str] = DEFAULT_INSPECTION_ENTITIES,
 ) -> TaskGraph:
     entity_ids = _validate_entity_ids(entity_ids, "inspection")
-    step_tokens = _unique_step_tokens(entity_ids)
+    step_tokens = _unique_step_tokens(entity_ids, preserve_legacy_tokens=True)
     steps = [
         TaskStep(
             step_id=f"inspect-{step_tokens[entity_id]}",

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -79,6 +79,15 @@ class PlannerTests(unittest.TestCase):
                 self.assertEqual(len(step_ids), len(set(step_ids)))
                 self.assertTrue(all(dependency in step_ids for step in first.steps for dependency in step.depends_on))
 
+    def test_kitting_and_inspection_preserve_ordinary_step_tokens(self) -> None:
+        for builder, expected in (
+            (build_kitting_plan, ("observe-BoxA", "grasp-BoxA", "place-BoxA")),
+            (build_inspection_plan, ("inspect-box.a",)),
+        ):
+            with self.subTest(builder=builder.__name__):
+                plan = builder("Preserve ordinary entity IDs", ["BoxA"] if builder is build_kitting_plan else ["box.a"])
+                self.assertEqual(tuple(step.step_id for step in plan.steps), expected)
+
     def test_parcel_plan_requires_inspection_before_bounded_routing(self) -> None:
         plan = build_parcel_sorting_plan("核对快递标签并分拣")
         self.assertEqual(plan.task_id, "task-sort-parcels")

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -7,6 +7,7 @@ sys.path[:0] = [str(ROOT / "libs/contracts"), str(ROOT / "services/agent_runtime
 
 from local_runner import plan_offline
 from workbench_agent_runtime import (
+    build_inspection_plan,
     build_kitting_plan,
     build_parcel_sorting_plan,
     build_policy_routed_parcel_plan,
@@ -67,6 +68,16 @@ class PlannerTests(unittest.TestCase):
         for routes in invalid_routes:
             with self.subTest(parcel_routes=routes), self.assertRaises(ValueError):
                 build_parcel_sorting_plan("Sort the parcels", routes)
+
+    def test_kitting_and_inspection_step_ids_survive_normalization_collisions(self) -> None:
+        for builder in (build_kitting_plan, build_inspection_plan):
+            with self.subTest(builder=builder.__name__):
+                first = builder("Handle colliding entity IDs", ["box_a", "box-a"])
+                second = builder("Handle colliding entity IDs", ["box_a", "box-a"])
+                step_ids = [step.step_id for step in first.steps]
+                self.assertEqual(step_ids, [step.step_id for step in second.steps])
+                self.assertEqual(len(step_ids), len(set(step_ids)))
+                self.assertTrue(all(dependency in step_ids for step in first.steps for dependency in step.depends_on))
 
     def test_parcel_plan_requires_inspection_before_bounded_routing(self) -> None:
         plan = build_parcel_sorting_plan("核对快递标签并分拣")


### PR DESCRIPTION
## Summary

- reuse the planner's deterministic collision-safe step-token helper for kitting and inspection graphs
- preserve existing readable IDs while suffixing normalization collisions
- add regression coverage for deterministic unique IDs and valid dependencies
- add Task Packet for #188

Closes #188

## Verification

- `.venv/bin/python -m pytest tests/unit/test_agent_runtime.py -q`
- `.venv/bin/python -m ruff check services/agent_runtime/workbench_agent_runtime/planner.py tests/unit/test_agent_runtime.py`
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/agent-unique-step-ids.json`
- `.venv/bin/python tools/scripts/check_context.py`
- `.venv/bin/python tools/scripts/validate_contracts.py`
