### PR TITLE
security(agent): bypass ambient proxies for local model

### DIFF
--- a/docs/task_packets/security-agent-local-model-no-proxy.json
+++ b/docs/task_packets/security-agent-local-model-no-proxy.json
@@ -1,0 +1,55 @@
+{
+  "issue": 189,
+  "human_owner": "Quchaosheng",
+  "objective": "Keep approved local-model HTTP requests direct by ignoring all process environment proxy configuration.",
+  "allowed_paths": [
+    "services/agent_runtime/workbench_agent_runtime/local_model.py",
+    "tests/unit/test_local_model.py",
+    "docs/task_packets/security-agent-local-model-no-proxy.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "services/agent_runtime/workbench_agent_runtime/__init__.py",
+    "tools/scripts/check_task_packet.py",
+    "tools/schemas/task-packet-v1.schema.json"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "robot/control/**",
+    "firmware/**",
+    "services/world_model/**",
+    "services/backend/**"
+  ],
+  "acceptance": [
+    "Ollama HTTP calls ignore uppercase and lowercase environment proxy variables",
+    "a direct loopback response succeeds with no NO_PROXY exemption while an unreachable proxy is configured",
+    "endpoint validation redirect behavior response parsing and last_call semantics remain unchanged",
+    "the fix uses only the Python standard library and adds no dependency",
+    "the regression test makes no public network request"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_local_model.py -v",
+    "python -m ruff check services/agent_runtime/workbench_agent_runtime/local_model.py tests/unit/test_local_model.py",
+    "python -m ruff format --check services/agent_runtime/workbench_agent_runtime/local_model.py tests/unit/test_local_model.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/security-agent-local-model-no-proxy.json",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "focused local-model unit test output",
+    "Ruff check and format output",
+    "Task Packet validation output",
+    "required repository check outputs",
+    "GitHub Actions results"
+  ],
+  "stop_conditions": [
+    "redirect behavior or response-body policy would need to change",
+    "an interface contract would need to change",
+    "robot control firmware hardware safety or physical validation paths require modification",
+    "the direct connection cannot preserve the existing approved-host policy"
+  ]
+}

--- a/services/agent_runtime/workbench_agent_runtime/local_model.py
+++ b/services/agent_runtime/workbench_agent_runtime/local_model.py
@@ -133,6 +133,7 @@ class OllamaModelProvider:
         self.model = model.strip()
         self.endpoint = validate_local_endpoint(endpoint, allowed_hosts)
         self.timeout_s = timeout_s
+        self._opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
         self.last_call: dict[str, object] = {}
 
     def route(self, goal: str) -> RouteDecision:
@@ -156,7 +157,7 @@ class OllamaModelProvider:
         )
         started = time.perf_counter()
         try:
-            with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
+            with self._opener.open(request, timeout=self.timeout_s) as response:
                 payload = json.loads(response.read())
         except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
             raise LocalModelError(f"local model request failed: {exc}") from exc

--- a/tests/unit/test_local_model.py
+++ b/tests/unit/test_local_model.py
@@ -1,8 +1,11 @@
 import json
+import os
+import socket
 import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import ClassVar
+from unittest.mock import patch
 
 from workbench_agent_runtime import (
     LocalModelError,
@@ -75,6 +78,22 @@ class LocalModelTests(unittest.TestCase):
         self.assertEqual(FakeOllamaHandler.request_payload["format"]["additionalProperties"], False)
         self.assertEqual(provider.last_call["endpoint_host"], "127.0.0.1")
         self.assertIsInstance(provider.last_call["latency_ms"], float)
+
+    def test_model_request_ignores_environment_proxies(self) -> None:
+        with socket.socket() as blocked_proxy:
+            blocked_proxy.bind(("127.0.0.1", 0))
+            proxy = f"http://127.0.0.1:{blocked_proxy.getsockname()[1]}"
+            proxies = {
+                name: proxy
+                for name in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy")
+            }
+            proxies.update({"NO_PROXY": "", "no_proxy": ""})
+            with patch.dict(os.environ, proxies, clear=True):
+                provider = OllamaModelProvider("test-model", endpoint=self.endpoint)
+                decision = provider.route("Handle everything waiting in the intake zone")
+
+        self.assertEqual(decision.task_family, "parcel_sorting")
+        self.assertEqual(provider.last_call["endpoint_host"], "127.0.0.1")
 
     def test_unsafe_route_fails_closed_before_building_actions(self) -> None:
         FakeOllamaHandler.route = {


### PR DESCRIPTION
## Summary

- disable ambient `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` handling for Ollama requests with a standard-library direct opener;
- preserve the existing endpoint validation, default redirect handler, response parsing, and telemetry behavior;
- add a deterministic regression test and bounded Task Packet.

Closes #189

## Verification

- `python -m pytest tests/unit/test_local_model.py -v` — 6 passed (3 subtests)
- `python -m ruff check services/agent_runtime/workbench_agent_runtime/local_model.py tests/unit/test_local_model.py` — passed
- `python -m ruff format --check services/agent_runtime/workbench_agent_runtime/local_model.py tests/unit/test_local_model.py` — passed
- `python tools/scripts/check_task_packet.py docs/task_packets/security-agent-local-model-no-proxy.json --base origin/main` — passed
- `make check PYTHON=.venv/bin/python` — passed (447 tests, contract/scenario/golden/context checks and both demos)
