### PR TITLE
fix(evaluation): enforce every published release threshold

### DIFF
--- a/docs/task_packets/evaluation-release-thresholds.json
+++ b/docs/task_packets/evaluation-release-thresholds.json
@@ -1,0 +1,46 @@
+{
+  "issue": 192,
+  "human_owner": "Quchaosheng",
+  "objective": "Make every published evaluation threshold participate in the Go/No-Go release decision.",
+  "allowed_paths": [
+    "tools/scripts/generate_report.py",
+    "tests/unit/test_evaluation_tools.py",
+    "docs/task_packets/evaluation-release-thresholds.json"
+  ],
+  "read_only_paths": [
+    "tools/scripts/collect_metrics.py",
+    "interfaces/**",
+    "libs/contracts/**"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "robot/control/**",
+    "services/world_model/**",
+    "services/agent_runtime/**"
+  ],
+  "acceptance": [
+    "recovery rate below 70 percent prevents GO",
+    "state hash consistency below 100 percent prevents GO",
+    "replay success below 95 percent prevents GO",
+    "mean observed entities below two prevents GO",
+    "missing evidence for any published threshold prevents GO",
+    "exact boundary values pass"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_evaluation_tools.py -v",
+    "python -m ruff check tools/scripts/generate_report.py tests/unit/test_evaluation_tools.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/evaluation-release-thresholds.json",
+    "make context-check"
+  ],
+  "evidence": [
+    "focused release-threshold regression output",
+    "evaluation unit-test output",
+    "Task Packet boundary validation",
+    "context validation output"
+  ],
+  "stop_conditions": [
+    "metric collection semantics must change",
+    "an interface or canonical contract change is required",
+    "a write outside allowed_paths is required"
+  ]
+}

--- a/docs/task_packets/evaluation-release-thresholds.json
+++ b/docs/task_packets/evaluation-release-thresholds.json
@@ -24,6 +24,7 @@
     "replay success below 95 percent prevents GO",
     "mean observed entities below two prevents GO",
     "missing evidence for any published threshold prevents GO",
+    "non-finite or non-numeric published metrics prevent GO",
     "exact boundary values pass"
   ],
   "commands": [

--- a/tests/unit/test_evaluation_tools.py
+++ b/tests/unit/test_evaluation_tools.py
@@ -267,13 +267,30 @@ class EvaluationPipelineTests(unittest.TestCase):
             "vtcr": 0.8,
             "task_duration_p95_s": 119,
             "evidence_coverage": 1.0,
+            "recovery_rate": 0.7,
+            "state_hash_consistency": 1.0,
+            "replay_success_rate": 0.95,
             "task_family_count": 4,
             "complex_task_rate": 0.5,
+            "mean_observed_entities": 2.0,
             "goal_condition_coverage": 1.0,
         }
         self.assertIn("评测任务族少于 5 类", release_reasons(metrics))
         metrics["task_family_count"] = 5
         self.assertEqual(release_reasons(metrics), [])
+
+        published_thresholds = {
+            "recovery_rate": (0.0, "恢复率缺失或低于 70%"),
+            "state_hash_consistency": (0.0, "state hash 一致性不是 100%"),
+            "replay_success_rate": (0.0, "回放成功率缺失或低于 95%"),
+            "mean_observed_entities": (0.0, "平均观测实体数缺失或低于 2"),
+        }
+        for metric, (failed_value, expected_reason) in published_thresholds.items():
+            with self.subTest(metric=metric):
+                candidate = {**metrics, metric: failed_value}
+                self.assertIn(expected_reason, release_reasons(candidate))
+                candidate.pop(metric)
+                self.assertIn(expected_reason, release_reasons(candidate))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_evaluation_tools.py
+++ b/tests/unit/test_evaluation_tools.py
@@ -292,6 +292,24 @@ class EvaluationPipelineTests(unittest.TestCase):
                 candidate.pop(metric)
                 self.assertIn(expected_reason, release_reasons(candidate))
 
+        all_numeric_thresholds = {
+            "vtcr": "VTCR 低于 80%",
+            "task_duration_p95_s": "任务 P95 缺失或未低于 120 秒",
+            "evidence_coverage": "验证证据覆盖率不是 100%",
+            "recovery_rate": "恢复率缺失或低于 70%",
+            "state_hash_consistency": "state hash 一致性不是 100%",
+            "replay_success_rate": "回放成功率缺失或低于 95%",
+            "task_family_count": "评测任务族少于 5 类",
+            "complex_task_rate": "复杂任务占比低于 50%",
+            "mean_observed_entities": "平均观测实体数缺失或低于 2",
+            "goal_condition_coverage": "目标条件覆盖率不是 100%",
+        }
+        for metric, expected_reason in all_numeric_thresholds.items():
+            for invalid_value in (float("nan"), float("inf"), "not-a-number", True):
+                with self.subTest(metric=metric, invalid_value=invalid_value):
+                    candidate = {**metrics, metric: invalid_value}
+                    self.assertIn(expected_reason, release_reasons(candidate))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/scripts/generate_report.py
+++ b/tools/scripts/generate_report.py
@@ -52,10 +52,18 @@ def release_reasons(metrics: dict[str, Any]) -> list[str]:
         reasons.append("任务 P95 缺失或未低于 120 秒")
     if metrics.get("evidence_coverage") != 1.0:
         reasons.append("验证证据覆盖率不是 100%")
+    if metrics.get("recovery_rate") is None or metrics["recovery_rate"] < 0.7:
+        reasons.append("恢复率缺失或低于 70%")
+    if metrics.get("state_hash_consistency") != 1.0:
+        reasons.append("state hash 一致性不是 100%")
+    if metrics.get("replay_success_rate") is None or metrics["replay_success_rate"] < 0.95:
+        reasons.append("回放成功率缺失或低于 95%")
     if metrics.get("task_family_count", 0) < 5:
         reasons.append("评测任务族少于 5 类")
     if metrics.get("complex_task_rate", 0.0) < 0.5:
         reasons.append("复杂任务占比低于 50%")
+    if metrics.get("mean_observed_entities") is None or metrics["mean_observed_entities"] < 2:
+        reasons.append("平均观测实体数缺失或低于 2")
     if metrics.get("goal_condition_coverage") != 1.0:
         reasons.append("目标条件覆盖率不是 100%")
     return reasons

--- a/tools/scripts/generate_report.py
+++ b/tools/scripts/generate_report.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import math
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,15 @@ def gate(mark: bool | None) -> str:
     return "通过" if mark else "未通过"
 
 
+def _finite_metric(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    try:
+        return float(value) if math.isfinite(value) else None
+    except OverflowError:
+        return None
+
+
 def release_reasons(metrics: dict[str, Any]) -> list[str]:
     reasons = []
     if not metrics.get("release_eligible"):
@@ -46,25 +56,35 @@ def release_reasons(metrics: dict[str, Any]) -> list[str]:
         reasons.append("碰撞不是 0")
     if metrics.get("policy_violation_count") != 0:
         reasons.append("模型越权不是 0")
-    if metrics.get("vtcr", 0.0) < 0.8:
+    vtcr = _finite_metric(metrics.get("vtcr"))
+    if vtcr is None or vtcr < 0.8:
         reasons.append("VTCR 低于 80%")
-    if metrics.get("task_duration_p95_s") is None or metrics["task_duration_p95_s"] >= 120:
+    task_duration_p95_s = _finite_metric(metrics.get("task_duration_p95_s"))
+    if task_duration_p95_s is None or task_duration_p95_s >= 120:
         reasons.append("任务 P95 缺失或未低于 120 秒")
-    if metrics.get("evidence_coverage") != 1.0:
+    evidence_coverage = _finite_metric(metrics.get("evidence_coverage"))
+    if evidence_coverage != 1.0:
         reasons.append("验证证据覆盖率不是 100%")
-    if metrics.get("recovery_rate") is None or metrics["recovery_rate"] < 0.7:
+    recovery_rate = _finite_metric(metrics.get("recovery_rate"))
+    if recovery_rate is None or recovery_rate < 0.7:
         reasons.append("恢复率缺失或低于 70%")
-    if metrics.get("state_hash_consistency") != 1.0:
+    state_hash_consistency = _finite_metric(metrics.get("state_hash_consistency"))
+    if state_hash_consistency != 1.0:
         reasons.append("state hash 一致性不是 100%")
-    if metrics.get("replay_success_rate") is None or metrics["replay_success_rate"] < 0.95:
+    replay_success_rate = _finite_metric(metrics.get("replay_success_rate"))
+    if replay_success_rate is None or replay_success_rate < 0.95:
         reasons.append("回放成功率缺失或低于 95%")
-    if metrics.get("task_family_count", 0) < 5:
+    task_family_count = _finite_metric(metrics.get("task_family_count"))
+    if task_family_count is None or task_family_count < 5:
         reasons.append("评测任务族少于 5 类")
-    if metrics.get("complex_task_rate", 0.0) < 0.5:
+    complex_task_rate = _finite_metric(metrics.get("complex_task_rate"))
+    if complex_task_rate is None or complex_task_rate < 0.5:
         reasons.append("复杂任务占比低于 50%")
-    if metrics.get("mean_observed_entities") is None or metrics["mean_observed_entities"] < 2:
+    mean_observed_entities = _finite_metric(metrics.get("mean_observed_entities"))
+    if mean_observed_entities is None or mean_observed_entities < 2:
         reasons.append("平均观测实体数缺失或低于 2")
-    if metrics.get("goal_condition_coverage") != 1.0:
+    goal_condition_coverage = _finite_metric(metrics.get("goal_condition_coverage"))
+    if goal_condition_coverage != 1.0:
         reasons.append("目标条件覆盖率不是 100%")
     return reasons
 


### PR DESCRIPTION
## Summary

- enforce recovery rate, state-hash consistency, replay success, and mean-observed-entity thresholds
- fail closed when any published metric is missing
- cover exact boundary values and both zero/missing failures
- keep metric collection semantics unchanged

Closes #192

## Verification

- `.venv/bin/python -m pytest tests/unit/test_evaluation_tools.py -q`
- `.venv/bin/python -m ruff check tools/scripts/generate_report.py tests/unit/test_evaluation_tools.py`
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/evaluation-release-thresholds.json`
- `.venv/bin/python tools/scripts/check_context.py`
