### PR TITLE
fix(backend): serve OpenAPI contract from installed package

### DIFF
--- a/docs/task_packets/api-read-only-contract.json
+++ b/docs/task_packets/api-read-only-contract.json
@@ -1,9 +1,10 @@
 {
   "issue": 80,
   "human_owner": "Quchaosheng",
-  "objective": "Publish and test a versioned read-only Dashboard API contract for local and split-host clients.",
+  "objective": "Publish and test a versioned read-only Dashboard API contract for source-tree, installed, and split-host clients.",
   "allowed_paths": [
     "services/backend/**",
+    "pyproject.toml",
     "tests/unit/test_dashboard_backend.py",
     "tests/unit/test_multi_host.py",
     "docs/api.md",
@@ -15,14 +16,16 @@
   "forbidden": ["interfaces/**", "robot/control/**", "firmware/**"],
   "acceptance": [
     "checked-in OpenAPI v1 lists methods, statuses, limits, and read-only policy",
+    "the OpenAPI v1 contract is package data and remains available from an isolated wheel install",
     "local and remote clients use the same versioned paths and validate the same response shape",
     "malformed identifiers, missing runs, malformed sources, and oversized responses fail closed",
     "legacy /api aliases remain additive and no write endpoint is introduced"
   ],
   "commands": [
     "python3 -m pytest tests/unit/test_dashboard_backend.py tests/unit/test_multi_host.py -q",
+    "python3 -m pip wheel . --no-deps --wheel-dir dist",
     "python3 -m mkdocs build --strict"
   ],
-  "evidence": ["OpenAPI fixture assertions", "local/remote HTTP test output", "strict docs build"],
+  "evidence": ["OpenAPI fixture and package-data assertions", "isolated wheel HTTP output", "strict docs build"],
   "stop_conditions": ["schema changes are required", "a write/control operation is requested"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ workbench_contracts = "libs/contracts/workbench_contracts"
 workbench_virtual_mcu = "firmware/virtual_mcu/workbench_virtual_mcu"
 workbench_world_model = "services/world_model/workbench_world_model"
 
+[tool.setuptools.package-data]
+workbench_backend = ["api-openapi-v1.json"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests", "libs/kernel/tests"]
 python_files = ["test_*.py"]

--- a/services/backend/workbench_backend/api-openapi-v1.json
+++ b/services/backend/workbench_backend/api-openapi-v1.json
@@ -1,0 +1,154 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Workbench Desk Robot read-only API",
+    "version": "1.0.0",
+    "description": "Read-only run, event, readiness, and expression projections. No endpoint grants robot or ROS control authority."
+  },
+  "servers": [{"url": "/"}],
+  "paths": {
+    "/healthz": {
+      "get": {
+        "operationId": "health",
+        "responses": {"200": {"description": "Process is responding.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Health"}}}}}
+      }
+    },
+    "/readyz": {
+      "get": {
+        "operationId": "readiness",
+        "responses": {
+          "200": {"description": "Event source is readable.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Readiness"}}}},
+          "503": {"description": "Event source is unavailable or malformed.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/openapi.json": {
+      "get": {"operationId": "apiContract", "responses": {"200": {"description": "This contract.", "content": {"application/json": {"schema": {"type": "object"}}}}}}
+    },
+    "/api/v1/runs": {
+      "get": {
+        "operationId": "listRuns",
+        "responses": {
+          "200": {"description": "Ordered run summaries.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/RunList"}}}},
+          "503": {"description": "Invalid source.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/runs/{run_id}": {
+      "get": {
+        "operationId": "getRun",
+        "parameters": [{"$ref": "#/components/parameters/RunId"}],
+        "responses": {
+          "200": {"description": "Run summary.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/RunDetail"}}}},
+          "400": {"description": "Identifier is empty or outside the allowed character set.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "404": {"description": "Run does not exist.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "413": {"description": "Response exceeds 4 MiB.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/runs/{run_id}/events": {
+      "get": {
+        "operationId": "getRunEvents",
+        "parameters": [{"$ref": "#/components/parameters/RunId"}],
+        "responses": {
+          "200": {"description": "Run summary and contiguous events.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/RunEvents"}}}},
+          "400": {"description": "Invalid run identifier.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "404": {"description": "Run does not exist.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "413": {"description": "Response exceeds 4 MiB.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}},
+          "503": {"description": "Event source is unavailable or malformed.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/v1/expression-states": {
+      "get": {"operationId": "expressionContract", "responses": {"200": {"description": "Expression states and transitions.", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExpressionContract"}}}}}}
+    }
+  },
+  "components": {
+    "parameters": {
+      "RunId": {
+        "name": "run_id",
+        "in": "path",
+        "required": true,
+        "description": "1-128 ASCII letters, digits, dot, underscore, colon, or hyphen.",
+        "schema": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"}
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {"error": {"type": "string"}, "message": {"type": "string"}, "run_id": {"type": "string"}}
+      },
+      "Health": {
+        "type": "object",
+        "required": ["status", "service", "version"],
+        "properties": {"status": {"const": "ok"}, "service": {"type": "string"}, "version": {"type": "string"}}
+      },
+      "Readiness": {
+        "type": "object",
+        "required": ["status", "data_source"],
+        "properties": {"status": {"enum": ["ready", "not_ready"]}, "data_source": {"type": "string"}}
+      },
+      "Event": {
+        "type": "object",
+        "required": ["event_id", "run_id", "sequence_no", "event_type", "occurred_at", "payload"],
+        "properties": {
+          "event_id": {"type": "string", "minLength": 1},
+          "run_id": {"type": "string", "minLength": 1},
+          "sequence_no": {"type": "integer", "minimum": 0},
+          "event_type": {"type": "string", "minLength": 1},
+          "occurred_at": {"type": "string", "minLength": 1},
+          "payload": {"type": "object"},
+          "evidence_refs": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "RunSummary": {
+        "type": "object",
+        "required": ["run_id", "status", "expression", "event_count", "visible_event_count", "safety"],
+        "properties": {
+          "run_id": {"type": "string"},
+          "status": {"type": "string"},
+          "expression": {"enum": ["idle", "thinking", "uncertain", "pleased"]},
+          "event_count": {"type": "integer", "minimum": 1},
+          "visible_event_count": {"type": "integer", "minimum": 1},
+          "evidence_refs": {"type": "array", "items": {"type": "string"}},
+          "safety": {"type": "object", "required": ["hardware_estop", "software_control"]}
+        },
+        "additionalProperties": true
+      },
+      "RunList": {
+        "type": "object",
+        "required": ["runs", "read_only"],
+        "properties": {"runs": {"type": "array", "items": {"$ref": "#/components/schemas/RunSummary"}}, "read_only": {"const": true}}
+      },
+      "RunDetail": {
+        "type": "object",
+        "required": ["run"],
+        "properties": {"run": {"$ref": "#/components/schemas/RunSummary"}}
+      },
+      "RunEvents": {
+        "type": "object",
+        "required": ["run", "events"],
+        "properties": {
+          "run": {"$ref": "#/components/schemas/RunSummary"},
+          "events": {"type": "array", "minItems": 1, "maxItems": 10000, "items": {"$ref": "#/components/schemas/Event"}}
+        }
+      },
+      "ExpressionContract": {
+        "type": "object",
+        "required": ["states", "transitions"],
+        "properties": {
+          "states": {"type": "array", "items": {"enum": ["idle", "thinking", "uncertain", "pleased"]}},
+          "transitions": {"type": "object"}
+        }
+      }
+    }
+  },
+  "x-compatibility": {
+    "current": "/api/v1",
+    "legacy_alias": "/api",
+    "policy": "v1 is additive and read-only; aliases remain until a documented v2 migration."
+  },
+  "x-limits": {"max_response_bytes": 4194304, "max_event_log_bytes": 10485760, "max_events_per_run": 10000},
+  "x-headers": {"content_type": "application/json; charset=utf-8", "api_version": "X-API-Version"}
+}

--- a/services/backend/workbench_backend/server.py
+++ b/services/backend/workbench_backend/server.py
@@ -5,6 +5,7 @@ import os
 import re
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib import resources
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
@@ -20,7 +21,7 @@ SOURCE_ROOT = Path(__file__).resolve().parents[3]
 ROOT = Path.cwd() if (Path.cwd() / "apps" / "dashboard").is_dir() else SOURCE_ROOT
 DEFAULT_STATIC_DIR = ROOT / "apps" / "dashboard"
 DEFAULT_DATA_DIR = DEFAULT_STATIC_DIR / "data"
-OPENAPI_PATH = SOURCE_ROOT / "docs" / "api-openapi-v1.json"
+OPENAPI_RESOURCE = resources.files("workbench_backend").joinpath("api-openapi-v1.json")
 API_VERSION = "1"
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -141,7 +142,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
             return
         if route in {"/api/openapi.json", "/api/v1/openapi.json"}:
             try:
-                contract = json.loads(OPENAPI_PATH.read_text(encoding="utf-8"))
+                contract = json.loads(OPENAPI_RESOURCE.read_text(encoding="utf-8"))
             except (OSError, UnicodeError, json.JSONDecodeError):
                 self._send_json(
                     {"error": "contract_unavailable"}, HTTPStatus.SERVICE_UNAVAILABLE, api_version=api_version

--- a/tests/unit/test_dashboard_backend.py
+++ b/tests/unit/test_dashboard_backend.py
@@ -3,6 +3,7 @@ import json
 import sys
 import tempfile
 import threading
+import tomllib
 import unittest
 import urllib.error
 import urllib.request
@@ -14,7 +15,7 @@ sys.path.insert(0, str(ROOT / "services" / "backend"))
 from workbench_backend.expression import ExpressionMachine, ExpressionState, derive_expression
 from workbench_backend.logging import StructuredLogger
 from workbench_backend.read_model import DashboardReadModel, ReadModelError
-from workbench_backend.server import create_server
+from workbench_backend.server import OPENAPI_RESOURCE, create_server
 
 
 def stored_event(run_id: object, sequence_no: object, event_type: object) -> dict:
@@ -296,6 +297,13 @@ class DashboardApiTests(unittest.TestCase):
         self.assertEqual(missing.exception.code, 404)
         with urllib.request.urlopen(f"{self.base_url}/api/v1/runs", timeout=2) as response:
             self.assertEqual(response.headers["X-API-Version"], "1")
+
+    def test_openapi_contract_is_packaged_and_matches_checked_in_docs(self) -> None:
+        packaged = json.loads(OPENAPI_RESOURCE.read_text(encoding="utf-8"))
+        checked_in = json.loads((ROOT / "docs" / "api-openapi-v1.json").read_text(encoding="utf-8"))
+        project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        self.assertEqual(packaged, checked_in)
+        self.assertIn("api-openapi-v1.json", project["tool"]["setuptools"]["package-data"]["workbench_backend"])
 
     def test_oversized_api_response_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- package the read-only OpenAPI v1 contract with `workbench_backend`
- load it through `importlib.resources` so source and wheel installs behave the same
- add package-data/contract drift regression coverage and update the #80 Task Packet

## Evidence
- focused backend + multi-host tests: 19 passed
- full isolated repository suite: 447 passed
- Ruff check/format: passed
- contract, scenario, context checks: passed
- MkDocs strict build: passed
- real wheel: contains `workbench_backend/api-openapi-v1.json` (7,238 bytes)
- isolated wheel HTTP probe: `GET /api/v1/openapi.json` => `200`, OpenAPI `1.0.0`, `X-API-Version: 1`

Closes #80