### PR TITLE
fix(backend): reject duplicate JSON object keys

### DIFF
--- a/docs/task_packets/backend-duplicate-json-keys.json
+++ b/docs/task_packets/backend-duplicate-json-keys.json
@@ -1,0 +1,46 @@
+{
+  "issue": 190,
+  "human_owner": "Quchaosheng",
+  "objective": "Reject duplicate JSON object keys before local or remote Dashboard event-source data is trusted.",
+  "allowed_paths": [
+    "services/backend/workbench_backend/read_model.py",
+    "tests/unit/test_dashboard_backend.py",
+    "tests/unit/test_multi_host.py",
+    "docs/task_packets/backend-duplicate-json-keys.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "services/backend/workbench_backend/server.py",
+    "robot/control/**",
+    "firmware/**"
+  ],
+  "forbidden": ["interfaces/**", "robot/control/**", "firmware/**"],
+  "acceptance": [
+    "local JSONL rejects top-level and nested duplicate object keys before caching or readiness",
+    "remote JSON rejects top-level and nested duplicate object keys before projection or display",
+    "duplicate-key failures retain the existing ReadModelError boundary without leaking response bodies",
+    "valid local and split-host behavior remains unchanged"
+  ],
+  "commands": [
+    "python3 -m pytest tests/unit/test_dashboard_backend.py tests/unit/test_multi_host.py -v",
+    "python3 -m ruff check services/backend/workbench_backend/read_model.py tests/unit/test_dashboard_backend.py tests/unit/test_multi_host.py",
+    "python3 -m ruff format --check services/backend/workbench_backend/read_model.py tests/unit/test_dashboard_backend.py tests/unit/test_multi_host.py",
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/backend-duplicate-json-keys.json --base origin/main",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "focused local and remote duplicate-key test output",
+    "full repository test output",
+    "Task Packet boundary validation",
+    "contract scenario and context check output"
+  ],
+  "stop_conditions": [
+    "an interfaces schema change is required",
+    "a dependency or generalized JSON framework is required",
+    "a write or control endpoint is requested",
+    "a modification outside allowed_paths is required"
+  ]
+}

--- a/services/backend/workbench_backend/read_model.py
+++ b/services/backend/workbench_backend/read_model.py
@@ -51,6 +51,19 @@ class ReadModelResponseTooLarge(ReadModelError):
     """Raised when a local or remote projection exceeds the HTTP contract."""
 
 
+class _DuplicateJsonKey(ValueError):
+    """Raised before JSON decoding can silently discard an object member."""
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise _DuplicateJsonKey(f"duplicate JSON key: {key!r}")
+        payload[key] = value
+    return payload
+
+
 class DashboardReadModel:
     def __init__(self, data_dir: str | Path) -> None:
         self.data_dir = Path(data_dir)
@@ -93,7 +106,13 @@ class DashboardReadModel:
             if contents is None or stable_stat is None:
                 raise ReadModelError(f"event source changed while being read: {path.name}")
             try:
-                events = [json.loads(line) for line in contents.splitlines() if line.strip()]
+                events = [
+                    json.loads(line, object_pairs_hook=_object_without_duplicates)
+                    for line in contents.splitlines()
+                    if line.strip()
+                ]
+            except _DuplicateJsonKey as exc:
+                raise ReadModelError(f"event log contains {exc}: {path.name}") from exc
             except json.JSONDecodeError as exc:
                 raise ReadModelError(f"event log is not valid JSONL: {path.name}") from exc
             if not events or len(events) > MAX_EVENTS_PER_RUN:
@@ -215,13 +234,15 @@ class RemoteDashboardReadModel(DashboardReadModel):
                 body = response.read(MAX_REMOTE_RESPONSE_BYTES + 1)
                 if len(body) > MAX_REMOTE_RESPONSE_BYTES:
                     raise ReadModelError("remote event source response is too large")
-                payload = json.loads(body)
+                payload = json.loads(body, object_pairs_hook=_object_without_duplicates)
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 raise KeyError(path) from None
             if exc.code == 413:
                 raise ReadModelResponseTooLarge("remote event source response is too large") from None
             raise ReadModelError(f"remote event source unavailable: {self.base_url}") from exc
+        except _DuplicateJsonKey as exc:
+            raise ReadModelError(f"remote event source returned {exc}: {self.base_url}") from exc
         except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
             raise ReadModelError(f"remote event source unavailable: {self.base_url}") from exc
         if not isinstance(payload, dict):

--- a/tests/unit/test_dashboard_backend.py
+++ b/tests/unit/test_dashboard_backend.py
@@ -211,6 +211,28 @@ class ReadModelTests(unittest.TestCase):
                 model.list_runs()
             self.assertFalse(model.ready())
 
+    def test_duplicate_json_keys_fail_closed_at_every_object_depth(self) -> None:
+        event = stored_event("run-duplicate", 0, "task_accepted")
+        event["payload"] = {"status": "confirmed"}
+        encoded = json.dumps(event)
+        cases = {
+            "run_id": encoded.replace(
+                '"run_id": "run-duplicate"',
+                '"run_id": "forged", "run_id": "run-duplicate"',
+            ),
+            "status": encoded.replace(
+                '"status": "confirmed"',
+                '"status": "forged", "status": "confirmed"',
+            ),
+        }
+        for duplicate_key, contents in cases.items():
+            with self.subTest(duplicate_key=duplicate_key), tempfile.TemporaryDirectory() as temp_dir:
+                Path(temp_dir, "duplicate.jsonl").write_text(contents + "\n", encoding="utf-8")
+                model = DashboardReadModel(temp_dir)
+                with self.assertRaisesRegex(ReadModelError, rf"duplicate JSON key: '{duplicate_key}'"):
+                    model.list_runs()
+                self.assertFalse(model.ready())
+
     def test_non_scalar_identifiers_are_rejected_as_data_errors(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "bad-types.jsonl"

--- a/tests/unit/test_multi_host.py
+++ b/tests/unit/test_multi_host.py
@@ -1,3 +1,4 @@
+import io
 import json
 import tempfile
 import threading
@@ -5,11 +6,34 @@ import unittest
 import urllib.error
 import urllib.request
 from pathlib import Path
+from unittest import mock
 
+from workbench_backend.read_model import ReadModelError, RemoteDashboardReadModel
 from workbench_backend.server import create_server
 
 
 class MultiHostReadModelTests(unittest.TestCase):
+    def test_remote_json_rejects_top_level_and_nested_duplicate_keys(self) -> None:
+        model = RemoteDashboardReadModel("http://127.0.0.1:1")
+        cases = {
+            "runs": b'{"runs":[],"runs":[]}',
+            "task_id": b'{"runs":[{"task_id":"secret-marker","task_id":"trusted"}]}',
+        }
+        for duplicate_key, body in cases.items():
+            with (
+                self.subTest(duplicate_key=duplicate_key),
+                mock.patch("workbench_backend.read_model.urllib.request.urlopen", return_value=io.BytesIO(body)),
+                self.assertRaisesRegex(ReadModelError, rf"duplicate JSON key: '{duplicate_key}'") as caught,
+            ):
+                model.list_runs()
+            self.assertNotIn("secret-marker", str(caught.exception))
+
+        with mock.patch(
+            "workbench_backend.read_model.urllib.request.urlopen",
+            return_value=io.BytesIO(b'{"status":"not_ready","status":"ready"}'),
+        ):
+            self.assertFalse(model.ready())
+
     def test_controller_reads_remote_source_and_fails_ready_when_peer_is_down(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             data_dir = Path(directory)


### PR DESCRIPTION
## Summary

- reject duplicate object keys in local JSONL at every nesting level before caching or readiness
- reject duplicate object keys in remote Dashboard JSON before projection or display
- preserve local and remote `ReadModelError` boundaries without echoing response bodies
- add focused local, remote, readiness, nesting, and valid split-host coverage

Closes #190

## Scope

This is complementary to #65 (remote semantic event validation), #183 (non-finite numbers), and #187 (evaluation inputs). It changes only the Backend JSON decoding boundary and tests; no schema or dependency changes.

## Verification

- `make check PYTHON=.venv/bin/python` — 448 passed, 60 subtests passed; Ruff, format, contracts, scenarios, golden set, context, scripted/offline demos passed
- `.venv/bin/python -m pytest tests/unit/test_dashboard_backend.py tests/unit/test_multi_host.py -v` — 20 passed, 4 subtests passed
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/backend-duplicate-json-keys.json --base origin/main` — passed
