### PR TITLE
fix(contract): reject contradictory result states

### DIFF
--- a/docs/task_packets/contract-state-invariants.json
+++ b/docs/task_packets/contract-state-invariants.json
@@ -1,0 +1,47 @@
+{
+  "issue": 196,
+  "human_owner": "Quchaosheng",
+  "objective": "Reject canonical ActionResult and VerificationResult values whose cross-field states contradict their completion claim.",
+  "allowed_paths": [
+    "libs/contracts/workbench_contracts/models.py",
+    "tests/unit/test_contract_state_invariants.py",
+    "docs/task_packets/contract-state-invariants.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "services/world_model/**",
+    "services/agent_runtime/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**",
+    "services/backend/**"
+  ],
+  "acceptance": [
+    "completed actions require sent dispatch and confirmed device state",
+    "send-failed or rejected actions cannot report completed",
+    "confirmed verification cannot use a failure reason",
+    "confirmed verification cannot be incomplete or request recovery",
+    "non-confirmed verification cannot use goal_satisfied",
+    "valid existing timeout and three-valued verification states remain accepted"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_contract_state_invariants.py tests/unit/test_world_model.py -v",
+    "python -m ruff check libs/contracts/workbench_contracts/models.py tests/unit/test_contract_state_invariants.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/contract-state-invariants.json",
+    "make contract",
+    "make context-check"
+  ],
+  "evidence": [
+    "focused contradictory-state regression output",
+    "World Model verifier regression output",
+    "contract validation output",
+    "Task Packet and context validation output"
+  ],
+  "stop_conditions": [
+    "an interface enum or JSON Schema change is required",
+    "a valid existing verifier output is rejected",
+    "a write outside allowed_paths is required"
+  ]
+}

--- a/libs/contracts/workbench_contracts/models.py
+++ b/libs/contracts/workbench_contracts/models.py
@@ -273,6 +273,14 @@ class ActionResult(BaseModel):
     resulting_location: str | None = None
     evidence_refs: list[str] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def validate_completion_state(self) -> "ActionResult":
+        if self.outcome is ActionOutcome.COMPLETED and (
+            self.dispatch_state is not DispatchState.SENT or self.device_state is not DeviceState.CONFIRMED
+        ):
+            raise ValueError("completed action requires sent dispatch and confirmed device state")
+        return self
+
 
 class WorldEvent(BaseModel):
     event_id: str
@@ -338,6 +346,19 @@ class VerificationResult(BaseModel):
     verified_at: str
     clock_id: ClockId = ClockId.MONOTONIC
     rule_version: str = "unversioned"
+
+    @model_validator(mode="after")
+    def validate_status_semantics(self) -> "VerificationResult":
+        if self.status is VerificationStatus.CONFIRMED:
+            if self.reason_code not in {None, ReasonCode.GOAL_SATISFIED}:
+                raise ValueError("confirmed verification cannot use a non-success reason")
+            if self.completeness is not None and self.completeness != 1.0:
+                raise ValueError("confirmed verification completeness must be 1")
+            if self.recovery_hint is not RecoveryHint.NONE:
+                raise ValueError("confirmed verification cannot request recovery")
+        elif self.reason_code is ReasonCode.GOAL_SATISFIED:
+            raise ValueError("non-confirmed verification cannot use goal_satisfied")
+        return self
 
     @property
     def completed(self) -> bool:

--- a/tests/unit/test_contract_state_invariants.py
+++ b/tests/unit/test_contract_state_invariants.py
@@ -1,0 +1,78 @@
+import pytest
+from workbench_contracts import ActionResult, VerificationResult
+
+
+def action_result(**updates) -> ActionResult:
+    values = {
+        "result_id": "result-1",
+        "action_id": "action-1",
+        "run_id": "run-1",
+        "outcome": "completed",
+        "dispatch_state": "sent",
+        "device_state": "confirmed",
+        "started_at": "1",
+        "ended_at": "2",
+    }
+    return ActionResult(**(values | updates))
+
+
+def verification_result(**updates) -> VerificationResult:
+    values = {
+        "verification_id": "verification-1",
+        "run_id": "run-1",
+        "task_id": "task-1",
+        "claim": "goal satisfied",
+        "status": "confirmed",
+        "reason_code": "goal_satisfied",
+        "completeness": 1.0,
+        "evidence_refs": ["frame://1"],
+        "recovery_hint": "none",
+        "verified_at": "3",
+    }
+    return VerificationResult(**(values | updates))
+
+
+@pytest.mark.parametrize(
+    ("dispatch_state", "device_state"),
+    [("send_failed", "rejected"), ("sent", "rejected"), ("not_sent", "unconfirmed")],
+)
+def test_completed_action_requires_confirmed_delivery(dispatch_state: str, device_state: str) -> None:
+    with pytest.raises(ValueError, match="completed action"):
+        action_result(dispatch_state=dispatch_state, device_state=device_state)
+
+    assert action_result()
+    assert action_result(outcome="timeout", dispatch_state="sent", device_state="unconfirmed")
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"reason_code": "target_not_observed"},
+        {"completeness": 0.0},
+        {"recovery_hint": "re_observe"},
+        {"status": "refuted", "reason_code": "goal_satisfied", "recovery_hint": "retry_action"},
+        {
+            "status": "insufficient_evidence",
+            "reason_code": "goal_satisfied",
+            "recovery_hint": "re_observe",
+        },
+    ],
+)
+def test_verification_rejects_contradictory_status_semantics(updates: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        verification_result(**updates)
+
+    assert verification_result()
+    assert verification_result(reason_code=None, completeness=None)
+    assert verification_result(
+        status="refuted",
+        reason_code="goal_not_satisfied",
+        completeness=1.0,
+        recovery_hint="retry_action",
+    )
+    assert verification_result(
+        status="insufficient_evidence",
+        reason_code="target_not_observed",
+        completeness=0.5,
+        recovery_hint="re_observe",
+    )


### PR DESCRIPTION
## Summary

- require a completed action to be both sent and device-confirmed
- reject confirmed verification values with failure reasons, incomplete coverage, or recovery requests
- reject non-confirmed verification values that claim `goal_satisfied`
- retain valid timeout, refuted, and insufficient-evidence combinations

No interface schema or enum changes.

Closes #196

## Verification

- `.venv/bin/python -m pytest tests/unit/test_contract_state_invariants.py tests/unit/test_world_model.py tests/unit/test_world_model_mock.py -q`
- `PYTHONPATH=libs/application:libs/hardware:libs/kernel:libs/contracts:services/agent_runtime:services/backend:services/world_model:firmware/virtual_mcu make test PYTHON=.venv/bin/python` — 454 passed
- `.venv/bin/python -m ruff check libs/contracts/workbench_contracts/models.py tests/unit/test_contract_state_invariants.py`
- `.venv/bin/python tools/scripts/validate_contracts.py`
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/contract-state-invariants.json`
- `.venv/bin/python tools/scripts/check_context.py`
