### PR TITLE
fix(performance): reject colliding evidence log names

### DIFF
--- a/docs/task_packets/hardware-evidence-log-identity.json
+++ b/docs/task_packets/hardware-evidence-log-identity.json
@@ -1,0 +1,45 @@
+{
+  "issue": 199,
+  "human_owner": "Quchaosheng",
+  "objective": "Keep hardware performance evidence log identities one-to-one with the analyzed files.",
+  "allowed_paths": [
+    "tools/scripts/register_hardware_evidence.py",
+    "tools/scripts/performance_tools.py",
+    "tests/unit/test_performance_tools.py",
+    "docs/task_packets/hardware-evidence-log-identity.json"
+  ],
+  "read_only_paths": [
+    "docs/performance/**",
+    "interfaces/**"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "robot/control/**",
+    "hardware/validation/**",
+    "services/**"
+  ],
+  "acceptance": [
+    "duplicate hardware log basenames fail before manifest creation",
+    "evidence validation independently rejects colliding analyzed paths",
+    "every analyzed log maps to exactly one manifest hash",
+    "ordinary unique log names remain compatible",
+    "changed log contents still fail hash validation"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_performance_tools.py -v",
+    "python -m ruff check tools/scripts/register_hardware_evidence.py tools/scripts/performance_tools.py tests/unit/test_performance_tools.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/hardware-evidence-log-identity.json",
+    "make context-check"
+  ],
+  "evidence": [
+    "colliding-basename regression output",
+    "performance evidence unit-test output",
+    "Task Packet boundary validation",
+    "context validation output"
+  ],
+  "stop_conditions": [
+    "telemetry schema or report semantics must change",
+    "a write outside allowed_paths is required",
+    "existing unique-name manifests become incompatible"
+  ]
+}

--- a/tests/unit/test_performance_tools.py
+++ b/tests/unit/test_performance_tools.py
@@ -2,15 +2,18 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from performance_tools import (
     file_sha256,
+    hardware_log_hashes,
     load_telemetry,
     parse_memory_bytes,
     summarize_resource_samples,
     summarize_telemetry,
     validate_hardware_evidence,
 )
+from register_hardware_evidence import main as register_hardware_evidence
 
 
 def record(source: str, run_id: str, sequence: int, stage: str, duration_ms: float) -> dict:
@@ -69,6 +72,56 @@ class TelemetryTests(unittest.TestCase):
             log_path.write_text(log_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
             with self.assertRaisesRegex(RuntimeError, "hashes"):
                 validate_hardware_evidence(paths, evidence_path)
+
+    def test_hardware_evidence_rejects_colliding_log_names(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first" / "run.jsonl"
+            second = root / "second" / "run.jsonl"
+            first.parent.mkdir()
+            second.parent.mkdir()
+            first.write_text("first", encoding="utf-8")
+            second.write_text("second", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "names must be unique"):
+                hardware_log_hashes([first, second])
+
+            evidence_path = root / "evidence.json"
+            evidence_path.write_text(
+                json.dumps(
+                    {
+                        "evidence_kind": "operator_attested_real_hardware",
+                        "hardware_id": "arm-01",
+                        "operator": "tester",
+                        "captured_at": "2026-08-08T00:00:00Z",
+                        "logs": {"run.jsonl": file_sha256(second)},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(RuntimeError, "names must be unique"):
+                validate_hardware_evidence([first, second], evidence_path)
+
+            output = root / "generated.json"
+            with (
+                patch(
+                    "sys.argv",
+                    [
+                        "register_hardware_evidence.py",
+                        str(first),
+                        str(second),
+                        "--hardware-id",
+                        "arm-01",
+                        "--operator",
+                        "tester",
+                        "--output",
+                        str(output),
+                    ],
+                ),
+                self.assertRaisesRegex(RuntimeError, "names must be unique"),
+            ):
+                register_hardware_evidence()
+            self.assertFalse(output.exists())
 
     def test_resource_units_and_percentiles(self) -> None:
         self.assertEqual(parse_memory_bytes("1.5MiB"), 1572864)

--- a/tools/scripts/performance_tools.py
+++ b/tools/scripts/performance_tools.py
@@ -50,6 +50,14 @@ def file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def hardware_log_hashes(paths: list[Path]) -> dict[str, str]:
+    names = [path.name for path in paths]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise RuntimeError(f"hardware evidence log names must be unique: {', '.join(duplicates)}")
+    return {path.name: file_sha256(path) for path in paths}
+
+
 def _telemetry_paths(inputs: list[Path]) -> list[Path]:
     paths: list[Path] = []
     for item in inputs:
@@ -105,7 +113,7 @@ def validate_hardware_evidence(paths: list[Path], evidence_path: Path | None) ->
     expected = evidence["logs"]
     if not isinstance(expected, dict):
         raise RuntimeError("hardware evidence logs must map file names to SHA-256 digests")
-    actual = {path.name: file_sha256(path) for path in paths}
+    actual = hardware_log_hashes(paths)
     if actual != expected:
         raise RuntimeError("hardware evidence log hashes do not match the analyzed files")
     return evidence

--- a/tools/scripts/register_hardware_evidence.py
+++ b/tools/scripts/register_hardware_evidence.py
@@ -6,7 +6,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from performance_tools import file_sha256
+from performance_tools import hardware_log_hashes
 
 
 def main() -> int:
@@ -24,7 +24,7 @@ def main() -> int:
         "hardware_id": args.hardware_id,
         "operator": args.operator,
         "captured_at": datetime.now(UTC).isoformat(),
-        "logs": {path.name: file_sha256(path) for path in args.logs},
+        "logs": hardware_log_hashes(args.logs),
         "attestation": "The named operator confirms these logs were captured from the identified physical system.",
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- centralize hardware evidence log hashing
- reject duplicate basenames before manifest generation
- independently reject duplicate basenames during evidence validation
- preserve existing unique-name manifest format and hash-change checks

Closes #199

## Verification

- `.venv/bin/python -m pytest tests/unit/test_performance_tools.py -q` — 4 passed
- `.venv/bin/python -m ruff check tools/scripts/register_hardware_evidence.py tools/scripts/performance_tools.py tests/unit/test_performance_tools.py`
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/hardware-evidence-log-identity.json --base origin/main`
- `.venv/bin/python tools/scripts/check_context.py`
