### PR TITLE
fix(agent-runtime): enforce tool parameter constraints

### DIFF
--- a/docs/task_packets/issue-103-tool-registry-constraints.json
+++ b/docs/task_packets/issue-103-tool-registry-constraints.json
@@ -1,0 +1,52 @@
+{
+  "issue": 103,
+  "human_owner": "Quchaosheng",
+  "objective": "Reject unsafe numeric, relational, and blank-string tool parameters from immutable ToolRegistry schemas and the A5 policy boundary.",
+  "allowed_paths": [
+    "services/agent_runtime/workbench_agent_runtime/tool_schemas.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_registry.py",
+    "services/agent_runtime/workbench_agent_runtime/policy_validator.py",
+    "tests/unit/test_tool_registry.py",
+    "tests/unit/test_policy_validator.py",
+    "docs/task_packets/issue-103-tool-registry-constraints.json"
+  ],
+  "read_only_paths": [
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "tests/unit/test_agent_runtime.py",
+    "interfaces/**",
+    "libs/contracts/**"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "robot/control/**",
+    "services/world_model/**"
+  ],
+  "acceptance": [
+    "required_confidence is finite and within the inclusive range zero to one",
+    "timeout_s is between one and 600 seconds and duration_ms is between one and 600000 milliseconds",
+    "destination counts are non-negative and when supplied are complete and satisfy capacity equals occupancy plus remaining",
+    "string tool parameters reject empty and whitespace-only values",
+    "NaN, Infinity, and booleans in numeric slots fail closed",
+    "value and relational constraints are immutable registry schema data consumed by ToolRegistry and PolicyValidator",
+    "focused tests cover invalid values and valid boundary values"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_tool_registry.py tests/unit/test_policy_validator.py tests/unit/test_agent_runtime.py -v",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "tool registry and A5 policy constraint regression output",
+    "agent runtime regression output",
+    "full test output",
+    "contract scenario and context check output"
+  ],
+  "stop_conditions": [
+    "an interface or contract change is required",
+    "a planner producer or world-model change is required",
+    "a write outside allowed_paths is required",
+    "a new supported parameter type or unbounded constraint kind is required"
+  ]
+}

--- a/services/agent_runtime/workbench_agent_runtime/policy_validator.py
+++ b/services/agent_runtime/workbench_agent_runtime/policy_validator.py
@@ -23,10 +23,9 @@ Three rules this module obeys and never crosses:
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 
-from workbench_contracts import ActionType, TaskGraph, TaskStep
+from workbench_contracts import TaskGraph, TaskStep
 
 from .tool_registry import ToolRegistry
 
@@ -97,142 +96,13 @@ class PolicyValidator:
 
     def _check_step(self, step: TaskStep) -> list[PolicyFinding]:
         action = step.action
-        findings: list[PolicyFinding] = []
-        step_id = step.step_id
-        action_id = action.action_id
-
-        # 0. action_type must be a registered ActionType
-        if not isinstance(action.action_type, ActionType):
-            return [
-                PolicyFinding(
-                    step_id,
-                    action_id,
-                    "action_type",
-                    f"expected an ActionType enum member, got {type(action.action_type).__name__!r}",
-                )
-            ]
-        if action.action_type not in self._registry.list_all():
-            return [
-                PolicyFinding(
-                    step_id,
-                    action_id,
-                    "action_type",
-                    f"unknown action_type '{action.action_type.value}'",
-                )
-            ]
-
-        schema = self._registry.get(action.action_type)
-        target_id_required: bool = schema.get("target_id_required", False)
-        required: frozenset[str] = schema["required_params"]
-        optional: frozenset[str] = schema["optional_params"]
-        allowed: frozenset[str] = required | optional
-        param_types: Mapping[str, type | object] = schema["param_types"]
-
-        # 1. target_id requirement (physical-safety boundary)
-        if target_id_required and (not isinstance(action.target_id, str) or not action.target_id.strip()):
-            findings.append(
-                PolicyFinding(
-                    step_id,
-                    action_id,
-                    "target_id",
-                    f"'{action.action_type.value}' requires a non-empty target_id",
-                )
-            )
-
-        # 2. parameters must be a mapping — fail-closed on malformed input
-        params = action.parameters
-        if not isinstance(params, Mapping):
-            findings.append(
-                PolicyFinding(
-                    step_id,
-                    action_id,
-                    "parameters",
-                    f"expected a mapping, got {type(params).__name__!r}",
-                )
-            )
-            return findings
-
-        # 3. exact field-set equality: reject extra and missing keys
-        actual_keys = set(params)
-        extra = actual_keys - allowed
-        missing = required - actual_keys
-        if extra:
-            findings.append(
-                PolicyFinding(
-                    step_id,
-                    action_id,
-                    "parameters",
-                    f"forbidden keys for '{action.action_type.value}': {sorted(extra)}; allowed: {sorted(allowed)}",
-                )
-            )
-        if missing:
-            findings.append(
-                PolicyFinding(
-                    step_id,
-                    action_id,
-                    "parameters",
-                    f"missing required keys for '{action.action_type.value}': {sorted(missing)}",
-                )
-            )
-
-        # 4. type safety (bool-before-int) — only for keys in the allow-list
-        for key, value in params.items():
-            expected_type = param_types.get(key)
-            if expected_type is None:
-                # undeclared key — already reported as forbidden, or permissive
-                continue
-            type_error = _type_error(key, value, expected_type)
-            if type_error is not None:
-                findings.append(PolicyFinding(step_id, action_id, f"parameters.{key}", type_error))
-
-        return findings
+        result = self._registry.validate(action)
+        return [PolicyFinding(step.step_id, action.action_id, error.field, error.message) for error in result.errors]
 
 
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
-
-
-def _type_error(key: str, value: object, expected: type | object) -> str | None:
-    """Return an error message if *value* violates *expected*; ``None`` if ok.
-
-    ``bool`` is checked before ``int`` / ``float`` because ``bool`` subclasses
-    ``int`` in Python.  ``duration_ms`` and any other integer slot must reject
-    ``True`` / ``False`` rather than coercing them to ``1`` / ``0``.
-    """
-    if expected is bool:
-        if not isinstance(value, bool):
-            return f"expected bool, got {_type_label(value)}"
-        return None
-    if expected is int:
-        if isinstance(value, bool):
-            return "expected int, got bool (bool is not int)"
-        if not isinstance(value, int):
-            return f"expected int, got {_type_label(value)}"
-        return None
-    if expected is float:
-        if isinstance(value, bool):
-            return "expected float, got bool"
-        if not isinstance(value, int | float):
-            return f"expected float, got {_type_label(value)}"
-        return None
-    if expected is str:
-        if not isinstance(value, str):
-            return f"expected str, got {_type_label(value)}"
-        return None
-    if expected is list:
-        if not isinstance(value, list):
-            return f"expected list, got {_type_label(value)}"
-        return None
-    if not isinstance(value, expected):
-        return f"expected {getattr(expected, '__name__', str(expected))}, got {_type_label(value)}"
-    return None
-
-
-def _type_label(value: object) -> str:
-    if isinstance(value, bool):
-        return "bool"
-    return type(value).__name__
 
 
 def _format_findings(findings: tuple[PolicyFinding, ...]) -> str:

--- a/services/agent_runtime/workbench_agent_runtime/tool_registry.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_registry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from math import isfinite
 from types import MappingProxyType
 
 from workbench_contracts import ActionType, SemanticAction
@@ -22,9 +23,22 @@ from . import tool_schemas as _schemas
 
 _TARGET_REQUIRED_ACTIONS: frozenset[ActionType] = frozenset({ActionType.GRASP, ActionType.PLACE})
 _SCHEMA_KEYS: frozenset[str] = frozenset(
-    {"description", "target_id_required", "required_params", "optional_params", "param_types"}
+    {
+        "description",
+        "target_id_required",
+        "required_params",
+        "optional_params",
+        "param_types",
+        "param_constraints",
+        "relational_constraints",
+    }
 )
 _SUPPORTED_PARAM_TYPES: frozenset[type] = frozenset({str, int, float, bool, list})
+_CONSTRAINT_KEYS: frozenset[str] = frozenset({"non_blank", "finite", "minimum", "maximum"})
+_SUPPORTED_RELATIONAL_CONSTRAINTS: frozenset[str] = frozenset({"destination_counts_consistent"})
+_DESTINATION_COUNT_PARAMS: frozenset[str] = frozenset(
+    {"destination_capacity", "destination_occupancy_after", "destination_remaining_after"}
+)
 
 
 @dataclass(frozen=True)
@@ -72,7 +86,9 @@ class ToolRegistry:
     4. **Type safety** — every parameter value must match its declared type.
        ``bool`` is checked *before* ``int`` so that ``True`` / ``False`` can
        never silently pass an integer slot.
-    5. **Semantic constraints** — emotion_state enum, observe attribute
+    5. **Schema constraints** — finite numeric ranges, non-blank strings, and
+       declared relationships between parameters.
+    6. **Semantic constraints** — emotion_state enum, observe attribute
        allow-list.
     """
 
@@ -165,8 +181,14 @@ class ToolRegistry:
         required: frozenset[str] = schema["required_params"]
         optional: frozenset[str] = schema["optional_params"]
         allowed: frozenset[str] = required | optional
-        param_types: dict[str, type | object] = schema["param_types"]
-        params: dict[str, object] = action.parameters or {}
+        param_types: Mapping[str, type | object] = schema["param_types"]
+        raw_params = action.parameters
+        if not isinstance(raw_params, Mapping):
+            return ValidationResult.fail(
+                action.action_id,
+                [ValidationError("parameters", f"expected a mapping, got {type(raw_params).__name__!r}")],
+            )
+        params: Mapping[str, object] = raw_params
 
         # ---- 2. target_id ---------------------------------------------------
         if target_id_required:
@@ -283,7 +305,15 @@ class ToolRegistry:
                     )
                 )
 
-        # ---- 5. semantic constraints ----------------------------------------
+        # Do not compare or inspect values that failed their declared type.
+        if errors:
+            return ValidationResult.fail(action.action_id, errors)
+
+        # ---- 5. schema constraints -----------------------------------------
+        errors.extend(_validate_parameter_values(params, schema["param_constraints"]))
+        errors.extend(_validate_parameter_relations(params, schema["relational_constraints"]))
+
+        # ---- 6. semantic constraints ----------------------------------------
         if action.action_type is ActionType.EXPRESS:
             emotion = params.get("emotion_state")
             if isinstance(emotion, str) and emotion not in _schemas.EXPRESS_EMOTION_STATES:
@@ -379,6 +409,62 @@ def _validate_schema(schema: Mapping[str, object]) -> None:
         labels = {name: _type_name(value) for name, value in unsupported.items()}
         raise ValueError(f"param_types contains unsupported types: {labels}")
 
+    _validate_param_constraints(schema["param_constraints"], allowed, param_types)
+    relations = _validate_param_set("relational_constraints", schema["relational_constraints"])
+    unsupported_relations = relations - _SUPPORTED_RELATIONAL_CONSTRAINTS
+    if unsupported_relations:
+        raise ValueError(f"relational_constraints contains unsupported constraints: {sorted(unsupported_relations)}")
+    if "destination_counts_consistent" in relations:
+        if not _DESTINATION_COUNT_PARAMS <= allowed:
+            raise ValueError("destination_counts_consistent requires all destination count parameters")
+        if any(param_types[name] is not int for name in _DESTINATION_COUNT_PARAMS):
+            raise ValueError("destination_counts_consistent requires integer destination count parameters")
+
+
+def _validate_param_constraints(
+    constraints: object,
+    allowed: frozenset[str],
+    param_types: Mapping[str, object],
+) -> None:
+    if not isinstance(constraints, Mapping):
+        raise ValueError("schema 'param_constraints' must be a mapping")
+    names = set(constraints)
+    if any(not isinstance(name, str) for name in names):
+        raise ValueError("schema 'param_constraints' keys must be strings")
+    unknown_names = names - allowed
+    if unknown_names:
+        raise ValueError(f"param_constraints contains unknown parameters: {sorted(unknown_names)}")
+
+    for name, raw_rules in constraints.items():
+        if not isinstance(raw_rules, Mapping):
+            raise ValueError(f"param_constraints for '{name}' must be a mapping")
+        rule_names = set(raw_rules)
+        if any(not isinstance(rule, str) for rule in rule_names):
+            raise ValueError(f"param_constraints for '{name}' must have string keys")
+        unknown_rules = rule_names - _CONSTRAINT_KEYS
+        if unknown_rules:
+            raise ValueError(f"param_constraints for '{name}' has unknown rules: {sorted(unknown_rules)}")
+
+        expected_type = param_types[name]
+        for flag in ("non_blank", "finite"):
+            if flag in raw_rules and raw_rules[flag] is not True:
+                raise ValueError(f"constraint '{flag}' for '{name}' must be true")
+        if "non_blank" in raw_rules and expected_type is not str:
+            raise ValueError(f"constraint 'non_blank' for '{name}' requires a string parameter")
+        numeric_rules = rule_names & {"finite", "minimum", "maximum"}
+        if numeric_rules and expected_type not in {int, float}:
+            raise ValueError(f"numeric constraints for '{name}' require an int or float parameter")
+
+        for bound_name in ("minimum", "maximum"):
+            if bound_name not in raw_rules:
+                continue
+            bound = raw_rules[bound_name]
+            if isinstance(bound, bool) or not isinstance(bound, int | float) or not _is_finite_number(bound):
+                raise ValueError(f"constraint '{bound_name}' for '{name}' must be a finite number")
+        if "minimum" in raw_rules and "maximum" in raw_rules:
+            if raw_rules["minimum"] > raw_rules["maximum"]:
+                raise ValueError(f"constraint minimum exceeds maximum for '{name}'")
+
 
 def _validate_param_set(name: str, value: object) -> frozenset[str]:
     if not isinstance(value, set | frozenset):
@@ -389,10 +475,59 @@ def _validate_param_set(name: str, value: object) -> frozenset[str]:
     return frozenset(value)
 
 
+def _validate_parameter_values(
+    params: Mapping[str, object], constraints: Mapping[str, object]
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    for name, raw_rules in constraints.items():
+        if name not in params:
+            continue
+        rules: Mapping[str, object] = raw_rules
+        value = params[name]
+        field = f"parameters.{name}"
+        if rules.get("non_blank") and isinstance(value, str) and not value.strip():
+            errors.append(ValidationError(field, "must be a non-empty, non-whitespace string"))
+        if rules.get("finite") and isinstance(value, int | float) and not _is_finite_number(value):
+            errors.append(ValidationError(field, "must be finite"))
+            continue
+        if "minimum" in rules and value < rules["minimum"]:
+            errors.append(ValidationError(field, f"must be greater than or equal to {rules['minimum']}"))
+        if "maximum" in rules and value > rules["maximum"]:
+            errors.append(ValidationError(field, f"must be less than or equal to {rules['maximum']}"))
+    return errors
+
+
+def _validate_parameter_relations(params: Mapping[str, object], constraints: frozenset[str]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    if "destination_counts_consistent" in constraints and _DESTINATION_COUNT_PARAMS & set(params):
+        missing = _DESTINATION_COUNT_PARAMS - set(params)
+        if missing:
+            errors.append(
+                ValidationError(
+                    "parameters",
+                    f"destination count snapshot is incomplete; missing: {sorted(missing)}",
+                )
+            )
+        elif params["destination_capacity"] != (
+            params["destination_occupancy_after"] + params["destination_remaining_after"]
+        ):
+            errors.append(
+                ValidationError(
+                    "parameters",
+                    "destination counts must satisfy capacity = occupancy_after + remaining_after",
+                )
+            )
+    return errors
+
+
 def _type_label(value: object) -> str:
     if isinstance(value, bool):
         return "bool"
     return type(value).__name__
+
+
+def _is_finite_number(value: int | float) -> bool:
+    return isinstance(value, int) or isfinite(value)
 
 
 def _freeze_mapping(value: Mapping[object, object]) -> Mapping:

--- a/services/agent_runtime/workbench_agent_runtime/tool_schemas.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_schemas.py
@@ -24,6 +24,10 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
             "required_confidence": float,
             "attributes": list,
         },
+        "param_constraints": {
+            "required_confidence": {"finite": True, "minimum": 0.0, "maximum": 1.0},
+        },
+        "relational_constraints": frozenset[str](),
     },
     ActionType.GRASP: {
         "description": "Grasp a known entity.  target_id is required — a grasp "
@@ -32,6 +36,8 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
         "required_params": frozenset[str](),
         "optional_params": frozenset[str](),
         "param_types": {},
+        "param_constraints": {},
+        "relational_constraints": frozenset[str](),
     },
     ActionType.PLACE: {
         "description": "Place a grasped entity into a destination.  target_id and destination_id are required.",
@@ -62,6 +68,19 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
             "destination_occupancy_after": int,
             "destination_remaining_after": int,
         },
+        "param_constraints": {
+            "destination_id": {"non_blank": True},
+            "routing_reason": {"non_blank": True},
+            "routing_priority": {"non_blank": True},
+            "policy_version": {"non_blank": True},
+            "identity_guard": {"non_blank": True},
+            "manifest_guard": {"non_blank": True},
+            "manifest_id": {"non_blank": True},
+            "destination_capacity": {"minimum": 0},
+            "destination_occupancy_after": {"minimum": 0},
+            "destination_remaining_after": {"minimum": 0},
+        },
+        "relational_constraints": frozenset({"destination_counts_consistent"}),
     },
     ActionType.ASK_CONFIRM: {
         "description": "Ask a human operator for confirmation before proceeding.",
@@ -72,6 +91,11 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
             "question": str,
             "timeout_s": int,
         },
+        "param_constraints": {
+            "question": {"non_blank": True},
+            "timeout_s": {"minimum": 1, "maximum": 600},
+        },
+        "relational_constraints": frozenset[str](),
     },
     ActionType.EXPRESS: {
         "description": "Express an emotion state (idle / thinking / uncertain / pleased).",
@@ -82,6 +106,11 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
             "emotion_state": str,
             "duration_ms": int,
         },
+        "param_constraints": {
+            "emotion_state": {"non_blank": True},
+            "duration_ms": {"minimum": 1, "maximum": 600000},
+        },
+        "relational_constraints": frozenset[str](),
     },
     ActionType.STOP: {
         "description": "Safe-stop the current run.  No required parameters.",
@@ -91,6 +120,10 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
         "param_types": {
             "reason": str,
         },
+        "param_constraints": {
+            "reason": {"non_blank": True},
+        },
+        "relational_constraints": frozenset[str](),
     },
 }
 

--- a/tests/unit/test_policy_validator.py
+++ b/tests/unit/test_policy_validator.py
@@ -190,6 +190,68 @@ class PolicyValidatorBoolBeforeIntTests(unittest.TestCase):
         self.assertTrue(report.is_valid)
 
 
+class PolicyValidatorSchemaConstraintTests(unittest.TestCase):
+    """A5 consumes value and relational constraints from ToolRegistry."""
+
+    def setUp(self) -> None:
+        self.validator = PolicyValidator()
+
+    def test_non_finite_confidence_is_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(_action(ActionType.OBSERVE, parameters={"required_confidence": float("nan")}))
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("finite" in finding.message for finding in report.findings))
+
+    def test_blank_question_and_out_of_range_timeout_are_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(_action(ActionType.ASK_CONFIRM, parameters={"question": " ", "timeout_s": 601}))
+        )
+        self.assertFalse(report.is_valid)
+        self.assertEqual(
+            {finding.field for finding in report.findings},
+            {"parameters.question", "parameters.timeout_s"},
+        )
+
+    def test_inconsistent_destination_snapshot_is_rejected(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(
+                    ActionType.PLACE,
+                    target_id="parcel",
+                    parameters={
+                        "destination_id": "bin",
+                        "destination_capacity": 5,
+                        "destination_occupancy_after": 2,
+                        "destination_remaining_after": 2,
+                    },
+                )
+            )
+        )
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("capacity = occupancy_after" in finding.message for finding in report.findings))
+
+    def test_valid_constraint_boundaries_are_accepted(self) -> None:
+        report = self.validator.check(
+            _graph(
+                _action(ActionType.OBSERVE, parameters={"required_confidence": 1.0}),
+                _action(ActionType.ASK_CONFIRM, parameters={"question": "continue?", "timeout_s": 600}),
+                _action(ActionType.EXPRESS, parameters={"emotion_state": "pleased", "duration_ms": 600000}),
+                _action(
+                    ActionType.PLACE,
+                    target_id="parcel",
+                    parameters={
+                        "destination_id": "bin",
+                        "destination_capacity": 0,
+                        "destination_occupancy_after": 0,
+                        "destination_remaining_after": 0,
+                    },
+                ),
+            )
+        )
+        self.assertTrue(report.is_valid, report.findings)
+
+
 class PolicyValidatorTypeMismatchTests(unittest.TestCase):
     def setUp(self) -> None:
         self.validator = PolicyValidator()

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -116,11 +116,14 @@ class ToolRegistryRegistrationTests(unittest.TestCase):
     def test_get_does_not_expose_mutable_registry_state(self) -> None:
         schema = self.registry.get(ActionType.PLACE)
         param_types = schema["param_types"]
+        capacity_constraints = schema["param_constraints"]["destination_capacity"]
 
         with self.assertRaises(TypeError):
             schema["required_params"] = frozenset()  # type: ignore[index]
         with self.assertRaises(TypeError):
             param_types["destination_id"] = int  # type: ignore[index]
+        with self.assertRaises(TypeError):
+            capacity_constraints["minimum"] = -1  # type: ignore[index]
 
         result = self.registry.validate(
             _action(ActionType.PLACE, target_id="red_block", parameters={"destination_id": "tray"})
@@ -134,11 +137,14 @@ class ToolRegistryRegistrationTests(unittest.TestCase):
             "required_params": {"reason"},
             "optional_params": set(),
             "param_types": {"reason": str},
+            "param_constraints": {"reason": {"non_blank": True}},
+            "relational_constraints": set(),
         }
         registry = ToolRegistry(load_defaults=False)
         registry.register(ActionType.STOP, schema)
         schema["required_params"].clear()
         schema["param_types"]["reason"] = int
+        schema["param_constraints"]["reason"]["non_blank"] = False
 
         self.assertFalse(registry.validate(_action(ActionType.STOP)).is_valid)
         self.assertTrue(registry.validate(_action(ActionType.STOP, parameters={"reason": "operator"})).is_valid)
@@ -191,6 +197,27 @@ class ToolRegistryRegistrationTests(unittest.TestCase):
         schema["target_id_required"] = 1
 
         with self.assertRaisesRegex(ValueError, "must be a bool"):
+            ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_register_rejects_unknown_or_mistyped_value_constraints(self) -> None:
+        cases = (
+            ({"reason": {"unknown": True}}, "unknown rules"),
+            ({"reason": {"minimum": 0}}, "require an int or float"),
+            ({"reason": {"non_blank": False}}, "must be true"),
+            ({"not_allowed": {"non_blank": True}}, "unknown parameters"),
+        )
+        for constraints, message in cases:
+            with self.subTest(constraints=constraints):
+                schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+                schema["param_constraints"] = constraints
+                with self.assertRaisesRegex(ValueError, message):
+                    ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
+
+    def test_register_rejects_unknown_relational_constraint(self) -> None:
+        schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+        schema["relational_constraints"] = {"unknown_relation"}
+
+        with self.assertRaisesRegex(ValueError, "unsupported constraints"):
             ToolRegistry(load_defaults=False).register(ActionType.STOP, schema)
 
     def test_rejected_schema_mutation_does_not_change_registry(self) -> None:
@@ -252,6 +279,18 @@ class ToolRegistryValidationTests(unittest.TestCase):
         result = self.registry.validate(_action(ActionType.OBSERVE, parameters={"required_confidence": 0.95}))
         self.assertTrue(result.is_valid)
 
+    def test_confidence_accepts_inclusive_boundaries(self) -> None:
+        for value in (0, 0.0, 1, 1.0):
+            with self.subTest(value=value):
+                result = self.registry.validate(_action(ActionType.OBSERVE, parameters={"required_confidence": value}))
+                self.assertTrue(result.is_valid, result.errors)
+
+    def test_confidence_rejects_non_finite_and_out_of_range_values(self) -> None:
+        for value in (float("nan"), float("inf"), float("-inf"), -0.01, 1.01):
+            with self.subTest(value=value):
+                result = self.registry.validate(_action(ActionType.OBSERVE, parameters={"required_confidence": value}))
+                self.assertFalse(result.is_valid)
+
     def test_grasp_with_target_id_is_valid(self) -> None:
         result = self.registry.validate(_action(ActionType.GRASP, target_id="red_block"))
         self.assertTrue(result.is_valid)
@@ -285,6 +324,66 @@ class ToolRegistryValidationTests(unittest.TestCase):
             )
         )
         self.assertTrue(result.is_valid)
+
+    def test_positive_time_boundaries_are_valid(self) -> None:
+        cases = (
+            (ActionType.ASK_CONFIRM, {"question": "continue?", "timeout_s": 1}),
+            (ActionType.ASK_CONFIRM, {"question": "continue?", "timeout_s": 600}),
+            (ActionType.EXPRESS, {"emotion_state": "pleased", "duration_ms": 1}),
+            (ActionType.EXPRESS, {"emotion_state": "pleased", "duration_ms": 600000}),
+        )
+        for action_type, parameters in cases:
+            with self.subTest(action_type=action_type, parameters=parameters):
+                self.assertTrue(self.registry.validate(_action(action_type, parameters=parameters)).is_valid)
+
+    def test_time_values_outside_documented_bounds_are_rejected(self) -> None:
+        cases = (
+            (ActionType.ASK_CONFIRM, {"question": "continue?", "timeout_s": 0}),
+            (ActionType.ASK_CONFIRM, {"question": "continue?", "timeout_s": 601}),
+            (ActionType.EXPRESS, {"emotion_state": "pleased", "duration_ms": 0}),
+            (ActionType.EXPRESS, {"emotion_state": "pleased", "duration_ms": 600001}),
+        )
+        for action_type, parameters in cases:
+            with self.subTest(action_type=action_type, parameters=parameters):
+                self.assertFalse(self.registry.validate(_action(action_type, parameters=parameters)).is_valid)
+
+    def test_destination_counts_are_non_negative_complete_and_consistent(self) -> None:
+        invalid_snapshots = (
+            {"destination_capacity": -1, "destination_occupancy_after": 0, "destination_remaining_after": 0},
+            {"destination_capacity": 1, "destination_occupancy_after": -1, "destination_remaining_after": 2},
+            {"destination_capacity": 1, "destination_occupancy_after": 0, "destination_remaining_after": -1},
+            {"destination_capacity": 5},
+            {"destination_capacity": 5, "destination_occupancy_after": 2, "destination_remaining_after": 2},
+        )
+        for snapshot in invalid_snapshots:
+            with self.subTest(snapshot=snapshot):
+                parameters = {"destination_id": "bin", **snapshot}
+                result = self.registry.validate(_action(ActionType.PLACE, target_id="parcel", parameters=parameters))
+                self.assertFalse(result.is_valid)
+
+        for snapshot in (
+            {"destination_capacity": 0, "destination_occupancy_after": 0, "destination_remaining_after": 0},
+            {"destination_capacity": 5, "destination_occupancy_after": 2, "destination_remaining_after": 3},
+        ):
+            with self.subTest(snapshot=snapshot):
+                parameters = {"destination_id": "bin", **snapshot}
+                result = self.registry.validate(_action(ActionType.PLACE, target_id="parcel", parameters=parameters))
+                self.assertTrue(result.is_valid, result.errors)
+
+    def test_string_parameters_reject_empty_or_whitespace_only_values(self) -> None:
+        cases = (
+            (ActionType.PLACE, "parcel", {"destination_id": " "}),
+            (ActionType.PLACE, "parcel", {"destination_id": "bin", "routing_reason": ""}),
+            (ActionType.PLACE, "parcel", {"destination_id": "bin", "policy_version": "\t"}),
+            (ActionType.PLACE, "parcel", {"destination_id": "bin", "manifest_id": "\n"}),
+            (ActionType.ASK_CONFIRM, None, {"question": " "}),
+            (ActionType.EXPRESS, None, {"emotion_state": " "}),
+            (ActionType.STOP, None, {"reason": ""}),
+        )
+        for action_type, target_id, parameters in cases:
+            with self.subTest(action_type=action_type, parameters=parameters):
+                result = self.registry.validate(_action(action_type, target_id=target_id, parameters=parameters))
+                self.assertFalse(result.is_valid)
 
     def test_ask_confirm_is_valid(self) -> None:
         result = self.registry.validate(_action(ActionType.ASK_CONFIRM, parameters={"question": "proceed?"}))


### PR DESCRIPTION
## Related Issue
Closes #103
## What changed

- Add immutable value and relational constraints to the canonical tool schemas.
- Require `required_confidence` to be finite and within the inclusive range `[0, 1]`.
- Bound `timeout_s` to `1–600` seconds.
- Bound `duration_ms` to `1–600000` milliseconds.
- Require destination capacity, occupancy and remaining counts to be non-negative.
- Require destination count snapshots to be complete and satisfy:
  `capacity = occupancy_after + remaining_after`.
- Reject empty and whitespace-only string tool parameters.
- Preserve bool-before-int handling and reject NaN and Infinity.
- Validate constraint definitions during tool registration.
- Make A5 `PolicyValidator` consume `ToolRegistry.validate()` directly, eliminating its duplicate validation implementation.
- Add the bounded Issue #103 Task Packet and focused regression tests.

## Interfaces affected
None.

No files under `interfaces/` or `libs/contracts/` were changed. Existing planner output remains compatible with the constrained schemas.

## Tests and commands

```text
python -m pytest tests/unit/test_tool_registry.py tests/unit/test_policy_validator.py tests/unit/test_agent_runtime.py -v
# 104 passed

python -m pytest -v
# 457 passed; one Windows symlink test was blocked by sandbox privileges

python -m pytest tests/unit/test_task_packet.py::test_path_validation_allows_future_paths_but_rejects_changed_links -v
# 1 passed when rerun with symlink permission

python tools/scripts/validate_contracts.py
# contract validation passed

python tools/scripts/validate_scenarios.py
# scenario validation passed for 12 frozen and 24 expanded manifests

python tools/scripts/check_context.py
# context validation passed

python tools/scripts/check_task_packet.py docs/task_packets/issue-103-tool-registry-constraints.json
# Task Packet validation passed

python -m ruff check services/agent_runtime/workbench_agent_runtime/tool_schemas.py services/agent_runtime/workbench_agent_runtime/tool_registry.py services/agent_runtime/workbench_agent_runtime/policy_validator.py tests/unit/test_tool_registry.py tests/unit/test_policy_validator.py
# All checks passed

python -m ruff format --check services/agent_runtime/workbench_agent_runtime/tool_schemas.py services/agent_runtime/workbench_agent_runtime/tool_registry.py services/agent_runtime/workbench_agent_runtime/policy_validator.py tests/unit/test_tool_registry.py tests/unit/test_policy_validator.py
# 5 files already formatted
```
## Evidence

Confidence accepts 0 and 1 and rejects out-of-range, NaN and Infinity values.
Timeout and duration accept documented boundary values and reject zero, negative and oversized values.
Destination counts reject negative, incomplete and arithmetically inconsistent snapshots.
Destination IDs, questions, reasons, policy/manifest IDs and other string parameters reject blank values.
Constraint mappings returned by the registry are immutable.
Unknown, mistyped and unsupported constraint definitions are rejected during registration.
A5 rejects the same unsafe values through the injected ToolRegistry.
Existing planner and default six-tool registration tests pass.
Contract, scenario, context, formatting and static checks pass.

## Risks and rollback

Existing callers that emit structurally valid but semantically unsafe parameters will now fail validation earlier. Partial destination count snapshots are no longer accepted; callers must provide all three count fields together or omit the snapshot.
PolicyValidator now delegates to the canonical registry, so it also applies registry semantic checks that were previously duplicated or absent from A5.
Rollback by reverting commit 1f71843.

## Checklist

- [ ] I changed only approved paths.
- [ ] Tests and contract checks pass.
- [ ] I covered normal and failure behavior.
- [ ] I updated examples/docs when an interface changed.
- [ ] I did not add secrets, private data or unreviewed assets.
