### PR TITLE
fix(agent): reject conflicting parcel manifest identities

### DIFF
--- a/docs/task_packets/parcel-manifest-identity-conflicts.json
+++ b/docs/task_packets/parcel-manifest-identity-conflicts.json
@@ -1,0 +1,50 @@
+{
+  "issue": 201,
+  "human_owner": "Quchaosheng",
+  "objective": "Reject contradictory parcel identity fields before emitting a manifest-matched plan.",
+  "allowed_paths": [
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "tests/unit/test_agent_runtime.py",
+    "docs/task_packets/parcel-manifest-identity-conflicts.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/world_model/**"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "hardware/safety/**"
+  ],
+  "input_refs": [
+    "interfaces/json_schema/task_graph.schema.json",
+    "interfaces/json_schema/semantic_action.schema.json",
+    "interfaces/examples/semantic-action-place.json",
+    "evaluation/golden-set-parcel-v0.1.json"
+  ],
+  "acceptance": [
+    "every parcel identity key present in both observation and manifest normalizes to the same value",
+    "a conflicting shared identity fails before a TaskGraph is returned",
+    "at least one normalized identity match remains required",
+    "cross-field identity fallback and no-manifest planning remain compatible"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_agent_runtime.py -q",
+    "python -m ruff check services/agent_runtime/workbench_agent_runtime/planner.py tests/unit/test_agent_runtime.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/parcel-manifest-identity-conflicts.json --base origin/main",
+    "python tools/scripts/check_context.py",
+    "make contract"
+  ],
+  "evidence": [
+    "focused planner regression test output",
+    "Ruff output",
+    "Task Packet boundary check",
+    "contract and context validation output"
+  ],
+  "stop_conditions": [
+    "an interface or contract change is required",
+    "World Model verification must change in the same pull request",
+    "motion, firmware, or physical hardware behavior is affected"
+  ]
+}

--- a/services/agent_runtime/workbench_agent_runtime/planner.py
+++ b/services/agent_runtime/workbench_agent_runtime/planner.py
@@ -467,7 +467,18 @@ def _validate_parcel_manifest(
         expected_values = set(manifest_identities[parcel_id].values())
         if not expected_values:
             raise ValueError(f"parcel manifest requires an identity for {parcel_id}")
-        observed_values = set(_parcel_identity_values(parcel_attributes[parcel_id]).values())
+        observed_identities = _parcel_identity_values(parcel_attributes[parcel_id])
+        conflicting_keys = [
+            key
+            for key, expected_value in manifest_identities[parcel_id].items()
+            if key in observed_identities and observed_identities[key] != expected_value
+        ]
+        if conflicting_keys:
+            raise ValueError(
+                f"parcel {parcel_id} identity conflicts with manifest {normalized_manifest_id}: "
+                f"{', '.join(conflicting_keys)}"
+            )
+        observed_values = set(observed_identities.values())
         if not observed_values:
             raise ValueError(f"parcel {parcel_id} has no readable identity for manifest {normalized_manifest_id}")
         if expected_values.isdisjoint(observed_values):

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -202,14 +202,29 @@ class PlannerTests(unittest.TestCase):
             "first": {"label_status": "verified", "condition": "intact", "tracking_id": "EXPECTED-1"},
             "second": {"label_status": "verified", "condition": "intact", "barcode": "WRONG-2"},
         }
-        with self.assertRaisesRegex(ValueError, "second identity does not match manifest"):
+        with self.assertRaisesRegex(ValueError, "second identity conflicts with manifest"):
             build_policy_routed_parcel_plan(
                 "Reject a parcel that is not on the inbound manifest",
                 observed,
                 parcel_manifest=manifest,
                 manifest_id="manifest-7",
             )
+        observed["second"] = {
+            "label_status": "verified",
+            "condition": "intact",
+            "tracking_id": "EXPECTED-2",
+            "barcode": "WRONG-2",
+        }
+        manifest["second"]["tracking_id"] = "EXPECTED-2"
+        with self.assertRaisesRegex(ValueError, "second identity conflicts with manifest manifest-7: barcode"):
+            build_policy_routed_parcel_plan(
+                "Reject conflicting identity fields",
+                observed,
+                parcel_manifest=manifest,
+                manifest_id="manifest-7",
+            )
         observed["second"].pop("barcode")
+        observed["second"].pop("tracking_id")
         with self.assertRaisesRegex(ValueError, "second has no readable identity"):
             build_policy_routed_parcel_plan(
                 "Reject a parcel whose manifest identity is missing",


### PR DESCRIPTION
## Summary

- reject conflicting identity values for keys shared by a parcel observation and manifest
- retain the existing normalized cross-field identity fallback
- cover the matching-tracking-ID/conflicting-barcode regression

Closes #201

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/unit/test_agent_runtime.py -q` — 12 passed
- `PYTHONPATH=... make test PYTHON=.venv/bin/python` — 446 passed
- `make contract` — passed
- `make scenario-check` — passed
- `make context-check` — passed
- `.venv/bin/python -m ruff check services/agent_runtime/workbench_agent_runtime/planner.py tests/unit/test_agent_runtime.py` — passed
- `.venv/bin/python -m ruff format --check services/agent_runtime/workbench_agent_runtime/planner.py tests/unit/test_agent_runtime.py` — passed
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/parcel-manifest-identity-conflicts.json --base origin/main` — passed