### PR TITLE
fix(world-model): refute conflicting parcel identities

### DIFF
--- a/docs/task_packets/world-model-parcel-manifest-identity-conflicts.json
+++ b/docs/task_packets/world-model-parcel-manifest-identity-conflicts.json
@@ -1,0 +1,50 @@
+{
+  "issue": 205,
+  "human_owner": "Quchaosheng",
+  "objective": "Refute contradictory parcel identity fields during independent World Model verification.",
+  "allowed_paths": [
+    "services/world_model/workbench_world_model/verifier.py",
+    "tests/unit/test_world_model.py",
+    "docs/task_packets/world-model-parcel-manifest-identity-conflicts.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/agent_runtime/**"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "hardware/safety/**"
+  ],
+  "input_refs": [
+    "interfaces/json_schema/verification_result.schema.json",
+    "interfaces/json_schema/world_state.schema.json",
+    "interfaces/examples/verification-insufficient-evidence.json",
+    "evaluation/golden-set-parcel-v0.1.json"
+  ],
+  "acceptance": [
+    "every identity key present in both WorldState attributes and manifest normalizes to the same value",
+    "a conflicting shared identity produces a refuted goal-not-satisfied result",
+    "at least one normalized identity match remains required",
+    "cross-field identity fallback and missing-evidence outcomes remain compatible"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_world_model.py -q",
+    "python -m ruff check services/world_model/workbench_world_model/verifier.py tests/unit/test_world_model.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/world-model-parcel-manifest-identity-conflicts.json --base origin/main",
+    "python tools/scripts/check_context.py",
+    "make contract"
+  ],
+  "evidence": [
+    "focused verifier regression test output",
+    "Ruff output",
+    "Task Packet boundary check",
+    "contract and context validation output"
+  ],
+  "stop_conditions": [
+    "an interface or contract change is required",
+    "agent planner behavior must change in the same pull request",
+    "motion, firmware, or physical hardware behavior is affected"
+  ]
+}

--- a/services/world_model/workbench_world_model/verifier.py
+++ b/services/world_model/workbench_world_model/verifier.py
@@ -60,7 +60,7 @@ def _validate_parcel_manifest(
     required: set[str],
     parcel_manifest: Mapping[str, Mapping[str, str]] | None,
     manifest_id: str | None,
-) -> tuple[str | None, dict[str, set[str]]]:
+) -> tuple[str | None, dict[str, dict[str, str]]]:
     if parcel_manifest is None:
         if manifest_id is not None:
             raise ValueError("manifest_id requires parcel_manifest")
@@ -72,7 +72,7 @@ def _validate_parcel_manifest(
     if set(parcel_manifest) != required:
         raise ValueError("parcel_manifest must contain exactly the required parcel IDs")
 
-    expected_identities: dict[str, set[str]] = {}
+    expected_identities: dict[str, dict[str, str]] = {}
     seen: dict[str, tuple[str, str]] = {}
     for parcel_id, attributes in parcel_manifest.items():
         if not isinstance(attributes, Mapping):
@@ -80,7 +80,7 @@ def _validate_parcel_manifest(
         unsupported = set(attributes) - set(PARCEL_IDENTITY_KEYS)
         if unsupported:
             raise ValueError(f"parcel manifest contains unsupported identity keys: {', '.join(sorted(unsupported))}")
-        expected_identities[parcel_id] = set()
+        expected_identities[parcel_id] = {}
         for key in PARCEL_IDENTITY_KEYS:
             if attributes.get(key) is None:
                 continue
@@ -91,7 +91,7 @@ def _validate_parcel_manifest(
                     f"duplicate parcel manifest identity: {previous[0]}.{previous[1]} and {parcel_id}.{key}"
                 )
             seen[identity] = (parcel_id, key)
-            expected_identities[parcel_id].add(identity)
+            expected_identities[parcel_id][key] = identity
         if not expected_identities[parcel_id]:
             raise ValueError(f"parcel manifest requires an identity for {parcel_id}")
     return manifest_id.strip(), expected_identities
@@ -377,7 +377,7 @@ def verify_parcel_policy(
             missing_attributes.append(f"{parcel_id}.label_status")
         if not isinstance(condition, str) or not condition.strip():
             missing_attributes.append(f"{parcel_id}.condition")
-        observed_identities: set[str] = set()
+        observed_identities: dict[str, str] = {}
         for identity_key in PARCEL_IDENTITY_KEYS:
             identity_value = observed.get(identity_key)
             if identity_value is None:
@@ -387,7 +387,7 @@ def verify_parcel_policy(
             except ValueError:
                 missing_attributes.append(f"{parcel_id}.{identity_key}")
                 continue
-            observed_identities.add(identity)
+            observed_identities[identity_key] = identity
             previous = seen_identities.get(identity)
             if previous is not None and previous[0] != parcel_id:
                 duplicate_identities.append(
@@ -398,7 +398,10 @@ def verify_parcel_policy(
         if normalized_manifest_id is not None:
             if not observed_identities:
                 missing_manifest_identities.append(parcel_id)
-            elif expected_identities[parcel_id].isdisjoint(observed_identities):
+            elif any(
+                key in expected_identities[parcel_id] and expected_identities[parcel_id][key] != identity
+                for key, identity in observed_identities.items()
+            ) or set(expected_identities[parcel_id].values()).isdisjoint(observed_identities.values()):
                 manifest_mismatches.append(parcel_id)
         if (
             not isinstance(label_status, str)

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -409,6 +409,21 @@ class WorldModelTests(unittest.TestCase):
         self.assertIn("box-b", result.claim)
         self.assertIn("label_unreadable", result.claim)
 
+        manifest["box-a"]["barcode"] = "BARCODE-A"
+        state.entity_attributes["box-a"]["barcode"] = "WRONG-BARCODE"
+        result = verify_parcel_policy(
+            state,
+            "task-sort-parcels",
+            ["box-a", "box-b", "box-c"],
+            parcel_manifest=manifest,
+            manifest_id="manifest-7",
+        )
+        self.assertEqual(result.status, VerificationStatus.REFUTED)
+        self.assertEqual(result.reason_code, ReasonCode.GOAL_NOT_SATISFIED)
+        self.assertIn("manifest_mismatches=['box-a']", result.claim)
+        manifest["box-a"].pop("barcode")
+        state.entity_attributes["box-a"].pop("barcode")
+
         state.entity_locations["box-b"] = "in:pickup_shelf"
         result = verify_parcel_policy(
             state,


### PR DESCRIPTION
## Summary

- preserve manifest identities by field during independent verification
- refute a parcel when any shared identity field conflicts
- retain normalized cross-field identity matching and missing-evidence outcomes

Closes #205

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/unit/test_world_model.py -q` — 17 passed
- `PYTHONPATH=... make test PYTHON=.venv/bin/python` — 446 passed
- `make contract` — passed
- `make scenario-check` — passed
- `make context-check` — passed
- `.venv/bin/python -m ruff check services/world_model/workbench_world_model/verifier.py tests/unit/test_world_model.py` — passed
- `.venv/bin/python -m ruff format --check services/world_model/workbench_world_model/verifier.py tests/unit/test_world_model.py` — passed
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/world-model-parcel-manifest-identity-conflicts.json --base origin/main` — passed