### PR TITLE
fix(kernel): reject non-string serialized message keys

### DIFF
--- a/docs/task_packets/kernel-serialized-message-keys.json
+++ b/docs/task_packets/kernel-serialized-message-keys.json
@@ -1,0 +1,46 @@
+{
+  "issue": 208,
+  "human_owner": "Quchaosheng",
+  "objective": "Reject non-string serialized message keys through the kernel integrity-error boundary.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/communication.py",
+    "tests/unit/test_kernel_envelope_lifecycle.py",
+    "docs/task_packets/kernel-serialized-message-keys.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**"
+  ],
+  "input_refs": [
+    "interfaces/json_schema/world_event.schema.json",
+    "interfaces/examples/observation-red-block.json",
+    "interfaces/examples/action-result-place-confirmed.json"
+  ],
+  "acceptance": [
+    "non-string serialized message keys raise MessageIntegrityError",
+    "string-only reserved-field operations never receive a non-string key",
+    "valid round trips, reserved-field rejection, and checksum tamper detection remain unchanged"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_kernel_envelope_lifecycle.py -q",
+    "python -m ruff check libs/kernel/workbench/kernel/communication.py tests/unit/test_kernel_envelope_lifecycle.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/kernel-serialized-message-keys.json --base origin/main",
+    "python tools/scripts/check_context.py",
+    "make contract"
+  ],
+  "evidence": [
+    "focused kernel envelope regression output",
+    "Ruff output",
+    "Task Packet boundary check",
+    "contract and context validation output"
+  ],
+  "stop_conditions": [
+    "an interface or contract change is required",
+    "broker or lifecycle semantics must change",
+    "robot control or firmware behavior is affected"
+  ]
+}

--- a/libs/kernel/workbench/kernel/communication.py
+++ b/libs/kernel/workbench/kernel/communication.py
@@ -120,6 +120,8 @@ class Message:
     def from_dict(cls, value: Mapping[str, Any]) -> "Message":
         if not isinstance(value, Mapping):
             raise MessageIntegrityError("serialized message must be an object")
+        if any(not isinstance(key, str) for key in value):
+            raise MessageIntegrityError("serialized message keys must be strings")
         required = {"_message_type", "_version", "_checksum", "_actor"}
         missing = required - set(value)
         if missing:

--- a/tests/unit/test_kernel_envelope_lifecycle.py
+++ b/tests/unit/test_kernel_envelope_lifecycle.py
@@ -49,6 +49,11 @@ def test_message_round_trip_verifies_checksum_and_reserved_fields() -> None:
     with pytest.raises(MessageIntegrityError, match="reserved"):
         Message.from_dict(encoded)
 
+    encoded = Message({"target": "red_block"}, "grasp", "1.0.0", "planner").to_dict()
+    encoded[1] = "unsupported"
+    with pytest.raises(MessageIntegrityError, match="keys must be strings"):
+        Message.from_dict(encoded)
+
 
 def test_message_rejects_non_json_and_non_finite_payloads() -> None:
     with pytest.raises(ValueError, match="finite"):


### PR DESCRIPTION
## Summary

- validate serialized mapping key types before reserved-field inspection
- return `MessageIntegrityError` instead of leaking `AttributeError`
- cover non-string ingress keys without changing valid envelope behavior

Closes #208

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/unit/test_kernel_envelope_lifecycle.py -q` — 5 passed
- isolated merged-package `make test` — 446 passed
- `make contract` — passed
- `make scenario-check` — passed
- `make context-check` — passed
- `.venv/bin/python -m ruff check libs/kernel/workbench/kernel/communication.py tests/unit/test_kernel_envelope_lifecycle.py` — passed
- `.venv/bin/python -m ruff format --check libs/kernel/workbench/kernel/communication.py tests/unit/test_kernel_envelope_lifecycle.py` — passed
- `.venv/bin/python tools/scripts/check_task_packet.py docs/task_packets/kernel-serialized-message-keys.json --base origin/main` — passed