### PR TITLE
fix(hardware-validation): make evidence registration atomic

### DIFF
--- a/docs/task_packets/hardware-validation-evidence.json
+++ b/docs/task_packets/hardware-validation-evidence.json
@@ -1,7 +1,7 @@
 {
   "issue": 87,
   "human_owner": "Quchaosheng",
-  "objective": "Bind physical fault-validation results to immutable raw evidence and keep release status fail closed.",
+  "objective": "Atomically bind physical fault-validation results to immutable raw evidence and keep release status fail closed.",
   "allowed_paths": [
     "hardware/validation/**",
     "tests/hardware/**",
@@ -22,17 +22,20 @@
     "every fault scenario has an owner, procedure, expected safe response, and evidence requirement",
     "registration binds scenario, unit, revisions, people, instruments, calibration, timestamp, result, and raw-file hashes",
     "duplicate identifiers, unknown scenarios, wrong revisions, missing files, and changed files fail closed",
+    "concurrent Linux threads and processes cannot create duplicate identifiers or lose distinct records",
+    "a failed append restores the previously valid JSONL register",
     "summary CSV edits cannot promote a scenario to PASS",
     "reports distinguish simulation, bench, and physical evidence"
   ],
   "commands": [
     "python tools/scripts/check_task_packet.py docs/task_packets/hardware-validation-evidence.json",
     "python hardware/validation/tools/validate_validation.py",
-    "python -m pytest tests/hardware -k validation -v"
+    "python -m pytest tests/hardware -k validation -v",
+    "python -m ruff check hardware/validation/tools/evidence.py tests/hardware/test_engineering_packages.py"
   ],
   "evidence": [
     "hardware/validation/generated/validation_report.json",
-    "hardware validation test output"
+    "hardware validation test output including process, thread, and short-write regressions"
   ],
   "stop_conditions": [
     "physical execution would be claimed without a valid evidence record",

--- a/hardware/validation/tools/evidence.py
+++ b/hardware/validation/tools/evidence.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
+import os
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -138,10 +140,23 @@ def register(
     scenarios: set[str],
     units: dict[str, tuple[str, str]],
 ) -> None:
-    existing = validate_register(path, root=root, scenarios=scenarios, units=units)
-    if record.get("evidence_id") in {item["evidence_id"] for item in existing}:
-        raise EvidenceError("duplicate evidence_id")
-    validate_record(record, root=root, scenarios=scenarios, units=units)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8", newline="\n") as handle:
-        handle.write(json.dumps(record, allow_nan=False, ensure_ascii=False, sort_keys=True) + "\n")
+    descriptor = os.open(path, os.O_APPEND | os.O_CREAT | os.O_RDWR, 0o666)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        existing = validate_register(path, root=root, scenarios=scenarios, units=units)
+        if record.get("evidence_id") in {item["evidence_id"] for item in existing}:
+            raise EvidenceError("duplicate evidence_id")
+        validate_record(record, root=root, scenarios=scenarios, units=units)
+        payload = (json.dumps(record, allow_nan=False, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+        original_size = os.fstat(descriptor).st_size
+        try:
+            if os.write(descriptor, payload) != len(payload):
+                raise OSError("short write while appending evidence")
+            os.fsync(descriptor)
+        except OSError:
+            os.ftruncate(descriptor, original_size)
+            os.fsync(descriptor)
+            raise
+    finally:
+        os.close(descriptor)

--- a/tests/hardware/test_engineering_packages.py
+++ b/tests/hardware/test_engineering_packages.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import csv
 import importlib.util
 import json
+import multiprocessing
 import re
 import tempfile
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -17,6 +21,23 @@ def load_module(name: str, path: Path):
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def _register_evidence_process(module_path, register, root, record, barrier, results) -> None:
+    module = load_module("validation_evidence_process", module_path)
+    barrier.wait()
+    try:
+        module.register(
+            register,
+            record,
+            root=root,
+            scenarios={"VAL5-01"},
+            units={"UNIT-001": ("EVT1", "a" * 64)},
+        )
+    except module.EvidenceError as exc:
+        results.put(("rejected", str(exc)))
+    else:
+        results.put(("accepted", ""))
 
 
 class MechanicalPackageTests(unittest.TestCase):
@@ -202,6 +223,38 @@ class QualityPackageTests(unittest.TestCase):
 
 
 class ValidationPackageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tempdir.cleanup)
+        self.root = Path(tempdir.name)
+        self.raw = self.root / "scope.csv"
+        self.raw.write_text("time,current\n0,0\n", encoding="utf-8")
+        self.module_path = ROOT / "hardware/validation/tools/evidence.py"
+        self.module = load_module("validation_evidence", self.module_path)
+        self.register = self.root / "register.jsonl"
+        self.kwargs = {
+            "root": self.root,
+            "scenarios": {"VAL5-01"},
+            "units": {"UNIT-001": ("EVT1", "a" * 64)},
+        }
+
+    def _record(self, evidence_id: str) -> dict:
+        return {
+            "evidence_id": evidence_id,
+            "scenario_id": "VAL5-01",
+            "unit_id": "UNIT-001",
+            "hardware_revision": "EVT1",
+            "config_hash": "a" * 64,
+            "operator": "operator",
+            "reviewer": "reviewer",
+            "captured_at": "2026-08-18T08:00:00Z",
+            "evidence_kind": "physical",
+            "instrument_refs": ["SCOPE-01"],
+            "calibration_refs": ["CAL-01"],
+            "raw_files": {"scope.csv": self.module.sha256(self.raw)},
+            "result": "PASS",
+        }
+
     def test_validation_package_has_fault_library_and_no_fake_units(self) -> None:
         module = load_module("validation_checks", ROOT / "hardware/validation/tools/validate_validation.py")
         report = module.validate()
@@ -211,41 +264,70 @@ class ValidationPackageTests(unittest.TestCase):
         self.assertEqual(report["physical_results"], "NOT_EXECUTED")
 
     def test_evidence_registration_fails_closed_and_accepts_valid_records(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            raw = root / "scope.csv"
-            raw.write_text("time,current\n0,0\n", encoding="utf-8")
-            module = load_module("validation_evidence", ROOT / "hardware/validation/tools/evidence.py")
-            base = {
-                "evidence_id": "EVIDENCE-001",
-                "scenario_id": "VAL5-01",
-                "unit_id": "UNIT-001",
-                "hardware_revision": "EVT1",
-                "config_hash": "a" * 64,
-                "operator": "operator",
-                "reviewer": "reviewer",
-                "captured_at": "2026-08-18T08:00:00Z",
-                "evidence_kind": "physical",
-                "instrument_refs": ["SCOPE-01"],
-                "calibration_refs": ["CAL-01"],
-                "raw_files": {"scope.csv": module.sha256(raw)},
-                "result": "PASS",
-            }
-            register = root / "register.jsonl"
-            kwargs = {
-                "root": root,
-                "scenarios": {"VAL5-01"},
-                "units": {"UNIT-001": ("EVT1", "a" * 64)},
-            }
-            module.register(register, base, **kwargs)
-            self.assertEqual(module.validate_register(register, **kwargs), [base])
-            with self.assertRaisesRegex(module.EvidenceError, "duplicate"):
-                module.register(register, base, **kwargs)
-            with self.assertRaisesRegex(module.EvidenceError, "revision mismatch"):
-                module.validate_record({**base, "hardware_revision": "EVT2"}, **kwargs)
-            raw.unlink()
-            with self.assertRaisesRegex(module.EvidenceError, "missing"):
-                module.validate_register(register, **kwargs)
+        base = self._record("EVIDENCE-001")
+        self.module.register(self.register, base, **self.kwargs)
+        self.assertEqual(self.module.validate_register(self.register, **self.kwargs), [base])
+        with self.assertRaisesRegex(self.module.EvidenceError, "duplicate"):
+            self.module.register(self.register, base, **self.kwargs)
+        with self.assertRaisesRegex(self.module.EvidenceError, "revision mismatch"):
+            self.module.validate_record({**base, "hardware_revision": "EVT2"}, **self.kwargs)
+        self.raw.unlink()
+        with self.assertRaisesRegex(self.module.EvidenceError, "missing"):
+            self.module.validate_register(self.register, **self.kwargs)
+
+    def test_concurrent_duplicate_evidence_id_has_one_process_winner(self) -> None:
+        record = self._record("EVIDENCE-DUPLICATE")
+        context = multiprocessing.get_context("fork")
+        barrier = context.Barrier(2)
+        results = context.Queue()
+        processes = [
+            context.Process(
+                target=_register_evidence_process,
+                args=(self.module_path, self.register, self.root, record, barrier, results),
+            )
+            for _ in range(2)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(10)
+            if process.is_alive():
+                process.terminate()
+                process.join()
+            self.assertEqual(process.exitcode, 0)
+        outcomes = [results.get(timeout=2) for _ in processes]
+        self.assertEqual(sorted(status for status, _ in outcomes), ["accepted", "rejected"])
+        self.assertIn("duplicate evidence_id", next(message for status, message in outcomes if status == "rejected"))
+        self.assertEqual(self.module.validate_register(self.register, **self.kwargs), [record])
+
+    def test_concurrent_distinct_evidence_ids_are_both_retained(self) -> None:
+        barrier = threading.Barrier(2)
+
+        def register_record(record: dict) -> None:
+            barrier.wait()
+            self.module.register(self.register, record, **self.kwargs)
+
+        records = [self._record(f"EVIDENCE-{index}") for index in range(2)]
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            for future in [executor.submit(register_record, record) for record in records]:
+                future.result(timeout=10)
+        actual = self.module.validate_register(self.register, **self.kwargs)
+        self.assertEqual({record["evidence_id"] for record in actual}, {"EVIDENCE-0", "EVIDENCE-1"})
+
+    def test_failed_append_restores_the_valid_register(self) -> None:
+        first = self._record("EVIDENCE-001")
+        self.module.register(self.register, first, **self.kwargs)
+        original = self.register.read_bytes()
+        write = self.module.os.write
+
+        def short_write(descriptor: int, payload: bytes) -> int:
+            return write(descriptor, payload[: len(payload) // 2])
+
+        with mock.patch.object(self.module.os, "write", side_effect=short_write):
+            with self.assertRaisesRegex(OSError, "short write"):
+                self.module.register(self.register, self._record("EVIDENCE-002"), **self.kwargs)
+        self.assertEqual(self.register.read_bytes(), original)
+        self.assertEqual(self.module.validate_register(self.register, **self.kwargs), [first])
 
     def test_physical_result_requires_physical_pass_for_every_scenario(self) -> None:
         module = load_module("validation_result_derivation", ROOT / "hardware/validation/tools/validate_validation.py")


### PR DESCRIPTION
## Related Issue

Closes #87.

## What changed

- serialize evidence-register validation, duplicate detection, and append under one Linux `flock` critical section
- write each JSONL record with one `O_APPEND` write and `fsync`
- restore the prior file length after a short write or persistence failure
- cover duplicate concurrent processes, distinct concurrent threads, failed appends, and existing validation behavior
- update the existing bounded Task Packet; no schema, firmware, robot-control, or physical-result changes

## Verification

- `python -m pytest tests/hardware/test_engineering_packages.py -k validation -v` — 7 passed
- `python -m pytest tests/hardware -v` — 32 passed
- `python tools/scripts/check_task_packet.py docs/task_packets/hardware-validation-evidence.json` — passed
- `python hardware/validation/tools/validate_validation.py` — package valid; physical status remains `PHYSICAL_EXECUTION_REQUIRED`
- `make check` — Ruff/format passed, 449 tests passed, contract/scenario/golden/context checks and scripted/offline demos passed

## Platform limits

`fcntl.flock` is the supported Linux/Ubuntu implementation and is advisory: every writer must use this registrar. Lock behavior on remote/network filesystems depends on the filesystem, so the controlled evidence register should remain on a local Linux filesystem.

## Risk and rollback

The register remains JSONL and existing post-hoc validation is unchanged. Reverting commit `1b027dc` restores the prior append behavior; no evidence records are migrated or rewritten by this change.
