### PR TITLE
fix(kernel): prevent version registry lost updates

### DIFF
--- a/docs/task_packets/kernel-version-registry.json
+++ b/docs/task_packets/kernel-version-registry.json
@@ -1,7 +1,7 @@
 {
   "issue": "97",
   "human_owner": "Quchaosheng",
-  "objective": "Prevent published schema versions from being silently overwritten while preserving idempotent registration.",
+  "objective": "Prevent stale registry instances and concurrent writers from losing or replacing published schema versions.",
   "allowed_paths": [
     "libs/kernel/workbench/kernel/version_registry.py",
     "libs/kernel/tests/test_k1_k10.py",
@@ -24,6 +24,8 @@
     "failed persistence does not update in-memory state",
     "identical registration is idempotent and does not rewrite the registry",
     "conflicting content for an existing schema version is rejected before persistence",
+    "stale instances preserve unrelated versions and recheck conflicts against disk",
+    "concurrent writers serialize read-modify-write and use unique temporary files",
     "repository lint and tests pass"
   ],
   "commands": [
@@ -36,6 +38,7 @@
     "registry reopen regression assertions",
     "malformed and failed-write assertions",
     "idempotent and conflicting registration assertions",
+    "stale-instance and concurrent-writer regression assertions",
     "K1-K10 integration test output",
     "repository test output"
   ],

--- a/libs/kernel/workbench/kernel/version_registry.py
+++ b/libs/kernel/workbench/kernel/version_registry.py
@@ -1,7 +1,11 @@
 """K3: durable schema version registry."""
 
+import fcntl
 import json
+import os
+import tempfile
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -21,9 +25,9 @@ class VersionRegistry:
         self._lock = threading.RLock()
         self._load()
 
-    def _load(self) -> None:
+    def _read(self) -> dict[str, dict[str, Any]]:
         if not self.registry_file.exists():
-            return
+            return {}
         try:
             payload = json.loads(self.registry_file.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, json.JSONDecodeError) as exc:
@@ -35,32 +39,70 @@ class VersionRegistry:
             for name, versions in payload.items()
         ):
             raise VersionRegistryError(f"registry must map schema names to version maps: {self.registry_file}")
-        self.versions = payload
+        return payload
 
-    def _persist(self, versions: dict[str, dict[str, Any]]) -> None:
+    def _load(self) -> None:
+        self.versions = self._read()
+
+    @contextmanager
+    def _file_lock(self):
+        """Serialize registry writers across threads and processes."""
         try:
             self.registry_file.parent.mkdir(parents=True, exist_ok=True)
-            temporary = self.registry_file.with_name(f".{self.registry_file.name}.tmp")
+            lock_path = self.registry_file.with_name(f".{self.registry_file.name}.lock")
+            with lock_path.open("a+b") as lock_file:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        except OSError as exc:
+            raise VersionRegistryError(f"registry could not be locked: {self.registry_file}") from exc
+
+    def _persist(self, versions: dict[str, dict[str, Any]]) -> None:
+        temporary_name: str | None = None
+        try:
+            self.registry_file.parent.mkdir(parents=True, exist_ok=True)
             serialized = json.dumps(versions, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-            temporary.write_text(serialized, encoding="utf-8")
-            temporary.replace(self.registry_file)
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                prefix=f".{self.registry_file.name}.",
+                suffix=".tmp",
+                dir=self.registry_file.parent,
+                delete=False,
+            ) as temporary:
+                temporary_name = temporary.name
+                temporary.write(serialized)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+            os.replace(temporary_name, self.registry_file)
+            temporary_name = None
         except (OSError, TypeError, ValueError) as exc:
             raise VersionRegistryError(f"registry could not be persisted: {self.registry_file}") from exc
+        finally:
+            if temporary_name is not None:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
 
     def register_schema(self, name: str, version: str, content: Any) -> None:
         if not isinstance(name, str) or not name:
             raise ValueError("schema name must be a non-empty string")
         if not isinstance(version, str) or not version:
             raise ValueError("schema version must be a non-empty string")
-        with self._lock:
-            existing = self.versions.get(name, {}).get(version)
-            if version in self.versions.get(name, {}):
-                if existing == content:
+        with self._lock, self._file_lock():
+            current = self._read()
+            registered = current.get(name, {})
+            if version in registered:
+                if registered[version] == content:
+                    self.versions = current
                     return
                 raise VersionConflictError(
                     f"schema {name!r} version {version!r} is already registered with different content"
                 )
-            updated = {schema: dict(versions) for schema, versions in self.versions.items()}
+            updated = {schema: dict(versions) for schema, versions in current.items()}
             updated.setdefault(name, {})[version] = content
             self._persist(updated)
             self.versions = updated

--- a/tests/unit/test_kernel_version_registry.py
+++ b/tests/unit/test_kernel_version_registry.py
@@ -1,5 +1,7 @@
 import json
+import multiprocessing
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -8,6 +10,16 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 
 from workbench.kernel.version_registry import VersionConflictError, VersionRegistry, VersionRegistryError
+
+
+class SlowRegistry(VersionRegistry):
+    def _persist(self, versions: dict[str, dict[str, object]]) -> None:
+        time.sleep(0.01)
+        super()._persist(versions)
+
+
+def _register_from_process(path: str, index: int) -> None:
+    SlowRegistry(Path(path)).register_schema("process", str(index), {"index": index})
 
 
 def test_registry_survives_reopen_and_keeps_versions_separate(tmp_path: Path) -> None:
@@ -72,3 +84,57 @@ def test_conflicting_registration_is_rejected_without_writing(tmp_path: Path) ->
     assert path.read_bytes() == before
     assert not path.with_name(f".{path.name}.tmp").exists()
     assert VersionRegistry(path).versions == registry.versions
+
+
+def test_failed_replace_keeps_original_and_removes_temporary_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "registry.json"
+    registry = VersionRegistry(path)
+    registry.register_schema("action", "1.0.0", {"required": ["id"]})
+    before = path.read_bytes()
+
+    def fail_replace(source: str, destination: Path) -> None:
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr("workbench.kernel.version_registry.os.replace", fail_replace)
+    with pytest.raises(VersionRegistryError, match="could not be persisted"):
+        registry.register_schema("result", "1.0.0", {"type": "object"})
+
+    assert path.read_bytes() == before
+    assert registry.versions == {"action": {"1.0.0": {"required": ["id"]}}}
+    assert list(tmp_path.glob(f".{path.name}.*.tmp")) == []
+
+
+def test_stale_instances_merge_disjoint_schema_versions(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    first = VersionRegistry(path)
+    second = VersionRegistry(path)
+
+    first.register_schema("action", "1.0.0", {"type": "object"})
+    second.register_schema("result", "1.0.0", {"type": "object"})
+
+    assert VersionRegistry(path).versions == {
+        "action": {"1.0.0": {"type": "object"}},
+        "result": {"1.0.0": {"type": "object"}},
+    }
+
+
+def test_stale_instance_rechecks_conflicting_version(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    first = VersionRegistry(path)
+    second = VersionRegistry(path)
+    first.register_schema("action", "1.0.0", {"required": ["id"]})
+
+    with pytest.raises(VersionConflictError, match="already registered"):
+        second.register_schema("action", "1.0.0", {"required": ["target"]})
+
+    assert VersionRegistry(path).versions == {"action": {"1.0.0": {"required": ["id"]}}}
+
+
+def test_concurrent_process_registrations_are_not_lost(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    with multiprocessing.get_context("fork").Pool(4) as processes:
+        processes.starmap(_register_from_process, [(str(path), index) for index in range(8)])
+
+    assert set(VersionRegistry(path).versions["process"]) == {str(index) for index in range(8)}


### PR DESCRIPTION
## Summary
- serialize registry read-modify-write with the Ubuntu standard-library `fcntl.flock`
- reload durable state inside the lock before idempotency and conflict checks
- publish through unique, fsynced temporary files and preserve the original on failure
- cover stale instances, conflicting stale writes, process concurrency, and replace failures

## Verification
- `make check` — 451 tests passed; lint, format, contracts, scenarios, golden set, context, and demos passed
- `python -m pytest tests/unit/test_kernel_version_registry.py -q` — 9 passed
- `python tools/scripts/check_task_packet.py --all --base origin/main` — passed

Closes #97