### PR TITLE
fix(kernel): validate generated MCU frame branches

### DIFF
--- a/docs/task_packets/kernel-schema-mcu-branch-validation.json
+++ b/docs/task_packets/kernel-schema-mcu-branch-validation.json
@@ -1,0 +1,47 @@
+{
+  "issue": "204",
+  "human_owner": "Quchaosheng",
+  "objective": "Make the generated MCU Pydantic model enforce the current protocol branch semantics without changing the canonical interface.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/schema_compiler.py",
+    "tests/unit/test_kernel_schema_compiler.py",
+    "tests/unit/test_mcu_protocol_contract.py",
+    "docs/task_packets/kernel-schema-mcu-branch-validation.json"
+  ],
+  "read_only_paths": [
+    "interfaces/json_schema/mcu_protocol.schema.json",
+    "interfaces/examples/mcu-frame-stop-ack.json",
+    "libs/contracts/workbench_contracts/models.py",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**"
+  ],
+  "acceptance": [
+    "generated MCU frames enforce branch-required fields",
+    "generated MCU frames reject branch-forbidden fields including legacy sent_at",
+    "generated MCU frames enforce current branch const and enum relationships",
+    "valid repository MCU frame vectors remain accepted",
+    "general schema compiler behavior remains bounded"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_kernel_schema_compiler.py tests/unit/test_mcu_protocol_contract.py -q",
+    "python -m ruff check libs/kernel/workbench/kernel/schema_compiler.py tests/unit/test_kernel_schema_compiler.py tests/unit/test_mcu_protocol_contract.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/kernel-schema-mcu-branch-validation.json --base origin/main",
+    "make contract",
+    "make context-check"
+  ],
+  "evidence": [
+    "generated-model acceptance matches the canonical MCU schema corpus",
+    "focused unit and contract checks",
+    "Task Packet boundary validation"
+  ],
+  "stop_conditions": [
+    "an interfaces schema change is required",
+    "the canonical contracts package must change",
+    "firmware or robot-control changes are required",
+    "a general JSON Schema compiler rewrite is required"
+  ]
+}

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -31,6 +31,14 @@ PROPERTY_KEYWORDS = {
     "required",
     "type",
 }
+RUNTIME_SCHEMA_KEYWORDS = (ROOT_KEYWORDS | PROPERTY_KEYWORDS) - {"$ref"} | {
+    "anyOf",
+    "const",
+    "else",
+    "if",
+    "not",
+    "then",
+}
 
 
 class SchemaValidationError(ValueError):
@@ -59,6 +67,20 @@ def _enum_contains(enum: list[Any], value: Any) -> bool:
     return any(type(candidate) is type(value) and candidate == value for candidate in enum)
 
 
+def _schema_matches(
+    value: Any,
+    schema: dict[str, Any],
+    *,
+    references: dict[str, dict[str, Any]] | None,
+    location: str,
+) -> bool:
+    try:
+        validate_schema_instance(value, schema, references=references, location=location)
+    except SchemaValidationError:
+        return False
+    return True
+
+
 def validate_schema_instance(
     value: Any,
     schema: dict[str, Any],
@@ -76,6 +98,9 @@ def validate_schema_instance(
             raise SchemaValidationError(f"unresolved schema reference {reference!r} at {location}")
         validate_schema_instance(value, referenced, references=references, location=location)
         return
+
+    if "const" in schema and (type(value) is not type(schema["const"]) or value != schema["const"]):
+        raise SchemaValidationError(f"value at {location} does not match const {schema['const']!r}")
 
     if "enum" in schema:
         enum = schema["enum"]
@@ -129,22 +154,24 @@ def validate_schema_instance(
                     location=f"{location}.{field_name}",
                 )
 
-    for conditional in schema.get("allOf", []):
-        condition_properties = conditional.get("if", {}).get("properties", {})
-        condition_matches = (
-            all(
-                field_name in value
-                and isinstance(definition, dict)
-                and "const" in definition
-                and type(value[field_name]) is type(definition["const"])
-                and value[field_name] == definition["const"]
-                for field_name, definition in condition_properties.items()
-            )
-            if isinstance(value, dict)
-            else False
-        )
-        if condition_matches:
-            validate_schema_instance(value, conditional.get("then", {}), references=references, location=location)
+    any_of = schema.get("anyOf")
+    if any_of is not None and not any(
+        _schema_matches(value, candidate, references=references, location=location) for candidate in any_of
+    ):
+        raise SchemaValidationError(f"value at {location} does not match any allowed schema")
+
+    excluded = schema.get("not")
+    if excluded is not None and _schema_matches(value, excluded, references=references, location=location):
+        raise SchemaValidationError(f"value at {location} matches a forbidden schema")
+
+    for constraint in schema.get("allOf", []):
+        validate_schema_instance(value, constraint, references=references, location=location)
+
+    condition = schema.get("if")
+    if condition is not None:
+        branch = "then" if _schema_matches(value, condition, references=references, location=location) else "else"
+        if branch in schema:
+            validate_schema_instance(value, schema[branch], references=references, location=location)
 
 
 def _model_name(value: str) -> str:
@@ -264,7 +291,59 @@ def _validate_definition(definition: dict[str, Any], location: str) -> None:
             _validate_definition(nested, f"{location}.{field_name}")
 
 
+def _validate_runtime_schema(schema: dict[str, Any], location: str) -> None:
+    unsupported = set(schema) - RUNTIME_SCHEMA_KEYWORDS
+    if unsupported:
+        raise ValueError(f"unsupported runtime schema keyword(s) at {location}: {sorted(unsupported)}")
+    required = schema.get("required")
+    if required is not None and (
+        not isinstance(required, list) or any(not isinstance(field_name, str) for field_name in required)
+    ):
+        raise ValueError(f"required must be a string list at {location}")
+    properties = schema.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict):
+            raise ValueError(f"properties must be an object at {location}")
+        for field_name, definition in properties.items():
+            if not isinstance(definition, dict):
+                raise ValueError(f"property definition must be an object: {location}.{field_name}")
+            _validate_runtime_schema(definition, f"{location}.{field_name}")
+    items = schema.get("items")
+    if items is not None:
+        if not isinstance(items, dict):
+            raise ValueError(f"items must be an object at {location}")
+        _validate_runtime_schema(items, f"{location}.items")
+    for schema_keyword in ("allOf", "anyOf"):
+        branches = schema.get(schema_keyword)
+        if branches is not None:
+            if not isinstance(branches, list) or not branches:
+                raise ValueError(f"{schema_keyword} must be a non-empty list at {location}")
+            for index, branch in enumerate(branches, start=1):
+                if not isinstance(branch, dict):
+                    raise ValueError(f"{schema_keyword} entry must be an object at {location}[{index}]")
+                _validate_runtime_schema(branch, f"{location}.{schema_keyword}[{index}]")
+    for schema_keyword in ("if", "then", "else", "not"):
+        branch = schema.get(schema_keyword)
+        if branch is not None:
+            if not isinstance(branch, dict):
+                raise ValueError(f"{schema_keyword} must be an object at {location}")
+            _validate_runtime_schema(branch, f"{location}.{schema_keyword}")
+
+
 def _conditional_validators(schema: dict[str, Any], name: str) -> tuple[list[str], list[dict[str, Any]]]:
+    if name == "mcu_protocol":
+        _validate_runtime_schema(schema, name)
+        return (
+            [
+                "",
+                '    @model_validator(mode="before")',
+                "    @classmethod",
+                "    def _validate_mcu_protocol(cls, value):",
+                "        validate_schema_instance(value, MCU_PROTOCOL_SCHEMA)",
+                "        return value",
+            ],
+            schema.get("allOf", []),
+        )
     lines: list[str] = []
     metadata: list[dict[str, Any]] = []
     for index, conditional in enumerate(schema.get("allOf", []), start=1):
@@ -461,8 +540,12 @@ class SchemaCompiler:
             self._append_python_model(model_name, schema, name, class_blocks, {})
             python_code = (
                 "from typing import Annotated, Any, Literal\n\n"
-                "from pydantic import BaseModel, ConfigDict, Field, model_validator\n\n\n" + "\n\n".join(class_blocks)
+                "from pydantic import BaseModel, ConfigDict, Field, model_validator\n"
             )
+            if name == "mcu_protocol":
+                python_code += "from workbench.kernel.schema_compiler import validate_schema_instance\n"
+                python_code += f"\n\nMCU_PROTOCOL_SCHEMA = {schema!r}\n"
+            python_code += "\n\n" + "\n\n".join(class_blocks)
             typescript_body = "\n".join(typescript_fields)
             metadata = {
                 "fields": constraint_metadata,

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -1,7 +1,10 @@
+import json
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
 from pydantic import BaseModel
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -89,14 +92,38 @@ def test_generated_models_validate_local_references(tmp_path: Path) -> None:
         observation(**valid)
 
 
-def test_generated_mcu_model_enforces_conditional_ranges(tmp_path: Path) -> None:
+def test_generated_mcu_model_enforces_protocol_branches(tmp_path: Path) -> None:
     mcu_frame = generated_model(tmp_path, "mcu_protocol", "McuFrame")
-    with pytest.raises(ValueError, match="frame_kind"):
-        mcu_frame(frame_id="f", frame_kind="command", command_id=40000, sent_at="t")
-    with pytest.raises(ValueError, match="frame_kind"):
-        mcu_frame(frame_id="f", frame_kind="stop", command_id=10, sent_at="t")
-    assert mcu_frame(frame_id="f", frame_kind="command", command_id=32767, sent_at="t")
-    assert mcu_frame(frame_id="f", frame_kind="stop", command_id=32768, sent_at="t")
+    schema = json.loads((ROOT / "interfaces/json_schema/mcu_protocol.schema.json").read_text(encoding="utf-8"))
+    valid = json.loads((ROOT / "interfaces/examples/mcu-frame-stop-ack.json").read_text(encoding="utf-8"))
+    invalid = []
+    for field in ("protocol_version", "opcode", "sent_at_us"):
+        payload = deepcopy(valid)
+        payload.pop(field)
+        invalid.append(payload)
+    for updates in (
+        {"sent_at": "legacy"},
+        {"opcode": "hold"},
+        {"result_code": 0, "fault_code": "stop_rejected", "device_mode": "faulted"},
+        {"result_code": 1, "fault_code": "none", "device_mode": "stopped"},
+    ):
+        payload = {**valid, **updates}
+        invalid.append(payload)
+
+    assert mcu_frame.model_validate(valid)
+    for payload in invalid:
+        assert list(Draft202012Validator(schema).iter_errors(payload))
+        with pytest.raises(ValueError):
+            mcu_frame.model_validate(payload)
+
+
+def test_generated_mcu_model_rejects_unknown_branch_keywords(tmp_path: Path) -> None:
+    compiler = SchemaCompiler(ROOT / "interfaces" / "json_schema")
+    compiler.load_schemas()
+    compiler.schemas["mcu_protocol"]["allOf"][0]["then"]["dependentRequired"] = {"opcode": ["command_id"]}
+
+    with pytest.raises(ValueError, match=r"unsupported runtime schema keyword.*dependentRequired"):
+        compiler.compile_all(tmp_path / "python", tmp_path / "typescript")
 
 
 def test_explicit_extra_forbid_and_unsupported_keywords_fail_closed(tmp_path: Path) -> None:

--- a/tests/unit/test_mcu_protocol_contract.py
+++ b/tests/unit/test_mcu_protocol_contract.py
@@ -251,7 +251,7 @@ def test_telemetry_sequence_half_range_vectors(last_accepted: int, candidate: in
     assert classify_telemetry_sequence(last_accepted, candidate) == expected
 
 
-def test_repository_schema_compiler_accepts_protocol_metadata(tmp_path: Path) -> None:
+def test_repository_schema_compiler_enforces_protocol_branches(tmp_path: Path) -> None:
     compiler = SchemaCompiler(ROOT / "interfaces" / "json_schema")
     compiler.load_schemas()
     compiler.compile_all(tmp_path / "python", tmp_path / "typescript")
@@ -260,8 +260,20 @@ def test_repository_schema_compiler_accepts_protocol_metadata(tmp_path: Path) ->
     namespace: dict[str, object] = {}
     exec(compile(generated.read_text(encoding="utf-8"), str(generated), "exec"), namespace)
     generated_model = namespace["McuFrame"]
-    generated_model(frame_id="f", frame_kind="command", command_id=32767, sent_at="compat")
-    generated_model(frame_id="f", frame_kind="stop", command_id=32768, sent_at="compat")
+    for label, payload in VALID_FRAMES.items():
+        assert generated_model.model_validate(payload), label
+    for payload in INVALID_FRAMES.values():
+        with pytest.raises(ValidationError):
+            generated_model.model_validate(payload)
+    frames_by_kind = {payload["frame_kind"]: payload for payload in VALID_FRAMES.values()}
+    for conditional in SCHEMA["allOf"]:
+        frame_kind = conditional["if"]["properties"]["frame_kind"]["const"]
+        for field in conditional["then"]["required"]:
+            missing = deepcopy(frames_by_kind[frame_kind])
+            missing.pop(field)
+            assert not schema_accepts(missing)
+            with pytest.raises(ValidationError):
+                generated_model.model_validate(missing)
 
 
 def test_committed_stop_ack_round_trips_through_schema_and_model() -> None:


### PR DESCRIPTION
## Summary

- validate generated `McuFrame` values against the supported MCU schema subset before Pydantic field coercion
- preserve branch `required`, forbidden-field, `const`, `enum`, `if/then/else`, and command-ID range semantics
- fail compilation when the MCU schema introduces an unsupported runtime keyword
- replace the old compatibility assertion with canonical valid/invalid corpus coverage and every branch-required field

The generated MCU Python model now has an explicit runtime dependency on `workbench.kernel.schema_compiler.validate_schema_instance`; other generated models remain standalone Pydantic modules. This keeps the change bounded to the current MCU schema instead of introducing a general code-generation framework.

No files under `interfaces/`, `firmware/`, or `robot/control/` are changed.

## Verification

- `65 passed`: `tests/unit/test_kernel_schema_compiler.py` and `tests/unit/test_mcu_protocol_contract.py`
- `447 passed`: full pytest with an isolated merged `workbench` namespace loading this worktree's kernel/application/hardware packages
- full repository Ruff check and format check
- `make contract`
- `make scenario-check`
- `make context-check`
- `python tools/scripts/check_task_packet.py --all --base origin/main`

Closes #204
