### PR TITLE
fix(wbcan): preserve effects when error skb allocation fails

### DIFF
--- a/docs/task_packets/linux-wbcan-error-skb-failure.json
+++ b/docs/task_packets/linux-wbcan-error-skb-failure.json
@@ -1,0 +1,45 @@
+{
+  "issue": 215,
+  "human_owner": "Quchaosheng",
+  "objective": "Preserve wbcan error effects when optional CAN error SKB allocation fails.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/test_wbcan.sh",
+    "docs/task_packets/linux-wbcan-error-skb-failure.json"
+  ],
+  "read_only_paths": [
+    ".github/workflows/ci.yml",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**"
+  ],
+  "acceptance": [
+    "arbitration loss increments its CAN statistic even when the optional error SKB allocation fails",
+    "stuff error increments its CAN statistic and enters warning even when the optional error SKB allocation fails",
+    "successful allocation retains the existing error frame and transmission behavior",
+    "the privileged regression restores allocation behavior before exit",
+    "the change does not alter CAN state synchronization owned by issue 153"
+  ],
+  "commands": [
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test",
+    "python tools/scripts/check_task_packet.py docs/task_packets/linux-wbcan-error-skb-failure.json --base origin/main",
+    "git diff --check origin/main...HEAD"
+  ],
+  "evidence": [
+    "kernel module build output",
+    "checkpatch output",
+    "privileged allocation-pressure simulation counter and state assertions; missing error frames are not physical CAN evidence",
+    "existing seven-mode fault-suite output"
+  ],
+  "stop_conditions": [
+    "CAN core APIs must change",
+    "state transition serialization from issue 153 must change",
+    "firmware interfaces or physical CAN claims are required"
+  ]
+}

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -12,6 +12,7 @@ set -uo pipefail
 
 IFACE="${1:-wbcan0}"
 DBG="/sys/kernel/debug/wbcan/${IFACE}"
+FAIL_ERROR_SKB="/sys/module/wbcan/parameters/fail_error_skb"
 PASS=0
 FAIL=0
 
@@ -26,6 +27,13 @@ need cansend
 need candump
 need python3
 
+restore_error_skb_allocation() {
+	if [ -w "$FAIL_ERROR_SKB" ]; then
+		printf '0\n' > "$FAIL_ERROR_SKB" || true
+	fi
+}
+trap restore_error_skb_allocation EXIT
+
 [ -d "$DBG" ] || { red "no debugfs dir at $DBG - is the module loaded?"; exit 1; }
 ip link show "$IFACE" >/dev/null 2>&1 || { red "no interface $IFACE"; exit 1; }
 if [ -w "$DBG/inject" ] && [ -r "$DBG/status" ]; then
@@ -35,10 +43,37 @@ else
 	red "FAIL  fault-plane readiness: FAIL"
 	FAIL=$((FAIL + 1))
 fi
+if [ -w "$FAIL_ERROR_SKB" ] && [ -r "$FAIL_ERROR_SKB" ]; then
+	green "PASS  error-SKB failure injection readiness: PASS"
+	PASS=$((PASS + 1))
+else
+	red "FAIL  error-SKB failure injection readiness: FAIL"
+	FAIL=$((FAIL + 1))
+fi
 
 arm()   { echo "$*" > "$DBG/inject"; }
 clear_fault() { arm "none 0"; }
 stat()  { awk -v k="$1" '$1==k{print $2}' "$DBG/status"; }
+can_xstat() {
+	local key="$1"
+
+	ip -details -statistics link show "$IFACE" |
+		awk -v key="$key" '
+			$1 == "re-started" {
+				for (field = 1; field <= NF; field++)
+					header[field] = $field
+				if (getline <= 0)
+					exit 1
+				for (field = 1; field <= NF; field++)
+					if (header[field] == key) {
+						print $field
+						found = 1
+						exit
+					}
+			}
+			END { if (!found) exit 1 }
+		'
+}
 
 wait_for_state() {
 	local want="$1" attempts="${2:-40}"
@@ -326,7 +361,7 @@ out=$(capture 500 & sleep 0.1
       cansend "$IFACE" 611#02
       wait)
 check "stuff-err emits a protocol error" \
-      "1" "$(grep -Eci 'ERRORFRAME|20000008' <<<"$out" | head -1)"
+      "1" "$(grep -Eci 'ERRORFRAME|2000000C' <<<"$out" | head -1)"
 check "stuff-err enters warning" \
       "error-warning" "$(stat state)"
 check "stuff-err consumes both shots" "0" "$(stat shots_left)"
@@ -339,7 +374,44 @@ check "first good frame after stuff-err is delivered" \
 check "first good frame recovers to active" \
       "error-active" "$(stat state)"
 
-# --- 12. counters are trustworthy -----------------------------------------
+# --- 12. error effects survive optional error-SKB allocation failure -------
+# This simulates allocation pressure; it is not evidence from a physical bus.
+printf '1\n' > "$FAIL_ERROR_SKB"
+
+clear_fault
+before_arb_lost=$(can_xstat arbit-lost)
+arm "arb-lost 1"
+out=$(capture 300 & sleep 0.1; cansend "$IFACE" 613#04; wait)
+check "arb-lost allocation failure emits no error frame" \
+      "0" "$(grep -Eci 'ERRORFRAME|20000002' <<<"$out" | head -1)"
+check "arb-lost allocation failure consumes its shot" \
+      "0" "$(stat shots_left)"
+check "arb-lost allocation failure increments its counter" \
+      "1" "$(( $(can_xstat arbit-lost) - before_arb_lost ))"
+check "arb-lost allocation failure leaves the bus active" \
+      "error-active" "$(stat state)"
+
+clear_fault
+before_bus_errors=$(stat bus_errors)
+arm "stuff-err 1"
+out=$(capture 300 & sleep 0.1; cansend "$IFACE" 614#05; wait)
+check "stuff-err allocation failure emits no error frame" \
+      "0" "$(grep -Eci 'ERRORFRAME|2000000C' <<<"$out" | head -1)"
+check "stuff-err allocation failure consumes its shot" \
+      "0" "$(stat shots_left)"
+check "stuff-err allocation failure increments its counter" \
+      "1" "$(( $(stat bus_errors) - before_bus_errors ))"
+check "stuff-err allocation failure enters warning" \
+      "error-warning" "$(stat state)"
+
+printf '0\n' > "$FAIL_ERROR_SKB"
+out=$(capture 300 & sleep 0.1; cansend "$IFACE" 615#06; wait)
+check "allocation recovery restores normal delivery" \
+      "1" "$(grep -c '615.*06' <<<"$out")"
+check "allocation recovery returns to active" \
+      "error-active" "$(stat state)"
+
+# --- 13. counters are trustworthy -----------------------------------------
 clear_fault
 before=$(stat tx_frames)
 cansend "$IFACE" 700#01
@@ -348,7 +420,7 @@ after=$(stat tx_frames)
 check "tx counter advances" \
       "1" "$(( after - before ))"
 
-# --- 13. rejecting a bad ABI write ----------------------------------------
+# --- 14. rejecting a bad ABI write ----------------------------------------
 if echo "not-a-mode 1" > "$DBG/inject" 2>/dev/null; then
 	check "bad fault name rejected" "rejected" "accepted"
 else

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -65,6 +65,10 @@ static const char *const wbcan_fault_names[] = {
 	[WBCAN_FAULT_STUFF_ERR]	= "stuff-err",
 };
 
+static bool fail_error_skb;
+module_param(fail_error_skb, bool, 0600);
+MODULE_PARM_DESC(fail_error_skb, "fail CAN error SKB allocation for testing");
+
 struct wbcan_priv {
 	struct can_priv		can;	/* must be first: can_priv contract */
 	struct net_device	*dev;
@@ -142,12 +146,12 @@ static bool wbcan_should_inject(struct wbcan_priv *priv, struct sk_buff *skb,
 static void wbcan_emit_error(struct net_device *dev, enum wbcan_fault fault)
 {
 	struct wbcan_priv *priv = netdev_priv(dev);
-	struct can_frame *cf;
+	struct can_frame *cf = NULL;
 	struct sk_buff *skb;
 	enum can_state tx_state = priv->can.state;
 	enum can_state rx_state = priv->can.state;
 
-	skb = alloc_can_err_skb(dev, &cf);
+	skb = READ_ONCE(fail_error_skb) ? NULL : alloc_can_err_skb(dev, &cf);
 
 	switch (fault) {
 	case WBCAN_FAULT_BUS_OFF:
@@ -165,22 +169,18 @@ static void wbcan_emit_error(struct net_device *dev, enum wbcan_fault fault)
 		break;
 
 	case WBCAN_FAULT_ARB_LOST:
+		priv->can.can_stats.arbitration_lost++;
 		if (!cf)
-			return;
+			break;
 		cf->can_id |= CAN_ERR_LOSTARB;
 		/*
 		 * Bit position that lost. 0 means unspecified, which is
 		 * honest here: we are not modelling a real bit timeline.
 		 */
 		cf->data[0] = 0;
-		priv->can.can_stats.arbitration_lost++;
 		break;
 
 	case WBCAN_FAULT_STUFF_ERR:
-		if (!cf)
-			return;
-		cf->can_id |= CAN_ERR_PROT;
-		cf->data[2] = CAN_ERR_PROT_STUFF;
 		/*
 		 * This is a bounded protocol-error model: one warning per
 		 * injected frame, then the next fault-free frame recovers to
@@ -189,6 +189,10 @@ static void wbcan_emit_error(struct net_device *dev, enum wbcan_fault fault)
 		priv->can.can_stats.bus_error++;
 		tx_state = CAN_STATE_ERROR_WARNING;
 		can_change_state(dev, cf, tx_state, rx_state);
+		if (!cf)
+			break;
+		cf->can_id |= CAN_ERR_PROT;
+		cf->data[2] = CAN_ERR_PROT_STUFF;
 		break;
 
 	default:


### PR DESCRIPTION
## Summary

- preserve `arb-lost` statistics when optional CAN error-SKB allocation fails
- preserve `stuff-err` bus-error accounting and `ERROR_WARNING` transition on allocation failure
- add a root-only deterministic allocation-failure switch and regression coverage
- document the allocation-pressure simulation as non-physical evidence

## Scope

- Changes only `kernel/wbcan/` and the matching Task Packet.
- Does not change CAN core APIs or #153 state-transition serialization.
- Original injected TX drop/error semantics remain unchanged.

## Verification

- `make -C kernel/wbcan` against Linux 6.17.0-40, 7.0.0-28, and 7.0.0-29 headers
- `make -C kernel/wbcan checkpatch` — 0 errors, 0 warnings
- `bash -n kernel/wbcan/test_wbcan.sh`
- Task Packet validation, contract/scenario/context checks
- Ruff, docs, demos, golden checks
- full test suite: 458 passed
- privileged `sudo make -C kernel/wbcan test` was not executable in this environment because sudo requires an interactive password; GitHub `kernel-module` runs the privileged suite

Closes #215
