### PR TITLE
feat(mcu): add watchdog and bounded STOP timing

### DIFF
--- a/docs/architecture/mcu-watchdog-v1.md
+++ b/docs/architecture/mcu-watchdog-v1.md
@@ -71,16 +71,18 @@ cleared.
 An exact link-level STOP retry while the pending slot is live replays the cached
 original STOP ACK record, including its observed timestamp, retry count, wire
 result, fault and device mode, and does not extend the deadline. A
-protocol-level retry with the same STOP command ID and a different
+protocol-level retry with the same STOP command ID and a strictly greater
 `retry_count` matches the same command semantics, emits a new observation that
 echoes the received `retry_count`, and preserves the original wire result,
-fault and device mode. Neither form repeats the STOP side effect or extends the
-deadline; the most recently emitted retry count is the one used for transport
-handoff confirmation and timeout correlation. Both replays remain unchanged in
-their semantic fields if the state machine enters a fault after the first ACK
-was created. A different pending STOP is rejected by the bounded single-slot
-implementation; retry deduplication and multi-command windows remain separate
-work.
+fault and device mode. A retry with the same count is an exact link replay; a
+lower/decreasing count, including a `255 -> 0` wrap, is stale and rejected
+without changing the pending slot. Neither accepted form repeats the STOP side
+effect or extends the deadline; the most recently emitted retry count is the
+one used for transport handoff confirmation and timeout correlation. Both
+replays remain unchanged in their semantic fields if the state machine enters a
+fault after the first ACK was created. A different pending STOP is rejected by
+the bounded single-slot implementation; retry deduplication and multi-command
+windows remain separate work.
 
 ## Hardware watchdog and HAL boundary
 

--- a/docs/architecture/mcu-watchdog-v1.md
+++ b/docs/architecture/mcu-watchdog-v1.md
@@ -68,10 +68,12 @@ never evidence that stopped confirmation was received. The safe state remains
 active and trusted reset cannot clear the timing cause until the owner marks it
 cleared.
 
-An exact STOP retry while the pending slot is live returns the same correlated
-STOP ACK record and does not extend the deadline. A different pending STOP is
-rejected by the bounded single-slot implementation; retry deduplication and
-multi-command windows remain separate work.
+An exact STOP retry while the pending slot is live replays the cached original
+STOP ACK record, including its observed timestamp, wire result, fault and
+device mode, and does not extend the deadline. The replay remains unchanged if
+the state machine enters a fault after the first ACK was created. A different
+pending STOP is rejected by the bounded single-slot implementation; retry
+deduplication and multi-command windows remain separate work.
 
 ## Hardware watchdog and HAL boundary
 
@@ -86,7 +88,9 @@ The QEMU HAL maps time to the virt machine CLINT `mtime`, dispatches a real
 machine-timer interrupt through `crt0.S`, and models the hardware watchdog as a
 finite deadline. The timer callback runs the same `mcu_watchdog_poll()` source
 as Host and feeds the modeled hardware watchdog only while the timing core and
-state machine remain valid without an active timing cause.
+state machine remain valid, the state is not `FAULT`, and no active timing
+cause exists. Clearing a timing cause does not make a latched `FAULT` state
+feed-eligible.
 
 QEMU proves timer-interrupt routing, deadline arithmetic, single-record
 emission and the HAL feed decision. It does not prove CH32V307 register

--- a/docs/architecture/mcu-watchdog-v1.md
+++ b/docs/architecture/mcu-watchdog-v1.md
@@ -52,13 +52,13 @@ independent cause-cleared gate.
 
 For a completely valid STOP, the core dispatches the state-machine STOP event
 first, disables the software link deadline, stores the STOP command ID and
-retry count, and creates a correlated `STOP_ACK` record immediately. The record
-is eligible for transport handoff until the inclusive `MCU_STOP_ACK_DEADLINE_US`
-deadline.
+attempt metadata, and creates a correlated `STOP_ACK` record immediately. The
+record is eligible for transport handoff until the inclusive
+`MCU_STOP_ACK_DEADLINE_US` deadline.
 
 The transport-facing adapter confirms the handoff with
-`mcu_watchdog_confirm_stop_ack()`. The command ID, retry count and local
-monotonic timestamp must match the pending slot. A confirmation at the exact
+`mcu_watchdog_confirm_stop_ack()`. The command ID and retry count of the most
+recently emitted ACK must match the pending slot. A confirmation at the exact
 deadline is accepted; a late confirmation is rejected.
 
 If the handoff is not confirmed after the deadline, the pending slot is closed
@@ -68,12 +68,19 @@ never evidence that stopped confirmation was received. The safe state remains
 active and trusted reset cannot clear the timing cause until the owner marks it
 cleared.
 
-An exact STOP retry while the pending slot is live replays the cached original
-STOP ACK record, including its observed timestamp, wire result, fault and
-device mode, and does not extend the deadline. The replay remains unchanged if
-the state machine enters a fault after the first ACK was created. A different
-pending STOP is rejected by the bounded single-slot implementation; retry
-deduplication and multi-command windows remain separate work.
+An exact link-level STOP retry while the pending slot is live replays the cached
+original STOP ACK record, including its observed timestamp, retry count, wire
+result, fault and device mode, and does not extend the deadline. A
+protocol-level retry with the same STOP command ID and a different
+`retry_count` matches the same command semantics, emits a new observation that
+echoes the received `retry_count`, and preserves the original wire result,
+fault and device mode. Neither form repeats the STOP side effect or extends the
+deadline; the most recently emitted retry count is the one used for transport
+handoff confirmation and timeout correlation. Both replays remain unchanged in
+their semantic fields if the state machine enters a fault after the first ACK
+was created. A different pending STOP is rejected by the bounded single-slot
+implementation; retry deduplication and multi-command windows remain separate
+work.
 
 ## Hardware watchdog and HAL boundary
 

--- a/docs/architecture/mcu-watchdog-v1.md
+++ b/docs/architecture/mcu-watchdog-v1.md
@@ -1,0 +1,106 @@
+# MCU Watchdog and STOP Timing V1
+
+Issue #60 owns the platform-independent timing safety path that sits above the
+Wire V1 codec and beside the C safety state machine. It turns missing valid
+control activity and an unconfirmed STOP acknowledgement into deterministic
+safe outcomes without claiming a physical board timing result.
+
+## Controlled constants
+
+The current implementation keeps all deployment-sensitive values in
+`firmware/mcu/core/watchdog.h`:
+
+| Constant | Value | Meaning |
+| --- | ---: | --- |
+| `MCU_HEARTBEAT_PERIOD_US` | 50,000 us | one-shot timer re-arm period |
+| `MCU_SOFTWARE_WATCHDOG_TIMEOUT_US` | 150,000 us | local link deadline after accepted activity |
+| `MCU_STOP_ACK_DEADLINE_US` | 10,000 us | bound from valid STOP receipt to transport handoff confirmation |
+| `MCU_HARDWARE_WATCHDOG_PERIOD_MS` | 500 ms | HAL hardware-watchdog configuration |
+
+These are implementation constants for deterministic Host/QEMU evidence. They
+are not CH32V307 interrupt-latency, motor-stop, electrical-bus or physical
+E-stop measurements.
+
+## Software link watchdog
+
+The transport/parser boundary must validate a complete frame and decide that
+its ordinary command serial is new before calling
+`mcu_watchdog_note_activity(..., MCU_WATCHDOG_ACTIVITY_VALID_NEW, ...)`.
+Only that explicit activity arms or refreshes the local deadline. Retries,
+duplicates, stale/out-of-window frames, malformed input and STOP never refresh
+an execution deadline.
+
+The deadline is an absolute `uint64_t` monotonic timestamp. The core compares
+timestamps using the unsigned half-range rule, so a deadline crossing
+`UINT64_MAX` remains deterministic. The implementation assumes, as required by
+the contract, that any one timing window is shorter than half the counter
+range.
+
+When the deadline is reached while the state machine is `EXECUTING`, the core:
+
+1. dispatches `MCU_EVENT_WATCHDOG_EXPIRED`;
+2. enters the latched `FAULT` / `watchdog_expired` state;
+3. disables further link-deadline refresh; and
+4. publishes exactly one correlated telemetry record with a monotonically
+   assigned telemetry sequence.
+
+Further polls do not emit another record. Ordinary activity cannot revive the
+state. Reset still requires the existing trusted authorization and an
+independent cause-cleared gate.
+
+## STOP acknowledgement timing
+
+For a completely valid STOP, the core dispatches the state-machine STOP event
+first, disables the software link deadline, stores the STOP command ID and
+retry count, and creates a correlated `STOP_ACK` record immediately. The record
+is eligible for transport handoff until the inclusive `MCU_STOP_ACK_DEADLINE_US`
+deadline.
+
+The transport-facing adapter confirms the handoff with
+`mcu_watchdog_confirm_stop_ack()`. The command ID, retry count and local
+monotonic timestamp must match the pending slot. A confirmation at the exact
+deadline is accepted; a late confirmation is rejected.
+
+If the handoff is not confirmed after the deadline, the pending slot is closed
+and exactly one local `STOP_TIMEOUT` record is published. This is a local
+absence-of-confirmation diagnostic, not a valid MCU Wire V1 fault frame and
+never evidence that stopped confirmation was received. The safe state remains
+active and trusted reset cannot clear the timing cause until the owner marks it
+cleared.
+
+An exact STOP retry while the pending slot is live returns the same correlated
+STOP ACK record and does not extend the deadline. A different pending STOP is
+rejected by the bounded single-slot implementation; retry deduplication and
+multi-command windows remain separate work.
+
+## Hardware watchdog and HAL boundary
+
+The core never touches timer or watchdog registers. It asks the HAL for:
+
+- monotonic microseconds;
+- one-shot timer arm/disarm and interrupt enable;
+- hardware watchdog start/feed; and
+- bounded Host/QEMU evidence counters.
+
+The QEMU HAL maps time to the virt machine CLINT `mtime`, dispatches a real
+machine-timer interrupt through `crt0.S`, and models the hardware watchdog as a
+finite deadline. The timer callback runs the same `mcu_watchdog_poll()` source
+as Host and feeds the modeled hardware watchdog only while the timing core and
+state machine remain valid without an active timing cause.
+
+QEMU proves timer-interrupt routing, deadline arithmetic, single-record
+emission and the HAL feed decision. It does not prove CH32V307 register
+semantics, interrupt latency, CAN electrical behavior, mechanical stopping
+time, bus-off recovery or physical E-stop performance.
+
+## Evidence and boundaries
+
+The shared fake-clock tests cover valid-new activity, rejected activity,
+deadline equality, counter wraparound, STOP ACK correlation, exact-deadline
+confirmation, late confirmation, STOP timeout, reset gates and invalid input.
+The QEMU executable additionally demonstrates timer interrupts, one fault
+record and hardware-watchdog expiry after the timing core stops feeding it.
+
+This issue does not implement the Host `SafeCANBus` transport adapter (#55),
+command deduplication (#61), HAL CAN drivers, vendor registers, motor control,
+bus-off recovery or physical hardware validation.

--- a/docs/task_packets/issue-60-mcu-watchdog-stop-timing.json
+++ b/docs/task_packets/issue-60-mcu-watchdog-stop-timing.json
@@ -45,6 +45,7 @@
     "Only explicitly accepted new protocol activity refreshes the software link watchdog; malformed, duplicate, retry and stale traffic cannot feed it.",
     "A link timeout observed while executing dispatches WATCHDOG_EXPIRED, forces safe outputs, latches the fault and emits exactly one correlated fault/telemetry record.",
     "A valid STOP enters the safe state and retains its command correlation until a bounded STOP acknowledgement is handed to transport; a missed deadline emits a distinct stop-timeout outcome and never reports stopped confirmation.",
+    "A pending STOP accepts an equal retry_count as a link replay and only a strictly greater retry_count as a protocol retry; decreasing or wrapped retry counts are rejected without changing ACK correlation or deadline.",
     "Reset cannot clear an active watchdog or STOP-timeout cause without the existing trusted state-machine transition.",
     "Deadline comparisons and deadline arithmetic remain deterministic across uint64_t wraparound.",
     "Host tests use an injected fake clock with no sleep or wall-clock flakiness and cover feed eligibility, link timeout, STOP acknowledgement bound, timeout fault and single-emission behavior.",

--- a/docs/task_packets/issue-60-mcu-watchdog-stop-timing.json
+++ b/docs/task_packets/issue-60-mcu-watchdog-stop-timing.json
@@ -1,0 +1,83 @@
+{
+  "issue": 60,
+  "human_owner": "TH3478",
+  "objective": "Implement the platform-independent MCU heartbeat watchdog and bounded STOP acknowledgement timing path with deterministic fake-clock and QEMU timer-interrupt evidence.",
+  "allowed_paths": [
+    "firmware/mcu/core/watchdog.h",
+    "firmware/mcu/core/watchdog.c",
+    "firmware/mcu/core/hal.h",
+    "firmware/mcu/hal/host/hal_host.c",
+    "firmware/mcu/hal/qemu/hal_qemu.c",
+    "firmware/mcu/hal/qemu/crt0.S",
+    "firmware/mcu/hal/qemu/main_qemu.c",
+    "firmware/mcu/tests/watchdog_tests.h",
+    "firmware/mcu/tests/watchdog_tests.c",
+    "firmware/mcu/tests/main_host.c",
+    "firmware/mcu/Makefile",
+    "firmware/mcu/README.md",
+    "docs/architecture/mcu-watchdog-v1.md",
+    "docs/task_packets/issue-60-mcu-watchdog-stop-timing.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "docs/architecture/mcu-protocol-v1.md",
+    "docs/architecture/mcu-wire-v1.md",
+    "interfaces/json_schema/mcu_protocol.schema.json",
+    "interfaces/examples/mcu-frame-stop-ack.json",
+    "firmware/mcu/core/state_machine.h",
+    "firmware/mcu/core/state_machine.c",
+    "firmware/mcu/core/frame_codec.h",
+    "firmware/mcu/core/frame_codec.c",
+    "firmware/virtual_mcu/**",
+    "docs/decisions/ADR-0003-mcu-riscv-qemu.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/mcu/hal/ch32v307/**",
+    "robot/control/**",
+    "hardware/**",
+    "services/**",
+    "firmware/virtual_mcu/**"
+  ],
+  "acceptance": [
+    "Heartbeat period, software link timeout, STOP acknowledgement deadline and hardware watchdog timeout are named controlled constants.",
+    "Only explicitly accepted new protocol activity refreshes the software link watchdog; malformed, duplicate, retry and stale traffic cannot feed it.",
+    "A link timeout observed while executing dispatches WATCHDOG_EXPIRED, forces safe outputs, latches the fault and emits exactly one correlated fault/telemetry record.",
+    "A valid STOP enters the safe state and retains its command correlation until a bounded STOP acknowledgement is handed to transport; a missed deadline emits a distinct stop-timeout outcome and never reports stopped confirmation.",
+    "Reset cannot clear an active watchdog or STOP-timeout cause without the existing trusted state-machine transition.",
+    "Deadline comparisons and deadline arithmetic remain deterministic across uint64_t wraparound.",
+    "Host tests use an injected fake clock with no sleep or wall-clock flakiness and cover feed eligibility, link timeout, STOP acknowledgement bound, timeout fault and single-emission behavior.",
+    "QEMU runs the shared timing tests and exercises a real machine-timer interrupt plus the modeled hardware-watchdog start/feed path.",
+    "The core remains freestanding-compatible with no vendor headers, dynamic allocation, floating point or hardware register access."
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-60-mcu-watchdog-stop-timing.json",
+    "make -C firmware/mcu test-host",
+    "make -C firmware/mcu test-host-sanitize",
+    "make -C firmware/mcu test-qemu",
+    "make -C firmware/mcu verify-no-fp",
+    "make -C firmware/mcu size-check",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "Issue #60 Task Packet validation output.",
+    "Host fake-clock watchdog test output with assertion and failure counts.",
+    "ASan/UBSan output for the shared timing corpus.",
+    "QEMU output proving timer-interrupt dispatch and watchdog feed evidence.",
+    "verify-no-fp and size-check output for the QEMU firmware image.",
+    "Repository test, contract, scenario and context-check output.",
+    "Final changed-path review and git diff --check proving the Task Packet boundary."
+  ],
+  "stop_conditions": [
+    "The implementation requires changing the frozen JSON Schema, Pydantic models or logical protocol semantics.",
+    "The implementation requires retry deduplication, host transport dispatch, vendor registers, motor control or physical CAN claims.",
+    "A new reset frame or reset opcode would be added to protocol v1.0.",
+    "The core cannot compile unchanged for Host and QEMU.",
+    "QEMU-only behavior would be presented as CH32V307 interrupt latency or physical E-stop evidence.",
+    "The implementation requires modifying .gitignore or unrelated local changes."
+  ]
+}

--- a/firmware/mcu/Makefile
+++ b/firmware/mcu/Makefile
@@ -16,7 +16,7 @@ HOSTCC  ?= cc
 
 BUILD   := build
 CORE    := $(wildcard core/*.c)
-SHARED_TESTS := tests/state_machine_tests.c tests/frame_codec_tests.c
+SHARED_TESTS := tests/state_machine_tests.c tests/frame_codec_tests.c tests/watchdog_tests.c
 HOST_TESTS := $(SHARED_TESTS) tests/main_host.c
 
 # rv32imac: no FPU. -mabi=ilp32 (not ilp32f/d) so a stray double is a link error
@@ -107,8 +107,8 @@ verify-no-fp: qemu
 	@echo "ok: no FP, no allocator"
 
 size-check: qemu
-	@text=$$($(RVSIZE) -A $(BUILD)/qemu/mcu.elf | awk '/^\.text/{print $$2}'); \
-	 bss=$$($(RVSIZE) -A $(BUILD)/qemu/mcu.elf | awk '/^\.bss/{print $$2}'); \
+	@text=$$($(RVSIZE) -A $(BUILD)/qemu/mcu.elf | awk '/^[[:space:]]*\.text/{print $$2}'); \
+	 bss=$$($(RVSIZE) -A $(BUILD)/qemu/mcu.elf | awk '/^[[:space:]]*\.bss/{print $$2}'); \
 	 echo ".text=$$text (max $(MAX_TEXT))  .bss=$$bss (max $(MAX_BSS))"; \
 	 [ "$${text:-0}" -le $(MAX_TEXT) ] || { echo "FAIL: .text over budget"; exit 1; }; \
 	 [ "$${bss:-0}" -le $(MAX_BSS) ] || { echo "FAIL: .bss over budget"; exit 1; }

--- a/firmware/mcu/README.md
+++ b/firmware/mcu/README.md
@@ -83,3 +83,8 @@ handoff before the controlled deadline; otherwise the core emits one local
 `STOP_TIMEOUT` outcome and never claims stopped confirmation. The exact
 constants and clock-wrap rules are documented in
 `docs/architecture/mcu-watchdog-v1.md`.
+
+While the STOP handoff is pending, an equal `retry_count` is an exact
+link-level replay and a strictly greater count is a protocol-level retry.
+Decreasing or wrapped retry counts are stale and rejected without changing the
+pending ACK correlation.

--- a/firmware/mcu/README.md
+++ b/firmware/mcu/README.md
@@ -7,7 +7,7 @@ Decision and rationale: `docs/decisions/ADR-0003-mcu-riscv-qemu.md`.
 
 ```
 core/           platform-independent C. State machine, frame codec,
-                watchdog, dedup, ring buffers.
+                watchdog timing, dedup, ring buffers.
                 No peripheral registers. No vendor headers.
 hal/qemu/       QEMU target, CTU CAN FD over PCI. Used by CI.
 hal/ch32v307/   real board, CH32V307 CAN peripheral. P3.
@@ -64,5 +64,22 @@ make test-qemu   # fault suite in QEMU, what CI runs
 
 The platform-independent C safety state machine is implemented by Issue #53.
 Issue #54 adds the strict Classic CAN Wire V1 codec and shared Host/QEMU golden
-vectors. The HAL CAN driver, watchdog timing path, command deduplication and
-physical CAN validation remain separate follow-up tasks.
+vectors. Issue #60 adds the allocation-free heartbeat watchdog, bounded STOP
+acknowledgement timing, fake-clock tests and QEMU machine-timer/watchdog
+evidence. The HAL CAN driver, command deduplication and physical CAN validation
+remain separate follow-up tasks.
+
+## Timing safety path
+
+`core/watchdog.[ch]` owns the timing state but not timer or watchdog registers.
+Only a complete, valid and serially new ordinary frame may refresh the
+software link watchdog. Malformed, retry, duplicate, stale and STOP traffic do
+not extend the execution deadline. A missed deadline enters the existing
+latched `FAULT/watchdog_expired` state and emits one telemetry record.
+
+A valid STOP immediately transitions the state machine to `SAFE_STOP` and
+creates a correlated `STOP_ACK` handoff record. The transport must confirm the
+handoff before the controlled deadline; otherwise the core emits one local
+`STOP_TIMEOUT` outcome and never claims stopped confirmation. The exact
+constants and clock-wrap rules are documented in
+`docs/architecture/mcu-watchdog-v1.md`.

--- a/firmware/mcu/core/hal.h
+++ b/firmware/mcu/core/hal.h
@@ -39,6 +39,8 @@ uint64_t hal_now_us(void);
 /* Arm a one-shot timer interrupt at an absolute time. Used by FW5. */
 void hal_timer_arm_us(uint64_t deadline_us);
 void hal_timer_disarm(void);
+/* Enable the target's global timer-interrupt delivery after setup. */
+void hal_timer_enable(void);
 
 /* ----------------------------------------------------------------------- CAN
  * Frame as it goes on the wire. Matches mcu_protocol.schema.json.
@@ -65,5 +67,7 @@ bool hal_can_recv(hal_can_frame *out);
  */
 void hal_wdt_start(uint32_t timeout_ms);
 void hal_wdt_feed(void);
+uint32_t hal_wdt_feed_count(void);
+bool hal_wdt_is_expired(void);
 
 #endif /* MCU_HAL_H */

--- a/firmware/mcu/core/watchdog.c
+++ b/firmware/mcu/core/watchdog.c
@@ -1,0 +1,346 @@
+#include "watchdog.h"
+
+#define MCU_WATCHDOG_COOKIE 0x57445431u
+#define MCU_TIME_HALF_RANGE (UINT64_C(1) << 63)
+
+static bool deadline_reached(uint64_t now_us, uint64_t deadline_us)
+{
+    return (uint64_t)(now_us - deadline_us) < MCU_TIME_HALF_RANGE;
+}
+
+static bool deadline_after(uint64_t now_us, uint64_t deadline_us)
+{
+    uint64_t delta = now_us - deadline_us;
+
+    return delta != 0u && delta < MCU_TIME_HALF_RANGE;
+}
+
+static void clear_frame(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_COMMAND;
+    frame->command_id = 0u;
+    frame->sequence_no = 0u;
+    frame->opcode = MCU_WIRE_OPCODE_RESERVED;
+    frame->retry_count = 0u;
+    frame->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    frame->fault_code = MCU_WIRE_FAULT_NONE;
+    frame->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void clear_record(mcu_watchdog_record_t *record)
+{
+    record->kind = MCU_WATCHDOG_RECORD_NONE;
+    record->fault = MCU_WATCHDOG_FAULT_NONE;
+    record->observed_at_us = 0u;
+    record->deadline_us = 0u;
+    record->command_id = 0u;
+    record->retry_count = 0u;
+    clear_frame(&record->frame);
+}
+
+static bool activity_is_valid(mcu_watchdog_activity_t activity)
+{
+    return activity >= MCU_WATCHDOG_ACTIVITY_VALID_NEW && activity < MCU_WATCHDOG_ACTIVITY_COUNT;
+}
+
+static bool stop_matches_pending(const mcu_watchdog_t *watchdog,
+                                 const mcu_wire_frame_t *stop)
+{
+    return watchdog->stop_ack_pending && watchdog->stop_command_id == stop->command_id &&
+           watchdog->stop_retry_count == stop->retry_count;
+}
+
+static mcu_wire_fault_t map_fault(mcu_fault_code_t fault_code)
+{
+    switch (fault_code) {
+    case MCU_FAULT_STOP_REJECTED:
+        return MCU_WIRE_FAULT_STOP_REJECTED;
+    case MCU_FAULT_LINK_LOST:
+        return MCU_WIRE_FAULT_LINK_LOST;
+    case MCU_FAULT_DUPLICATE_FRAME:
+        return MCU_WIRE_FAULT_DUPLICATE_FRAME;
+    case MCU_FAULT_WATCHDOG_EXPIRED:
+        return MCU_WIRE_FAULT_WATCHDOG_EXPIRED;
+    case MCU_FAULT_MALFORMED_FRAME:
+        return MCU_WIRE_FAULT_MALFORMED_FRAME;
+    case MCU_FAULT_NONE:
+    case MCU_FAULT_COUNT:
+    default:
+        return MCU_WIRE_FAULT_NONE;
+    }
+}
+
+static void make_watchdog_telemetry(mcu_watchdog_t *watchdog,
+                                    uint64_t now_us,
+                                    uint64_t deadline_us,
+                                    mcu_watchdog_record_t *record)
+{
+    clear_record(record);
+    record->kind = MCU_WATCHDOG_RECORD_FAULT_TELEMETRY;
+    record->fault = MCU_WATCHDOG_FAULT_WATCHDOG_EXPIRED;
+    record->observed_at_us = now_us;
+    record->deadline_us = deadline_us;
+    record->frame.kind = MCU_WIRE_FRAME_TELEMETRY;
+    record->frame.sequence_no = watchdog->next_telemetry_sequence++;
+    record->frame.fault_code = MCU_WIRE_FAULT_WATCHDOG_EXPIRED;
+    record->frame.device_mode = MCU_WIRE_MODE_FAULTED;
+}
+
+static void make_stop_ack(const mcu_wire_frame_t *stop,
+                          const mcu_transition_result_t *transition,
+                          uint64_t now_us,
+                          uint64_t deadline_us,
+                          mcu_watchdog_record_t *record)
+{
+    clear_record(record);
+    record->kind = MCU_WATCHDOG_RECORD_STOP_ACK;
+    record->fault = MCU_WATCHDOG_FAULT_NONE;
+    record->observed_at_us = now_us;
+    record->deadline_us = deadline_us;
+    record->command_id = stop->command_id;
+    record->retry_count = stop->retry_count;
+    record->frame.kind = MCU_WIRE_FRAME_STOP_ACK;
+    record->frame.command_id = stop->command_id;
+    record->frame.opcode = MCU_WIRE_OPCODE_STOP;
+    record->frame.retry_count = stop->retry_count;
+    record->frame.result_code = transition->result_code == MCU_RESULT_ACCEPTED
+                                    ? MCU_WIRE_RESULT_ACCEPTED
+                                    : MCU_WIRE_RESULT_REJECTED;
+    record->frame.fault_code = map_fault(transition->response_fault_code);
+    record->frame.device_mode = transition->device_mode == MCU_DEVICE_MODE_FAULTED
+                                    ? MCU_WIRE_MODE_FAULTED
+                                    : MCU_WIRE_MODE_STOPPED;
+}
+
+void mcu_watchdog_init(mcu_watchdog_t *watchdog, uint32_t first_telemetry_sequence)
+{
+    if (watchdog == 0) {
+        return;
+    }
+
+    watchdog->initialized = MCU_WATCHDOG_COOKIE;
+    watchdog->next_telemetry_sequence = first_telemetry_sequence;
+    watchdog->link_watchdog_armed = false;
+    watchdog->watchdog_cause_active = false;
+    watchdog->watchdog_record_emitted = false;
+    watchdog->link_deadline_us = 0u;
+    watchdog->stop_ack_pending = false;
+    watchdog->stop_timeout_cause_active = false;
+    watchdog->stop_timeout_record_emitted = false;
+    watchdog->stop_deadline_us = 0u;
+    watchdog->stop_command_id = 0u;
+    watchdog->stop_retry_count = 0u;
+}
+
+bool mcu_watchdog_is_valid(const mcu_watchdog_t *watchdog)
+{
+    if (watchdog == 0 || watchdog->initialized != MCU_WATCHDOG_COOKIE) {
+        return false;
+    }
+    if (watchdog->stop_ack_pending && watchdog->stop_command_id < MCU_STOP_ID_MIN) {
+        return false;
+    }
+    return true;
+}
+
+bool mcu_watchdog_note_activity(mcu_watchdog_t *watchdog,
+                                const mcu_state_machine_t *machine,
+                                mcu_watchdog_activity_t activity,
+                                uint64_t now_us)
+{
+    if (!mcu_watchdog_is_valid(watchdog) || machine == 0 || !mcu_sm_is_valid(machine) ||
+        !activity_is_valid(activity)) {
+        return false;
+    }
+    if (machine->state != MCU_STATE_EXECUTING) {
+        watchdog->link_watchdog_armed = false;
+        return false;
+    }
+    if (watchdog->watchdog_cause_active || activity != MCU_WATCHDOG_ACTIVITY_VALID_NEW) {
+        return false;
+    }
+
+    watchdog->link_watchdog_armed = true;
+    watchdog->link_deadline_us = now_us + MCU_SOFTWARE_WATCHDOG_TIMEOUT_US;
+    return true;
+}
+
+bool mcu_watchdog_poll(mcu_watchdog_t *watchdog,
+                       mcu_state_machine_t *machine,
+                       uint64_t now_us,
+                       mcu_watchdog_record_t *record)
+{
+    mcu_event_t event;
+    mcu_transition_result_t transition;
+
+    if (watchdog == 0 || machine == 0 || record == 0 || !mcu_watchdog_is_valid(watchdog) ||
+        !mcu_sm_is_valid(machine)) {
+        return false;
+    }
+
+    if (watchdog->stop_ack_pending && deadline_after(now_us, watchdog->stop_deadline_us)) {
+        clear_record(record);
+        record->kind = MCU_WATCHDOG_RECORD_STOP_TIMEOUT;
+        record->fault = MCU_WATCHDOG_FAULT_STOP_TIMEOUT;
+        record->observed_at_us = now_us;
+        record->deadline_us = watchdog->stop_deadline_us;
+        record->command_id = watchdog->stop_command_id;
+        record->retry_count = watchdog->stop_retry_count;
+        watchdog->stop_ack_pending = false;
+        watchdog->stop_timeout_cause_active = true;
+        watchdog->stop_timeout_record_emitted = true;
+        return true;
+    }
+
+    if (machine->state != MCU_STATE_EXECUTING) {
+        watchdog->link_watchdog_armed = false;
+        return false;
+    }
+    if (!watchdog->link_watchdog_armed || !deadline_reached(now_us, watchdog->link_deadline_us) ||
+        watchdog->watchdog_cause_active) {
+        return false;
+    }
+
+    event.kind = MCU_EVENT_WATCHDOG_EXPIRED;
+    event.fault_code = MCU_FAULT_NONE;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(machine, &event, &transition);
+    watchdog->link_watchdog_armed = false;
+    watchdog->watchdog_cause_active = true;
+    if (watchdog->watchdog_record_emitted) {
+        return false;
+    }
+    watchdog->watchdog_record_emitted = true;
+    make_watchdog_telemetry(watchdog, now_us, watchdog->link_deadline_us, record);
+    return true;
+}
+
+bool mcu_watchdog_receive_stop(mcu_watchdog_t *watchdog,
+                               mcu_state_machine_t *machine,
+                               const mcu_wire_frame_t *stop,
+                               uint64_t now_us,
+                               mcu_watchdog_record_t *record)
+{
+    uint16_t arbitration_id;
+    uint8_t encoded[MCU_WIRE_DLC];
+    uint8_t encoded_length;
+    mcu_transition_result_t transition;
+    mcu_event_t event;
+
+    if (watchdog == 0 || machine == 0 || stop == 0 || record == 0 ||
+        !mcu_watchdog_is_valid(watchdog) || !mcu_sm_is_valid(machine)) {
+        return false;
+    }
+    if (mcu_frame_encode(stop, &arbitration_id, encoded, sizeof(encoded), &encoded_length) != MCU_CODEC_OK ||
+        arbitration_id != MCU_CAN_ID_STOP || encoded_length != MCU_WIRE_DLC) {
+        return false;
+    }
+    if (watchdog->stop_timeout_cause_active) {
+        return false;
+    }
+    if (watchdog->stop_ack_pending) {
+        if (!stop_matches_pending(watchdog, stop) ||
+            deadline_after(now_us, watchdog->stop_deadline_us)) {
+            return false;
+        }
+        clear_record(record);
+        record->kind = MCU_WATCHDOG_RECORD_STOP_ACK;
+        record->observed_at_us = now_us;
+        record->deadline_us = watchdog->stop_deadline_us;
+        record->command_id = stop->command_id;
+        record->retry_count = stop->retry_count;
+        record->frame.kind = MCU_WIRE_FRAME_STOP_ACK;
+        record->frame.command_id = stop->command_id;
+        record->frame.opcode = MCU_WIRE_OPCODE_STOP;
+        record->frame.retry_count = stop->retry_count;
+        record->frame.result_code = machine->state == MCU_STATE_FAULT
+                                      ? MCU_WIRE_RESULT_REJECTED
+                                      : MCU_WIRE_RESULT_ACCEPTED;
+        record->frame.fault_code = machine->state == MCU_STATE_FAULT
+                                     ? MCU_WIRE_FAULT_STOP_REJECTED
+                                     : MCU_WIRE_FAULT_NONE;
+        record->frame.device_mode = machine->state == MCU_STATE_FAULT
+                                      ? MCU_WIRE_MODE_FAULTED
+                                      : MCU_WIRE_MODE_STOPPED;
+        return true;
+    }
+
+    event.kind = MCU_EVENT_STOP;
+    event.fault_code = MCU_FAULT_NONE;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(machine, &event, &transition);
+    watchdog->link_watchdog_armed = false;
+    watchdog->stop_ack_pending = transition.result_code == MCU_RESULT_ACCEPTED;
+    watchdog->stop_deadline_us = now_us + MCU_STOP_ACK_DEADLINE_US;
+    watchdog->stop_command_id = stop->command_id;
+    watchdog->stop_retry_count = stop->retry_count;
+    make_stop_ack(stop, &transition, now_us, watchdog->stop_deadline_us, record);
+    return true;
+}
+
+bool mcu_watchdog_confirm_stop_ack(mcu_watchdog_t *watchdog,
+                                   uint16_t command_id,
+                                   uint8_t retry_count,
+                                   uint64_t now_us)
+{
+    if (!mcu_watchdog_is_valid(watchdog) || !watchdog->stop_ack_pending ||
+        watchdog->stop_command_id != command_id || watchdog->stop_retry_count != retry_count ||
+        deadline_after(now_us, watchdog->stop_deadline_us)) {
+        return false;
+    }
+
+    watchdog->stop_ack_pending = false;
+    return true;
+}
+
+void mcu_watchdog_mark_causes_cleared(mcu_watchdog_t *watchdog)
+{
+    if (watchdog == 0 || !mcu_watchdog_is_valid(watchdog)) {
+        return;
+    }
+
+    watchdog->watchdog_cause_active = false;
+    watchdog->stop_timeout_cause_active = false;
+}
+
+bool mcu_watchdog_request_reset(mcu_watchdog_t *watchdog,
+                                mcu_state_machine_t *machine,
+                                bool reset_authorized,
+                                bool cause_cleared,
+                                mcu_transition_result_t *result)
+{
+    mcu_event_t event;
+    bool live_cause;
+
+    if (watchdog == 0 || machine == 0 || result == 0 || !mcu_watchdog_is_valid(watchdog)) {
+        return false;
+    }
+
+    live_cause = watchdog->watchdog_cause_active || watchdog->stop_timeout_cause_active ||
+                 watchdog->stop_ack_pending;
+    event.kind = MCU_EVENT_TRUSTED_RESET;
+    event.fault_code = MCU_FAULT_NONE;
+    event.reset_authorized = reset_authorized;
+    event.cause_cleared = cause_cleared && !live_cause;
+    mcu_sm_dispatch(machine, &event, result);
+    if (result->result_code != MCU_RESULT_ACCEPTED) {
+        return false;
+    }
+
+    watchdog->link_watchdog_armed = false;
+    watchdog->watchdog_cause_active = false;
+    watchdog->watchdog_record_emitted = false;
+    watchdog->stop_ack_pending = false;
+    watchdog->stop_timeout_cause_active = false;
+    watchdog->stop_timeout_record_emitted = false;
+    return true;
+}
+
+bool mcu_watchdog_should_feed_hardware(const mcu_watchdog_t *watchdog,
+                                       const mcu_state_machine_t *machine)
+{
+    return mcu_watchdog_is_valid(watchdog) && machine != 0 && mcu_sm_is_valid(machine) &&
+           !watchdog->watchdog_cause_active && !watchdog->stop_timeout_cause_active;
+}

--- a/firmware/mcu/core/watchdog.c
+++ b/firmware/mcu/core/watchdog.c
@@ -71,8 +71,10 @@ static bool activity_is_valid(mcu_watchdog_activity_t activity)
 static bool stop_matches_pending(const mcu_watchdog_t *watchdog,
                                  const mcu_wire_frame_t *stop)
 {
-    return watchdog->stop_ack_pending && watchdog->stop_command_id == stop->command_id &&
-           watchdog->stop_retry_count == stop->retry_count;
+    /* retry_count is attempt metadata, not part of STOP command semantics.
+     * mcu_frame_encode() has already validated the STOP opcode and frame kind,
+     * so the command ID is the remaining correlation key. */
+    return watchdog->stop_ack_pending && watchdog->stop_command_id == stop->command_id;
 }
 
 static mcu_wire_fault_t map_fault(mcu_fault_code_t fault_code)
@@ -135,6 +137,33 @@ static void make_stop_ack(const mcu_wire_frame_t *stop,
     record->frame.device_mode = transition->device_mode == MCU_DEVICE_MODE_FAULTED
                                     ? MCU_WIRE_MODE_FAULTED
                                     : MCU_WIRE_MODE_STOPPED;
+}
+
+static void replay_pending_stop_ack(mcu_watchdog_t *watchdog,
+                                    const mcu_wire_frame_t *stop,
+                                    uint64_t now_us,
+                                    mcu_watchdog_record_t *record)
+{
+    bool exact_retry = watchdog->stop_retry_count == stop->retry_count;
+
+    clear_record(record);
+    record->kind = MCU_WATCHDOG_RECORD_STOP_ACK;
+    record->fault = MCU_WATCHDOG_FAULT_NONE;
+    record->observed_at_us = exact_retry ? watchdog->stop_ack_observed_at_us : now_us;
+    record->deadline_us = watchdog->stop_deadline_us;
+    record->command_id = watchdog->stop_command_id;
+    record->retry_count = stop->retry_count;
+    copy_frame(&record->frame, &watchdog->stop_ack_frame);
+    /* Preserve the original result/fault/device mode while echoing the
+     * attempt metadata carried by a protocol-level retry. */
+    record->frame.retry_count = stop->retry_count;
+    if (!exact_retry) {
+        /* The next exact link retry must replay this most recently emitted
+         * attempt, while the semantic response fields remain immutable. */
+        watchdog->stop_ack_observed_at_us = now_us;
+        watchdog->stop_ack_frame.retry_count = stop->retry_count;
+    }
+    watchdog->stop_retry_count = stop->retry_count;
 }
 
 void mcu_watchdog_init(mcu_watchdog_t *watchdog, uint32_t first_telemetry_sequence)
@@ -271,13 +300,7 @@ bool mcu_watchdog_receive_stop(mcu_watchdog_t *watchdog,
             deadline_after(now_us, watchdog->stop_deadline_us)) {
             return false;
         }
-        clear_record(record);
-        record->kind = MCU_WATCHDOG_RECORD_STOP_ACK;
-        record->observed_at_us = watchdog->stop_ack_observed_at_us;
-        record->deadline_us = watchdog->stop_deadline_us;
-        record->command_id = stop->command_id;
-        record->retry_count = stop->retry_count;
-        copy_frame(&record->frame, &watchdog->stop_ack_frame);
+        replay_pending_stop_ack(watchdog, stop, now_us, record);
         return true;
     }
 

--- a/firmware/mcu/core/watchdog.c
+++ b/firmware/mcu/core/watchdog.c
@@ -27,6 +27,31 @@ static void clear_frame(mcu_wire_frame_t *frame)
     frame->device_mode = MCU_WIRE_MODE_IDLE;
 }
 
+static void copy_frame(mcu_wire_frame_t *destination, const mcu_wire_frame_t *source)
+{
+    destination->kind = source->kind;
+    destination->command_id = source->command_id;
+    destination->sequence_no = source->sequence_no;
+    destination->opcode = source->opcode;
+    destination->retry_count = source->retry_count;
+    destination->result_code = source->result_code;
+    destination->fault_code = source->fault_code;
+    destination->device_mode = source->device_mode;
+}
+
+static void clear_stop_ack_cache(mcu_watchdog_t *watchdog)
+{
+    watchdog->stop_ack_observed_at_us = 0u;
+    clear_frame(&watchdog->stop_ack_frame);
+}
+
+static void cache_stop_ack(mcu_watchdog_t *watchdog,
+                           const mcu_watchdog_record_t *record)
+{
+    watchdog->stop_ack_observed_at_us = record->observed_at_us;
+    copy_frame(&watchdog->stop_ack_frame, &record->frame);
+}
+
 static void clear_record(mcu_watchdog_record_t *record)
 {
     record->kind = MCU_WATCHDOG_RECORD_NONE;
@@ -130,6 +155,7 @@ void mcu_watchdog_init(mcu_watchdog_t *watchdog, uint32_t first_telemetry_sequen
     watchdog->stop_deadline_us = 0u;
     watchdog->stop_command_id = 0u;
     watchdog->stop_retry_count = 0u;
+    clear_stop_ack_cache(watchdog);
 }
 
 bool mcu_watchdog_is_valid(const mcu_watchdog_t *watchdog)
@@ -187,6 +213,7 @@ bool mcu_watchdog_poll(mcu_watchdog_t *watchdog,
         record->command_id = watchdog->stop_command_id;
         record->retry_count = watchdog->stop_retry_count;
         watchdog->stop_ack_pending = false;
+        clear_stop_ack_cache(watchdog);
         watchdog->stop_timeout_cause_active = true;
         watchdog->stop_timeout_record_emitted = true;
         return true;
@@ -246,23 +273,11 @@ bool mcu_watchdog_receive_stop(mcu_watchdog_t *watchdog,
         }
         clear_record(record);
         record->kind = MCU_WATCHDOG_RECORD_STOP_ACK;
-        record->observed_at_us = now_us;
+        record->observed_at_us = watchdog->stop_ack_observed_at_us;
         record->deadline_us = watchdog->stop_deadline_us;
         record->command_id = stop->command_id;
         record->retry_count = stop->retry_count;
-        record->frame.kind = MCU_WIRE_FRAME_STOP_ACK;
-        record->frame.command_id = stop->command_id;
-        record->frame.opcode = MCU_WIRE_OPCODE_STOP;
-        record->frame.retry_count = stop->retry_count;
-        record->frame.result_code = machine->state == MCU_STATE_FAULT
-                                      ? MCU_WIRE_RESULT_REJECTED
-                                      : MCU_WIRE_RESULT_ACCEPTED;
-        record->frame.fault_code = machine->state == MCU_STATE_FAULT
-                                     ? MCU_WIRE_FAULT_STOP_REJECTED
-                                     : MCU_WIRE_FAULT_NONE;
-        record->frame.device_mode = machine->state == MCU_STATE_FAULT
-                                      ? MCU_WIRE_MODE_FAULTED
-                                      : MCU_WIRE_MODE_STOPPED;
+        copy_frame(&record->frame, &watchdog->stop_ack_frame);
         return true;
     }
 
@@ -277,6 +292,11 @@ bool mcu_watchdog_receive_stop(mcu_watchdog_t *watchdog,
     watchdog->stop_command_id = stop->command_id;
     watchdog->stop_retry_count = stop->retry_count;
     make_stop_ack(stop, &transition, now_us, watchdog->stop_deadline_us, record);
+    if (watchdog->stop_ack_pending) {
+        cache_stop_ack(watchdog, record);
+    } else {
+        clear_stop_ack_cache(watchdog);
+    }
     return true;
 }
 
@@ -292,6 +312,7 @@ bool mcu_watchdog_confirm_stop_ack(mcu_watchdog_t *watchdog,
     }
 
     watchdog->stop_ack_pending = false;
+    clear_stop_ack_cache(watchdog);
     return true;
 }
 
@@ -333,6 +354,7 @@ bool mcu_watchdog_request_reset(mcu_watchdog_t *watchdog,
     watchdog->watchdog_cause_active = false;
     watchdog->watchdog_record_emitted = false;
     watchdog->stop_ack_pending = false;
+    clear_stop_ack_cache(watchdog);
     watchdog->stop_timeout_cause_active = false;
     watchdog->stop_timeout_record_emitted = false;
     return true;
@@ -342,5 +364,6 @@ bool mcu_watchdog_should_feed_hardware(const mcu_watchdog_t *watchdog,
                                        const mcu_state_machine_t *machine)
 {
     return mcu_watchdog_is_valid(watchdog) && machine != 0 && mcu_sm_is_valid(machine) &&
-           !watchdog->watchdog_cause_active && !watchdog->stop_timeout_cause_active;
+           machine->state != MCU_STATE_FAULT && !watchdog->watchdog_cause_active &&
+           !watchdog->stop_timeout_cause_active;
 }

--- a/firmware/mcu/core/watchdog.c
+++ b/firmware/mcu/core/watchdog.c
@@ -72,9 +72,11 @@ static bool stop_matches_pending(const mcu_watchdog_t *watchdog,
                                  const mcu_wire_frame_t *stop)
 {
     /* retry_count is attempt metadata, not part of STOP command semantics.
-     * mcu_frame_encode() has already validated the STOP opcode and frame kind,
-     * so the command ID is the remaining correlation key. */
-    return watchdog->stop_ack_pending && watchdog->stop_command_id == stop->command_id;
+     * Equal counts are link-level replays and strictly greater counts are
+     * protocol retries. A pending uint8_t retry sequence does not wrap: a
+     * lower count is stale and must not roll back the correlation slot. */
+    return watchdog->stop_ack_pending && watchdog->stop_command_id == stop->command_id &&
+           stop->retry_count >= watchdog->stop_retry_count;
 }
 
 static mcu_wire_fault_t map_fault(mcu_fault_code_t fault_code)

--- a/firmware/mcu/core/watchdog.h
+++ b/firmware/mcu/core/watchdog.h
@@ -92,10 +92,11 @@ bool mcu_watchdog_poll(mcu_watchdog_t *watchdog,
 
 /* A valid STOP is dispatched before this function returns. The returned ACK
  * is ready for transport immediately; an exact link retry replays the cached
- * record, while a protocol retry with the same command ID echoes its new
- * retry_count and preserves the cached result fields. Neither retry extends
- * the pending deadline. The caller must confirm handoff through
- * mcu_watchdog_confirm_stop_ack(). */
+ * record, while a protocol retry with the same command ID and a strictly
+ * greater retry_count echoes its new count and preserves the cached result
+ * fields. A lower retry_count is stale and rejected; the pending retry
+ * sequence does not wrap. Neither retry extends the pending deadline. The
+ * caller must confirm handoff through mcu_watchdog_confirm_stop_ack(). */
 bool mcu_watchdog_receive_stop(mcu_watchdog_t *watchdog,
                                mcu_state_machine_t *machine,
                                const mcu_wire_frame_t *stop,

--- a/firmware/mcu/core/watchdog.h
+++ b/firmware/mcu/core/watchdog.h
@@ -65,6 +65,8 @@ typedef struct {
     uint64_t stop_deadline_us;
     uint16_t stop_command_id;
     uint8_t stop_retry_count;
+    uint64_t stop_ack_observed_at_us;
+    mcu_wire_frame_t stop_ack_frame;
 } mcu_watchdog_t;
 
 void mcu_watchdog_init(mcu_watchdog_t *watchdog, uint32_t first_telemetry_sequence);
@@ -115,9 +117,9 @@ bool mcu_watchdog_request_reset(mcu_watchdog_t *watchdog,
                                 bool cause_cleared,
                                 mcu_transition_result_t *result);
 
-/* Hardware watchdog feed is a liveness action for a running firmware loop
- * without an active timing cause. A hung loop or a timed-out safety path cannot
- * call this function successfully. */
+/* Hardware watchdog feed is allowed only for a valid non-fault state without
+ * an active timing cause. A hung loop or a timed-out safety path cannot call
+ * this function successfully. */
 bool mcu_watchdog_should_feed_hardware(const mcu_watchdog_t *watchdog,
                                        const mcu_state_machine_t *machine);
 

--- a/firmware/mcu/core/watchdog.h
+++ b/firmware/mcu/core/watchdog.h
@@ -64,8 +64,11 @@ typedef struct {
     bool stop_timeout_record_emitted;
     uint64_t stop_deadline_us;
     uint16_t stop_command_id;
+    /* Retry count of the most recently emitted STOP_ACK attempt. */
     uint8_t stop_retry_count;
     uint64_t stop_ack_observed_at_us;
+    /* Cached semantic ACK; protocol-level retries update only attempt metadata
+     * here and never mutate result_code, fault_code or device_mode. */
     mcu_wire_frame_t stop_ack_frame;
 } mcu_watchdog_t;
 
@@ -87,8 +90,11 @@ bool mcu_watchdog_poll(mcu_watchdog_t *watchdog,
                        uint64_t now_us,
                        mcu_watchdog_record_t *record);
 
-/* A valid STOP is dispatched before this function returns.  The returned ACK
- * is ready for transport immediately; the caller must confirm handoff through
+/* A valid STOP is dispatched before this function returns. The returned ACK
+ * is ready for transport immediately; an exact link retry replays the cached
+ * record, while a protocol retry with the same command ID echoes its new
+ * retry_count and preserves the cached result fields. Neither retry extends
+ * the pending deadline. The caller must confirm handoff through
  * mcu_watchdog_confirm_stop_ack(). */
 bool mcu_watchdog_receive_stop(mcu_watchdog_t *watchdog,
                                mcu_state_machine_t *machine,

--- a/firmware/mcu/core/watchdog.h
+++ b/firmware/mcu/core/watchdog.h
@@ -1,0 +1,124 @@
+#ifndef MCU_WATCHDOG_H
+#define MCU_WATCHDOG_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "frame_codec.h"
+#include "state_machine.h"
+
+/* Controlled implementation constants for Wire V1 timing.  The values are
+ * deliberately small enough for deterministic QEMU evidence and are not
+ * physical CH32V307 latency or E-stop measurements. */
+#define MCU_HEARTBEAT_PERIOD_US 50000ull
+#define MCU_SOFTWARE_WATCHDOG_TIMEOUT_US 150000ull
+#define MCU_STOP_ACK_DEADLINE_US 10000ull
+#define MCU_HARDWARE_WATCHDOG_PERIOD_MS 500u
+
+typedef enum {
+    MCU_WATCHDOG_ACTIVITY_VALID_NEW = 0,
+    MCU_WATCHDOG_ACTIVITY_RETRY,
+    MCU_WATCHDOG_ACTIVITY_DUPLICATE,
+    MCU_WATCHDOG_ACTIVITY_STALE,
+    MCU_WATCHDOG_ACTIVITY_MALFORMED,
+    MCU_WATCHDOG_ACTIVITY_STOP,
+    MCU_WATCHDOG_ACTIVITY_COUNT
+} mcu_watchdog_activity_t;
+
+typedef enum {
+    MCU_WATCHDOG_RECORD_NONE = 0,
+    MCU_WATCHDOG_RECORD_FAULT_TELEMETRY,
+    MCU_WATCHDOG_RECORD_STOP_ACK,
+    MCU_WATCHDOG_RECORD_STOP_TIMEOUT,
+    MCU_WATCHDOG_RECORD_COUNT
+} mcu_watchdog_record_kind_t;
+
+typedef enum {
+    MCU_WATCHDOG_FAULT_NONE = 0,
+    MCU_WATCHDOG_FAULT_WATCHDOG_EXPIRED,
+    MCU_WATCHDOG_FAULT_STOP_TIMEOUT,
+    MCU_WATCHDOG_FAULT_COUNT
+} mcu_watchdog_fault_t;
+
+typedef struct {
+    mcu_watchdog_record_kind_t kind;
+    mcu_watchdog_fault_t fault;
+    uint64_t observed_at_us;
+    uint64_t deadline_us;
+    uint16_t command_id;
+    uint8_t retry_count;
+    mcu_wire_frame_t frame;
+} mcu_watchdog_record_t;
+
+typedef struct {
+    uint32_t initialized;
+    uint32_t next_telemetry_sequence;
+
+    bool link_watchdog_armed;
+    bool watchdog_cause_active;
+    bool watchdog_record_emitted;
+    uint64_t link_deadline_us;
+
+    bool stop_ack_pending;
+    bool stop_timeout_cause_active;
+    bool stop_timeout_record_emitted;
+    uint64_t stop_deadline_us;
+    uint16_t stop_command_id;
+    uint8_t stop_retry_count;
+} mcu_watchdog_t;
+
+void mcu_watchdog_init(mcu_watchdog_t *watchdog, uint32_t first_telemetry_sequence);
+bool mcu_watchdog_is_valid(const mcu_watchdog_t *watchdog);
+
+/* Only callers that have already validated the complete frame and accepted a
+ * serially new command may pass VALID_NEW.  Retry, duplicate, stale,
+ * malformed and STOP activity never refreshes the execution watchdog. */
+bool mcu_watchdog_note_activity(mcu_watchdog_t *watchdog,
+                                const mcu_state_machine_t *machine,
+                                mcu_watchdog_activity_t activity,
+                                uint64_t now_us);
+
+/* Poll is allocation-free and deterministic.  It publishes at most one
+ * record per call and leaves the output untouched when no deadline fired. */
+bool mcu_watchdog_poll(mcu_watchdog_t *watchdog,
+                       mcu_state_machine_t *machine,
+                       uint64_t now_us,
+                       mcu_watchdog_record_t *record);
+
+/* A valid STOP is dispatched before this function returns.  The returned ACK
+ * is ready for transport immediately; the caller must confirm handoff through
+ * mcu_watchdog_confirm_stop_ack(). */
+bool mcu_watchdog_receive_stop(mcu_watchdog_t *watchdog,
+                               mcu_state_machine_t *machine,
+                               const mcu_wire_frame_t *stop,
+                               uint64_t now_us,
+                               mcu_watchdog_record_t *record);
+
+/* Confirmation at the exact deadline is still within the inclusive bound.
+ * A late confirmation is rejected and leaves the timeout cause observable via
+ * poll(). */
+bool mcu_watchdog_confirm_stop_ack(mcu_watchdog_t *watchdog,
+                                   uint16_t command_id,
+                                   uint8_t retry_count,
+                                   uint64_t now_us);
+
+/* Trusted safety-control operation: this does not authorize reset.  It records
+ * that the external owner has cleared live timing causes. */
+void mcu_watchdog_mark_causes_cleared(mcu_watchdog_t *watchdog);
+
+/* Reset still goes through the existing state-machine authorization and cause
+ * gates.  A live timing cause forces cause_cleared=false regardless of the
+ * caller's requested value. */
+bool mcu_watchdog_request_reset(mcu_watchdog_t *watchdog,
+                                mcu_state_machine_t *machine,
+                                bool reset_authorized,
+                                bool cause_cleared,
+                                mcu_transition_result_t *result);
+
+/* Hardware watchdog feed is a liveness action for a running firmware loop
+ * without an active timing cause. A hung loop or a timed-out safety path cannot
+ * call this function successfully. */
+bool mcu_watchdog_should_feed_hardware(const mcu_watchdog_t *watchdog,
+                                       const mcu_state_machine_t *machine);
+
+#endif /* MCU_WATCHDOG_H */

--- a/firmware/mcu/hal/host/hal_host.c
+++ b/firmware/mcu/hal/host/hal_host.c
@@ -1,0 +1,106 @@
+#include "hal.h"
+
+#include <stdio.h>
+
+static uint64_t host_now_us;
+static uint64_t host_timer_deadline_us;
+static uint32_t host_wdt_timeout_ms;
+static uint64_t host_wdt_deadline_us;
+static uint32_t host_wdt_feeds;
+static bool host_wdt_running;
+
+static bool host_deadline_reached(uint64_t now_us, uint64_t deadline_us)
+{
+    return (uint64_t)(now_us - deadline_us) < (UINT64_C(1) << 63);
+}
+
+void hal_putc(char c)
+{
+    (void)putchar((int)c);
+}
+
+void hal_puts(const char *s)
+{
+    if (s != 0) {
+        (void)fputs(s, stdout);
+    }
+}
+
+void hal_put_u32(uint32_t value)
+{
+    (void)printf("%u", (unsigned)value);
+}
+
+void hal_report_exit(int code)
+{
+    (void)code;
+}
+
+void hal_report_trap(uint32_t mcause, uint32_t mepc)
+{
+    (void)mcause;
+    (void)mepc;
+}
+
+uint64_t hal_now_us(void)
+{
+    return host_now_us;
+}
+
+void hal_timer_arm_us(uint64_t deadline_us)
+{
+    host_timer_deadline_us = deadline_us;
+}
+
+void hal_timer_disarm(void)
+{
+    host_timer_deadline_us = UINT64_MAX;
+}
+
+void hal_timer_enable(void)
+{
+}
+
+bool hal_can_init(void)
+{
+    return false;
+}
+
+bool hal_can_send(const hal_can_frame *frame)
+{
+    (void)frame;
+    return false;
+}
+
+bool hal_can_recv(hal_can_frame *frame)
+{
+    (void)frame;
+    return false;
+}
+
+void hal_wdt_start(uint32_t timeout_ms)
+{
+    host_wdt_timeout_ms = timeout_ms;
+    host_wdt_running = true;
+    host_wdt_deadline_us = host_now_us + (uint64_t)timeout_ms * 1000u;
+    host_wdt_feeds = 0u;
+}
+
+void hal_wdt_feed(void)
+{
+    if (!host_wdt_running) {
+        return;
+    }
+    host_wdt_feeds++;
+    host_wdt_deadline_us = host_now_us + (uint64_t)host_wdt_timeout_ms * 1000u;
+}
+
+uint32_t hal_wdt_feed_count(void)
+{
+    return host_wdt_feeds;
+}
+
+bool hal_wdt_is_expired(void)
+{
+    return host_wdt_running && host_deadline_reached(host_now_us, host_wdt_deadline_us);
+}

--- a/firmware/mcu/hal/qemu/crt0.S
+++ b/firmware/mcu/hal/qemu/crt0.S
@@ -78,9 +78,51 @@ halt:
     .global trap_entry
     .type trap_entry, @function
 trap_entry:
-    addi    sp, sp, -16
-    sw      ra, 12(sp)
+    /* Preserve the caller-saved registers before inspecting mcause. In
+     * particular, t0/t1 are used for dispatch and must still be restored to
+     * their pre-interrupt values on the timer-return path. */
+    addi    sp, sp, -64
+    sw      ra, 0(sp)
+    sw      t0, 4(sp)
+    sw      t1, 8(sp)
+    sw      t2, 12(sp)
+    sw      t3, 16(sp)
+    sw      t4, 20(sp)
+    sw      t5, 24(sp)
+    sw      t6, 28(sp)
+    sw      a0, 32(sp)
+    sw      a1, 36(sp)
+    sw      a2, 40(sp)
+    sw      a3, 44(sp)
+    sw      a4, 48(sp)
+    sw      a5, 52(sp)
+    sw      a6, 56(sp)
+    sw      a7, 60(sp)
 
+    csrr    t0, mcause
+    li      t1, 0x80000007
+    bne     t0, t1, unexpected_trap
+    call    mcu_qemu_timer_interrupt
+    lw      ra, 0(sp)
+    lw      t0, 4(sp)
+    lw      t1, 8(sp)
+    lw      t2, 12(sp)
+    lw      t3, 16(sp)
+    lw      t4, 20(sp)
+    lw      t5, 24(sp)
+    lw      t6, 28(sp)
+    lw      a0, 32(sp)
+    lw      a1, 36(sp)
+    lw      a2, 40(sp)
+    lw      a3, 44(sp)
+    lw      a4, 48(sp)
+    lw      a5, 52(sp)
+    lw      a6, 56(sp)
+    lw      a7, 60(sp)
+    addi    sp, sp, 64
+    mret
+
+unexpected_trap:
     csrr    a0, mcause
     csrr    a1, mepc
     call    hal_report_trap

--- a/firmware/mcu/hal/qemu/hal_qemu.c
+++ b/firmware/mcu/hal/qemu/hal_qemu.c
@@ -114,6 +114,12 @@ void hal_timer_disarm(void)
     CLINT_MTIMECMP = (uint64_t)-1;
 }
 
+void hal_timer_enable(void)
+{
+    /* Enable global machine interrupts (MIE, bit 3) after mtvec is valid. */
+    __asm__ volatile("csrs mstatus, %0" :: "r"(1u << 3));
+}
+
 /* --- CAN: FW10 wires CTU CAN FD over PCI to the host vcan. Not yet. --------
  * Returning false rather than pretending to succeed: a stub that reports
  * success would let FW4's tests pass against nothing.
@@ -122,6 +128,50 @@ bool hal_can_init(void) { return false; }
 bool hal_can_send(const hal_can_frame *f) { (void)f; return false; }
 bool hal_can_recv(hal_can_frame *out) { (void)out; return false; }
 
-/* --- watchdog: FW5 uses the timer above; the hardware WDT model is FW20. --- */
-void hal_wdt_start(uint32_t timeout_ms) { (void)timeout_ms; }
-void hal_wdt_feed(void) { }
+/* QEMU virt has no CH32V307 IWDG. This bounded model records the same start,
+ * feed and expiry decisions so the core's feed policy is observable without
+ * presenting it as physical hardware evidence. */
+static bool qemu_wdt_running;
+static bool qemu_wdt_expired;
+static uint32_t qemu_wdt_timeout_ms;
+static uint32_t qemu_wdt_feeds;
+static uint64_t qemu_wdt_deadline_us;
+
+static bool qemu_deadline_reached(uint64_t now_us, uint64_t deadline_us)
+{
+    return (uint64_t)(now_us - deadline_us) < (UINT64_C(1) << 63);
+}
+
+void hal_wdt_start(uint32_t timeout_ms)
+{
+    qemu_wdt_running = true;
+    qemu_wdt_expired = false;
+    qemu_wdt_timeout_ms = timeout_ms;
+    qemu_wdt_feeds = 0u;
+    qemu_wdt_deadline_us = hal_now_us() + (uint64_t)timeout_ms * 1000u;
+}
+
+void hal_wdt_feed(void)
+{
+    if (!qemu_wdt_running || qemu_wdt_expired) {
+        return;
+    }
+    qemu_wdt_feeds++;
+    qemu_wdt_deadline_us = hal_now_us() + (uint64_t)qemu_wdt_timeout_ms * 1000u;
+}
+
+uint32_t hal_wdt_feed_count(void)
+{
+    return qemu_wdt_feeds;
+}
+
+bool hal_wdt_is_expired(void)
+{
+    if (!qemu_wdt_running) {
+        return false;
+    }
+    if (qemu_deadline_reached(hal_now_us(), qemu_wdt_deadline_us)) {
+        qemu_wdt_expired = true;
+    }
+    return qemu_wdt_expired;
+}

--- a/firmware/mcu/hal/qemu/main_qemu.c
+++ b/firmware/mcu/hal/qemu/main_qemu.c
@@ -18,6 +18,8 @@
 #include "hal.h"
 #include "frame_codec_tests.h"
 #include "state_machine_tests.h"
+#include "watchdog.h"
+#include "watchdog_tests.h"
 
 /* Deliberately uninitialised: if crt0 skipped the .bss loop this is garbage
  * and the check below fails. QEMU happens to hand out zeroed RAM, so this
@@ -25,6 +27,51 @@
  * the board (FW17), where it does not.
  */
 static uint32_t bss_probe[4];
+
+static mcu_state_machine_t timer_machine;
+static mcu_watchdog_t timer_watchdog;
+static volatile uint32_t timer_interrupts;
+static volatile uint32_t timer_fault_records;
+static volatile bool timer_record_available;
+static mcu_watchdog_record_t timer_record;
+
+static void copy_timer_record(const mcu_watchdog_record_t *source)
+{
+    timer_record.kind = source->kind;
+    timer_record.fault = source->fault;
+    timer_record.observed_at_us = source->observed_at_us;
+    timer_record.deadline_us = source->deadline_us;
+    timer_record.command_id = source->command_id;
+    timer_record.retry_count = source->retry_count;
+    timer_record.frame.kind = source->frame.kind;
+    timer_record.frame.command_id = source->frame.command_id;
+    timer_record.frame.sequence_no = source->frame.sequence_no;
+    timer_record.frame.opcode = source->frame.opcode;
+    timer_record.frame.retry_count = source->frame.retry_count;
+    timer_record.frame.result_code = source->frame.result_code;
+    timer_record.frame.fault_code = source->frame.fault_code;
+    timer_record.frame.device_mode = source->frame.device_mode;
+}
+
+/* Called by the machine-timer path in crt0.S. It is intentionally tiny: the
+ * same allocation-free poll used by Host runs here, followed by the HAL-owned
+ * hardware watchdog feed and the next one-shot timer arm. */
+void mcu_qemu_timer_interrupt(void)
+{
+    mcu_watchdog_record_t record;
+    uint64_t now_us = hal_now_us();
+
+    timer_interrupts++;
+    if (mcu_watchdog_poll(&timer_watchdog, &timer_machine, now_us, &record)) {
+        copy_timer_record(&record);
+        timer_record_available = true;
+        timer_fault_records++;
+    }
+    if (mcu_watchdog_should_feed_hardware(&timer_watchdog, &timer_machine)) {
+        hal_wdt_feed();
+    }
+    hal_timer_arm_us(now_us + MCU_HEARTBEAT_PERIOD_US);
+}
 
 static int check_bss_zeroed(void)
 {
@@ -108,6 +155,82 @@ static int run_frame_codec_tests(void)
     return report.failures == 0u ? 0 : 5;
 }
 
+static int run_watchdog_tests(void)
+{
+    mcu_test_report_t report;
+
+    mcu_watchdog_run_tests(&report);
+    hal_puts("[mcu] watchdog assertions=");
+    hal_put_u32(report.assertions);
+    hal_puts(" failures=");
+    hal_put_u32(report.failures);
+    hal_puts(" first_failure=");
+    hal_put_u32(report.first_failure);
+    hal_putc('\n');
+    return report.failures == 0u ? 0 : 6;
+}
+
+static int run_qemu_timing_evidence(void)
+{
+    mcu_event_t begin_move;
+    mcu_transition_result_t transition;
+    uint64_t start_us;
+
+    mcu_sm_init(&timer_machine);
+    mcu_watchdog_init(&timer_watchdog, 100u);
+    begin_move.kind = MCU_EVENT_BEGIN_MOVE;
+    begin_move.fault_code = MCU_FAULT_NONE;
+    begin_move.reset_authorized = false;
+    begin_move.cause_cleared = false;
+    mcu_sm_dispatch(&timer_machine, &begin_move, &transition);
+    if (transition.result_code != MCU_RESULT_ACCEPTED) {
+        hal_puts("[mcu] watchdog demo could not enter executing\n");
+        return 7;
+    }
+
+    start_us = hal_now_us();
+    if (!mcu_watchdog_note_activity(&timer_watchdog,
+                                    &timer_machine,
+                                    MCU_WATCHDOG_ACTIVITY_VALID_NEW,
+                                    start_us)) {
+        hal_puts("[mcu] watchdog demo could not arm link timeout\n");
+        return 8;
+    }
+    hal_wdt_start(MCU_HARDWARE_WATCHDOG_PERIOD_MS);
+    timer_interrupts = 0u;
+    timer_fault_records = 0u;
+    timer_record_available = false;
+    hal_timer_arm_us(start_us + MCU_HEARTBEAT_PERIOD_US);
+    hal_timer_enable();
+
+    /* Three timer periods reach the software deadline. The fourth proves that
+     * the timer keeps running after the fault while the core stops feeding the
+     * modeled hardware watchdog. */
+    while (timer_interrupts < 4u && !hal_wdt_is_expired()) {
+        __asm__ volatile("wfi");
+    }
+    if (timer_interrupts < 3u || timer_fault_records != 1u || !timer_record_available ||
+        timer_record.kind != MCU_WATCHDOG_RECORD_FAULT_TELEMETRY ||
+        timer_machine.state != MCU_STATE_FAULT || hal_wdt_feed_count() == 0u) {
+        hal_timer_disarm();
+        hal_puts("[mcu] QEMU timer/watchdog evidence failed\n");
+        return 9;
+    }
+
+    while (!hal_wdt_is_expired()) {
+        __asm__ volatile("wfi");
+    }
+    hal_timer_disarm();
+    hal_puts("[mcu] QEMU timer interrupts=");
+    hal_put_u32(timer_interrupts);
+    hal_puts(" fault_records=");
+    hal_put_u32(timer_fault_records);
+    hal_puts(" wdt_feeds=");
+    hal_put_u32(hal_wdt_feed_count());
+    hal_puts(" wdt_expired=1\n");
+    return 0;
+}
+
 int main(void)
 {
     hal_puts("\n[mcu] FW1/FW2 smoke test\n");
@@ -118,6 +241,8 @@ int main(void)
     rc |= check_stack_sane();
     rc |= run_state_machine_tests();
     rc |= run_frame_codec_tests();
+    rc |= run_watchdog_tests();
+    rc |= run_qemu_timing_evidence();
 
     /* CAN is deliberately not checked: hal_can_init returns false until FW10,
      * and a smoke test that skipped over that would be misleading. */

--- a/firmware/mcu/tests/main_host.c
+++ b/firmware/mcu/tests/main_host.c
@@ -2,11 +2,13 @@
 
 #include "frame_codec_tests.h"
 #include "state_machine_tests.h"
+#include "watchdog_tests.h"
 
 int main(void)
 {
     mcu_test_report_t state_machine_report;
     mcu_test_report_t frame_codec_report;
+    mcu_test_report_t watchdog_report;
 
     mcu_state_machine_run_tests(&state_machine_report);
     printf("[mcu-host] state-machine assertions=%u failures=%u first_failure=%u\n",
@@ -19,5 +21,14 @@ int main(void)
            (unsigned)frame_codec_report.assertions,
            (unsigned)frame_codec_report.failures,
            (unsigned)frame_codec_report.first_failure);
-    return state_machine_report.failures == 0u && frame_codec_report.failures == 0u ? 0 : 1;
+
+    mcu_watchdog_run_tests(&watchdog_report);
+    printf("[mcu-host] watchdog assertions=%u failures=%u first_failure=%u\n",
+           (unsigned)watchdog_report.assertions,
+           (unsigned)watchdog_report.failures,
+           (unsigned)watchdog_report.first_failure);
+    return state_machine_report.failures == 0u && frame_codec_report.failures == 0u &&
+             watchdog_report.failures == 0u
+             ? 0
+             : 1;
 }

--- a/firmware/mcu/tests/watchdog_tests.c
+++ b/firmware/mcu/tests/watchdog_tests.c
@@ -1,0 +1,357 @@
+#include "watchdog_tests.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+
+#include "watchdog.h"
+
+typedef struct {
+    uint64_t now_us;
+} fake_clock_t;
+
+static void check(mcu_test_report_t *report, bool condition)
+{
+    report->assertions++;
+    if (!condition) {
+        report->failures++;
+        if (report->first_failure == 0u) {
+            report->first_failure = report->assertions;
+        }
+    }
+}
+
+static void dispatch(mcu_state_machine_t *machine,
+                     mcu_event_kind_t kind,
+                     mcu_transition_result_t *result)
+{
+    mcu_event_t event;
+
+    event.kind = kind;
+    event.fault_code = MCU_FAULT_NONE;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(machine, &event, result);
+}
+
+static void start_move(mcu_state_machine_t *machine)
+{
+    mcu_transition_result_t result;
+
+    mcu_sm_init(machine);
+    dispatch(machine, MCU_EVENT_BEGIN_MOVE, &result);
+}
+
+static void make_stop(mcu_wire_frame_t *stop, uint16_t command_id, uint8_t retry_count)
+{
+    stop->kind = MCU_WIRE_FRAME_STOP;
+    stop->command_id = command_id;
+    stop->sequence_no = 0u;
+    stop->opcode = MCU_WIRE_OPCODE_STOP;
+    stop->retry_count = retry_count;
+    stop->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    stop->fault_code = MCU_WIRE_FAULT_NONE;
+    stop->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static bool record_frame_encodes(const mcu_watchdog_record_t *record)
+{
+    uint16_t arbitration_id;
+    uint8_t data[MCU_WIRE_DLC];
+    uint8_t length;
+
+    return mcu_frame_encode(&record->frame, &arbitration_id, data, sizeof(data), &length) ==
+             MCU_CODEC_OK &&
+           length == MCU_WIRE_DLC;
+}
+
+static void test_controlled_constants(mcu_test_report_t *report)
+{
+    check(report, MCU_HEARTBEAT_PERIOD_US > 0u);
+    check(report, MCU_SOFTWARE_WATCHDOG_TIMEOUT_US >= 2u * MCU_HEARTBEAT_PERIOD_US);
+    check(report, MCU_STOP_ACK_DEADLINE_US > 0u);
+    check(report, MCU_STOP_ACK_DEADLINE_US < MCU_SOFTWARE_WATCHDOG_TIMEOUT_US);
+    check(report, MCU_HARDWARE_WATCHDOG_PERIOD_MS > 0u);
+}
+
+static void test_only_valid_new_activity_feeds(mcu_test_report_t *report)
+{
+    static const mcu_watchdog_activity_t rejected_activity[] = {
+        MCU_WATCHDOG_ACTIVITY_RETRY,
+        MCU_WATCHDOG_ACTIVITY_DUPLICATE,
+        MCU_WATCHDOG_ACTIVITY_STALE,
+        MCU_WATCHDOG_ACTIVITY_MALFORMED,
+        MCU_WATCHDOG_ACTIVITY_STOP,
+    };
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_transition_result_t transition;
+    fake_clock_t clock = {.now_us = 1000u};
+    uint64_t deadline;
+    unsigned i;
+
+    mcu_watchdog_init(&watchdog, 7u);
+    mcu_sm_init(&machine);
+    check(report,
+          !mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, clock.now_us));
+    check(report, !watchdog.link_watchdog_armed);
+
+    dispatch(&machine, MCU_EVENT_BEGIN_MOVE, &transition);
+    check(report,
+          mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, clock.now_us));
+    deadline = clock.now_us + MCU_SOFTWARE_WATCHDOG_TIMEOUT_US;
+    check(report, watchdog.link_watchdog_armed);
+    check(report, watchdog.link_deadline_us == deadline);
+
+    for (i = 0u; i < sizeof(rejected_activity) / sizeof(rejected_activity[0]); i++) {
+        clock.now_us += MCU_HEARTBEAT_PERIOD_US;
+        check(report,
+              !mcu_watchdog_note_activity(
+                &watchdog, &machine, rejected_activity[i], clock.now_us));
+        check(report, watchdog.link_deadline_us == deadline);
+    }
+
+    check(report,
+          !mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_COUNT, clock.now_us));
+    check(report, watchdog.link_deadline_us == deadline);
+}
+
+static void test_watchdog_deadline_and_single_record(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_watchdog_record_t record;
+    fake_clock_t clock = {.now_us = 9000u};
+    uint64_t deadline;
+
+    mcu_watchdog_init(&watchdog, 41u);
+    start_move(&machine);
+    check(report,
+          mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, clock.now_us));
+    deadline = watchdog.link_deadline_us;
+
+    record.kind = MCU_WATCHDOG_RECORD_STOP_ACK;
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, deadline - 1u, &record));
+    check(report, record.kind == MCU_WATCHDOG_RECORD_STOP_ACK);
+    check(report, machine.state == MCU_STATE_EXECUTING);
+
+    check(report, mcu_watchdog_poll(&watchdog, &machine, deadline, &record));
+    check(report, record.kind == MCU_WATCHDOG_RECORD_FAULT_TELEMETRY);
+    check(report, record.fault == MCU_WATCHDOG_FAULT_WATCHDOG_EXPIRED);
+    check(report, record.observed_at_us == deadline);
+    check(report, record.deadline_us == deadline);
+    check(report, record.frame.kind == MCU_WIRE_FRAME_TELEMETRY);
+    check(report, record.frame.sequence_no == 41u);
+    check(report, record.frame.fault_code == MCU_WIRE_FAULT_WATCHDOG_EXPIRED);
+    check(report, record.frame.device_mode == MCU_WIRE_MODE_FAULTED);
+    check(report, record_frame_encodes(&record));
+    check(report, machine.state == MCU_STATE_FAULT);
+    check(report, machine.device_mode == MCU_DEVICE_MODE_FAULTED);
+    check(report, machine.fault_code == MCU_FAULT_WATCHDOG_EXPIRED);
+    check(report, !watchdog.link_watchdog_armed);
+
+    record.kind = MCU_WATCHDOG_RECORD_STOP_ACK;
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, deadline + 1u, &record));
+    check(report, record.kind == MCU_WATCHDOG_RECORD_STOP_ACK);
+}
+
+static void test_uint64_wraparound(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_watchdog_record_t record;
+    fake_clock_t clock = {.now_us = UINT64_MAX - 100000u};
+    uint64_t deadline = clock.now_us + MCU_SOFTWARE_WATCHDOG_TIMEOUT_US;
+
+    mcu_watchdog_init(&watchdog, UINT32_MAX);
+    start_move(&machine);
+    check(report,
+          mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, clock.now_us));
+    check(report, watchdog.link_deadline_us == deadline);
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, deadline - 1u, &record));
+    check(report, machine.state == MCU_STATE_EXECUTING);
+    check(report, mcu_watchdog_poll(&watchdog, &machine, deadline, &record));
+    check(report, record.frame.sequence_no == UINT32_MAX);
+    check(report, watchdog.next_telemetry_sequence == 0u);
+    check(report, machine.state == MCU_STATE_FAULT);
+}
+
+static void test_stop_ack_within_bound(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_wire_frame_t stop;
+    mcu_watchdog_record_t record;
+    fake_clock_t clock = {.now_us = 50000u};
+    uint64_t deadline;
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    check(report,
+          mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, clock.now_us));
+    make_stop(&stop, MCU_STOP_ID_MIN + 9u, 2u);
+    check(report, mcu_watchdog_receive_stop(&watchdog, &machine, &stop, clock.now_us, &record));
+    deadline = clock.now_us + MCU_STOP_ACK_DEADLINE_US;
+
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, machine.device_mode == MCU_DEVICE_MODE_STOPPED);
+    check(report, !watchdog.link_watchdog_armed);
+    check(report, watchdog.stop_ack_pending);
+    check(report, watchdog.stop_deadline_us == deadline);
+    check(report, record.kind == MCU_WATCHDOG_RECORD_STOP_ACK);
+    check(report, record.command_id == stop.command_id);
+    check(report, record.retry_count == stop.retry_count);
+    check(report, record.deadline_us == deadline);
+    check(report, record.observed_at_us == clock.now_us);
+    check(report, record.frame.kind == MCU_WIRE_FRAME_STOP_ACK);
+    check(report, record.frame.command_id == stop.command_id);
+    check(report, record.frame.retry_count == stop.retry_count);
+    check(report, record.frame.result_code == MCU_WIRE_RESULT_ACCEPTED);
+    check(report, record.frame.fault_code == MCU_WIRE_FAULT_NONE);
+    check(report, record.frame.device_mode == MCU_WIRE_MODE_STOPPED);
+    check(report, record_frame_encodes(&record));
+
+    check(report,
+          !mcu_watchdog_confirm_stop_ack(
+            &watchdog, (uint16_t)(stop.command_id + 1u), stop.retry_count, deadline));
+    check(report, watchdog.stop_ack_pending);
+    check(report,
+          mcu_watchdog_confirm_stop_ack(
+            &watchdog, stop.command_id, stop.retry_count, deadline));
+    check(report, !watchdog.stop_ack_pending);
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, deadline + 1u, &record));
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+}
+
+static void test_stop_timeout_is_distinct_and_latched(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_wire_frame_t stop;
+    mcu_watchdog_record_t record;
+    mcu_transition_result_t reset;
+    fake_clock_t clock = {.now_us = UINT64_MAX - 4000u};
+    uint64_t deadline = clock.now_us + MCU_STOP_ACK_DEADLINE_US;
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    make_stop(&stop, MCU_STOP_ID_MIN, 255u);
+    check(report, mcu_watchdog_receive_stop(&watchdog, &machine, &stop, clock.now_us, &record));
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, deadline, &record));
+    check(report, watchdog.stop_ack_pending);
+    check(report, mcu_watchdog_poll(&watchdog, &machine, deadline + 1u, &record));
+    check(report, record.kind == MCU_WATCHDOG_RECORD_STOP_TIMEOUT);
+    check(report, record.fault == MCU_WATCHDOG_FAULT_STOP_TIMEOUT);
+    check(report, record.command_id == stop.command_id);
+    check(report, record.retry_count == stop.retry_count);
+    check(report, record.deadline_us == deadline);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, machine.device_mode == MCU_DEVICE_MODE_STOPPED);
+    check(report, !watchdog.stop_ack_pending);
+    check(report, watchdog.stop_timeout_cause_active);
+    check(report,
+          !mcu_watchdog_receive_stop(&watchdog, &machine, &stop, deadline + 2u, &record));
+    check(report,
+          !mcu_watchdog_confirm_stop_ack(
+            &watchdog, stop.command_id, stop.retry_count, deadline + 1u));
+
+    record.kind = MCU_WATCHDOG_RECORD_STOP_ACK;
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, deadline + 2u, &record));
+    check(report, record.kind == MCU_WATCHDOG_RECORD_STOP_ACK);
+    check(report,
+          !mcu_watchdog_request_reset(&watchdog, &machine, true, true, &reset));
+    check(report, reset.reason == MCU_REASON_RESET_CAUSE_ACTIVE);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    mcu_watchdog_mark_causes_cleared(&watchdog);
+    check(report,
+          !mcu_watchdog_request_reset(&watchdog, &machine, false, true, &reset));
+    check(report, reset.reason == MCU_REASON_RESET_NOT_AUTHORIZED);
+    check(report, mcu_watchdog_request_reset(&watchdog, &machine, true, true, &reset));
+    check(report, machine.state == MCU_STATE_IDLE);
+}
+
+static void test_watchdog_reset_requires_live_cause_clear(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_watchdog_record_t record;
+    mcu_transition_result_t reset;
+    fake_clock_t clock = {.now_us = 8u};
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    check(report,
+          mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, clock.now_us));
+    check(report,
+          mcu_watchdog_poll(
+            &watchdog, &machine, clock.now_us + MCU_SOFTWARE_WATCHDOG_TIMEOUT_US, &record));
+    check(report, watchdog.watchdog_cause_active);
+    check(report,
+          !mcu_watchdog_request_reset(&watchdog, &machine, true, true, &reset));
+    check(report, reset.reason == MCU_REASON_RESET_CAUSE_ACTIVE);
+    check(report, machine.state == MCU_STATE_FAULT);
+    mcu_watchdog_mark_causes_cleared(&watchdog);
+    check(report, mcu_watchdog_request_reset(&watchdog, &machine, true, true, &reset));
+    check(report, machine.state == MCU_STATE_IDLE);
+    check(report, !watchdog.watchdog_record_emitted);
+}
+
+static void test_invalid_inputs_and_hardware_feed_gate(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_watchdog_record_t record;
+    mcu_wire_frame_t stop;
+
+    mcu_watchdog_init(&watchdog, 0u);
+    mcu_sm_init(&machine);
+    check(report, mcu_watchdog_is_valid(&watchdog));
+    check(report, mcu_watchdog_should_feed_hardware(&watchdog, &machine));
+    check(report, !mcu_watchdog_should_feed_hardware(0, &machine));
+    check(report, !mcu_watchdog_should_feed_hardware(&watchdog, 0));
+
+    machine.device_mode = MCU_DEVICE_MODE_MOVING;
+    check(report, !mcu_watchdog_should_feed_hardware(&watchdog, &machine));
+    check(report,
+          !mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, 0u));
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, 0u, &record));
+
+    mcu_sm_init(&machine);
+    make_stop(&stop, MCU_STOP_ID_MIN, 0u);
+    stop.opcode = MCU_WIRE_OPCODE_HEARTBEAT;
+    check(report, !mcu_watchdog_receive_stop(&watchdog, &machine, &stop, 0u, &record));
+    check(report, machine.state == MCU_STATE_IDLE);
+    check(report, !watchdog.stop_ack_pending);
+
+    watchdog.initialized = 0u;
+    check(report, !mcu_watchdog_is_valid(&watchdog));
+    check(report, !mcu_watchdog_poll(&watchdog, &machine, 0u, &record));
+}
+
+void mcu_watchdog_run_tests(mcu_test_report_t *report)
+{
+    if (report == 0) {
+        return;
+    }
+
+    report->assertions = 0u;
+    report->failures = 0u;
+    report->first_failure = 0u;
+
+    test_controlled_constants(report);
+    test_only_valid_new_activity_feeds(report);
+    test_watchdog_deadline_and_single_record(report);
+    test_uint64_wraparound(report);
+    test_stop_ack_within_bound(report);
+    test_stop_timeout_is_distinct_and_latched(report);
+    test_watchdog_reset_requires_live_cause_clear(report);
+    test_invalid_inputs_and_hardware_feed_gate(report);
+}

--- a/firmware/mcu/tests/watchdog_tests.c
+++ b/firmware/mcu/tests/watchdog_tests.c
@@ -284,6 +284,60 @@ static void test_stop_ack_retry_replays_original_after_fault(mcu_test_report_t *
     check(report, watchdog.stop_ack_pending);
 }
 
+static void test_stop_ack_protocol_retry_echoes_count(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_wire_frame_t stop;
+    mcu_wire_frame_t retry;
+    mcu_watchdog_record_t first_record;
+    mcu_watchdog_record_t retry_record;
+    mcu_watchdog_record_t duplicate_record;
+    mcu_transition_result_t transition;
+    mcu_event_t event;
+    uint64_t now_us = 71000u;
+    uint64_t retry_now_us = now_us + 2u;
+    uint64_t deadline;
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    make_stop(&stop, MCU_STOP_ID_MIN + 11u, 7u);
+    check(report, mcu_watchdog_receive_stop(&watchdog, &machine, &stop, now_us, &first_record));
+    deadline = watchdog.stop_deadline_us;
+
+    event.kind = MCU_EVENT_RAISE_FAULT;
+    event.fault_code = MCU_FAULT_MALFORMED_FRAME;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(&machine, &event, &transition);
+    check(report, machine.state == MCU_STATE_FAULT);
+
+    make_stop(&retry, stop.command_id, (uint8_t)(stop.retry_count + 1u));
+    check(report,
+          mcu_watchdog_receive_stop(&watchdog, &machine, &retry, retry_now_us, &retry_record));
+    check(report, retry_record.kind == MCU_WATCHDOG_RECORD_STOP_ACK);
+    check(report, retry_record.command_id == stop.command_id);
+    check(report, retry_record.retry_count == retry.retry_count);
+    check(report, retry_record.frame.retry_count == retry.retry_count);
+    check(report, retry_record.frame.result_code == first_record.frame.result_code);
+    check(report, retry_record.frame.fault_code == first_record.frame.fault_code);
+    check(report, retry_record.frame.device_mode == first_record.frame.device_mode);
+    check(report, retry_record.observed_at_us == retry_now_us);
+    check(report, retry_record.deadline_us == deadline);
+    check(report, watchdog.stop_deadline_us == deadline);
+    check(report, watchdog.stop_retry_count == retry.retry_count);
+    check(report, record_frame_encodes(&retry_record));
+
+    check(report,
+          mcu_watchdog_receive_stop(
+            &watchdog, &machine, &retry, retry_now_us + 1u, &duplicate_record));
+    check(report, records_equal(&duplicate_record, &retry_record));
+    check(report,
+          mcu_watchdog_confirm_stop_ack(
+            &watchdog, retry.command_id, retry.retry_count, deadline));
+    check(report, !watchdog.stop_ack_pending);
+}
+
 static void test_stop_timeout_is_distinct_and_latched(mcu_test_report_t *report)
 {
     mcu_watchdog_t watchdog;
@@ -445,6 +499,7 @@ void mcu_watchdog_run_tests(mcu_test_report_t *report)
     test_uint64_wraparound(report);
     test_stop_ack_within_bound(report);
     test_stop_ack_retry_replays_original_after_fault(report);
+    test_stop_ack_protocol_retry_echoes_count(report);
     test_stop_timeout_is_distinct_and_latched(report);
     test_watchdog_reset_requires_live_cause_clear(report);
     test_hardware_feed_policy_in_latched_fault(report);

--- a/firmware/mcu/tests/watchdog_tests.c
+++ b/firmware/mcu/tests/watchdog_tests.c
@@ -303,6 +303,31 @@ static void test_watchdog_reset_requires_live_cause_clear(mcu_test_report_t *rep
     check(report, !watchdog.watchdog_record_emitted);
 }
 
+static void test_hardware_feed_policy_in_latched_fault(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_watchdog_record_t record;
+    fake_clock_t clock = {.now_us = 21u};
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    check(report,
+          mcu_watchdog_note_activity(
+            &watchdog, &machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, clock.now_us));
+    check(report,
+          mcu_watchdog_poll(
+            &watchdog, &machine, clock.now_us + MCU_SOFTWARE_WATCHDOG_TIMEOUT_US, &record));
+    check(report, machine.state == MCU_STATE_FAULT);
+    check(report, watchdog.watchdog_cause_active);
+    check(report, !mcu_watchdog_should_feed_hardware(&watchdog, &machine));
+
+    mcu_watchdog_mark_causes_cleared(&watchdog);
+    check(report, machine.state == MCU_STATE_FAULT);
+    check(report, !watchdog.watchdog_cause_active);
+    check(report, mcu_watchdog_should_feed_hardware(&watchdog, &machine));
+}
+
 static void test_invalid_inputs_and_hardware_feed_gate(mcu_test_report_t *report)
 {
     mcu_watchdog_t watchdog;
@@ -353,5 +378,6 @@ void mcu_watchdog_run_tests(mcu_test_report_t *report)
     test_stop_ack_within_bound(report);
     test_stop_timeout_is_distinct_and_latched(report);
     test_watchdog_reset_requires_live_cause_clear(report);
+    test_hardware_feed_policy_in_latched_fault(report);
     test_invalid_inputs_and_hardware_feed_gate(report);
 }

--- a/firmware/mcu/tests/watchdog_tests.c
+++ b/firmware/mcu/tests/watchdog_tests.c
@@ -338,6 +338,72 @@ static void test_stop_ack_protocol_retry_echoes_count(mcu_test_report_t *report)
     check(report, !watchdog.stop_ack_pending);
 }
 
+static void test_stop_ack_rejects_stale_protocol_retry(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_wire_frame_t stop;
+    mcu_wire_frame_t retry;
+    mcu_wire_frame_t stale;
+    mcu_watchdog_record_t record;
+    mcu_watchdog_record_t latest_record;
+    mcu_watchdog_record_t stale_record;
+    uint64_t now_us = 72000u;
+    uint64_t deadline;
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    make_stop(&stop, MCU_STOP_ID_MIN + 12u, 0u);
+    check(report, mcu_watchdog_receive_stop(&watchdog, &machine, &stop, now_us, &record));
+    deadline = watchdog.stop_deadline_us;
+
+    make_stop(&retry, stop.command_id, 1u);
+    check(report,
+          mcu_watchdog_receive_stop(&watchdog, &machine, &retry, now_us + 1u, &record));
+    make_stop(&retry, stop.command_id, 2u);
+    check(report,
+          mcu_watchdog_receive_stop(&watchdog, &machine, &retry, now_us + 2u, &latest_record));
+    check(report, watchdog.stop_retry_count == retry.retry_count);
+    check(report, watchdog.stop_ack_pending);
+
+    make_stop(&stale, stop.command_id, 1u);
+    stale_record.kind = MCU_WATCHDOG_RECORD_NONE;
+    check(report,
+          !mcu_watchdog_receive_stop(&watchdog, &machine, &stale, now_us + 3u, &stale_record));
+    check(report, stale_record.kind == MCU_WATCHDOG_RECORD_NONE);
+    check(report, watchdog.stop_retry_count == retry.retry_count);
+    check(report, watchdog.stop_deadline_us == deadline);
+    check(report, watchdog.stop_ack_pending);
+    check(report,
+          !mcu_watchdog_confirm_stop_ack(
+            &watchdog, stale.command_id, stale.retry_count, deadline));
+    check(report,
+          mcu_watchdog_confirm_stop_ack(
+            &watchdog, retry.command_id, retry.retry_count, deadline));
+    check(report, !watchdog.stop_ack_pending);
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    make_stop(&stop, MCU_STOP_ID_MIN + 13u, 255u);
+    check(report, mcu_watchdog_receive_stop(&watchdog, &machine, &stop, now_us, &record));
+    deadline = watchdog.stop_deadline_us;
+    make_stop(&stale, stop.command_id, 0u);
+    stale_record.kind = MCU_WATCHDOG_RECORD_NONE;
+    check(report,
+          !mcu_watchdog_receive_stop(&watchdog, &machine, &stale, now_us + 1u, &stale_record));
+    check(report, stale_record.kind == MCU_WATCHDOG_RECORD_NONE);
+    check(report, watchdog.stop_retry_count == 255u);
+    check(report, watchdog.stop_deadline_us == deadline);
+    check(report, watchdog.stop_ack_pending);
+    check(report,
+          !mcu_watchdog_confirm_stop_ack(
+            &watchdog, stale.command_id, stale.retry_count, deadline));
+    check(report,
+          mcu_watchdog_confirm_stop_ack(
+            &watchdog, stop.command_id, stop.retry_count, deadline));
+    check(report, !watchdog.stop_ack_pending);
+}
+
 static void test_stop_timeout_is_distinct_and_latched(mcu_test_report_t *report)
 {
     mcu_watchdog_t watchdog;
@@ -500,6 +566,7 @@ void mcu_watchdog_run_tests(mcu_test_report_t *report)
     test_stop_ack_within_bound(report);
     test_stop_ack_retry_replays_original_after_fault(report);
     test_stop_ack_protocol_retry_echoes_count(report);
+    test_stop_ack_rejects_stale_protocol_retry(report);
     test_stop_timeout_is_distinct_and_latched(report);
     test_watchdog_reset_requires_live_cause_clear(report);
     test_hardware_feed_policy_in_latched_fault(report);

--- a/firmware/mcu/tests/watchdog_tests.c
+++ b/firmware/mcu/tests/watchdog_tests.c
@@ -65,6 +65,23 @@ static bool record_frame_encodes(const mcu_watchdog_record_t *record)
            length == MCU_WIRE_DLC;
 }
 
+static bool frames_equal(const mcu_wire_frame_t *left, const mcu_wire_frame_t *right)
+{
+    return left->kind == right->kind && left->command_id == right->command_id &&
+           left->sequence_no == right->sequence_no && left->opcode == right->opcode &&
+           left->retry_count == right->retry_count && left->result_code == right->result_code &&
+           left->fault_code == right->fault_code && left->device_mode == right->device_mode;
+}
+
+static bool records_equal(const mcu_watchdog_record_t *left,
+                          const mcu_watchdog_record_t *right)
+{
+    return left->kind == right->kind && left->fault == right->fault &&
+           left->observed_at_us == right->observed_at_us &&
+           left->deadline_us == right->deadline_us && left->command_id == right->command_id &&
+           left->retry_count == right->retry_count && frames_equal(&left->frame, &right->frame);
+}
+
 static void test_controlled_constants(mcu_test_report_t *report)
 {
     check(report, MCU_HEARTBEAT_PERIOD_US > 0u);
@@ -229,6 +246,44 @@ static void test_stop_ack_within_bound(mcu_test_report_t *report)
     check(report, machine.state == MCU_STATE_SAFE_STOP);
 }
 
+static void test_stop_ack_retry_replays_original_after_fault(mcu_test_report_t *report)
+{
+    mcu_watchdog_t watchdog;
+    mcu_state_machine_t machine;
+    mcu_wire_frame_t stop;
+    mcu_watchdog_record_t first_record;
+    mcu_watchdog_record_t retry_record;
+    mcu_transition_result_t transition;
+    mcu_event_t event;
+    uint64_t now_us = 70000u;
+    uint64_t deadline;
+
+    mcu_watchdog_init(&watchdog, 0u);
+    start_move(&machine);
+    make_stop(&stop, MCU_STOP_ID_MIN + 10u, 3u);
+    check(report, mcu_watchdog_receive_stop(&watchdog, &machine, &stop, now_us, &first_record));
+    deadline = watchdog.stop_deadline_us;
+    check(report, first_record.frame.result_code == MCU_WIRE_RESULT_ACCEPTED);
+    check(report, first_record.frame.fault_code == MCU_WIRE_FAULT_NONE);
+    check(report, first_record.frame.device_mode == MCU_WIRE_MODE_STOPPED);
+
+    event.kind = MCU_EVENT_RAISE_FAULT;
+    event.fault_code = MCU_FAULT_MALFORMED_FRAME;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(&machine, &event, &transition);
+    check(report, machine.state == MCU_STATE_FAULT);
+    check(report, !watchdog.watchdog_cause_active);
+    check(report, !watchdog.stop_timeout_cause_active);
+
+    check(report,
+          mcu_watchdog_receive_stop(
+            &watchdog, &machine, &stop, now_us + 1u, &retry_record));
+    check(report, records_equal(&retry_record, &first_record));
+    check(report, watchdog.stop_deadline_us == deadline);
+    check(report, watchdog.stop_ack_pending);
+}
+
 static void test_stop_timeout_is_distinct_and_latched(mcu_test_report_t *report)
 {
     mcu_watchdog_t watchdog;
@@ -308,6 +363,8 @@ static void test_hardware_feed_policy_in_latched_fault(mcu_test_report_t *report
     mcu_watchdog_t watchdog;
     mcu_state_machine_t machine;
     mcu_watchdog_record_t record;
+    mcu_transition_result_t transition;
+    mcu_event_t event;
     fake_clock_t clock = {.now_us = 21u};
 
     mcu_watchdog_init(&watchdog, 0u);
@@ -325,7 +382,18 @@ static void test_hardware_feed_policy_in_latched_fault(mcu_test_report_t *report
     mcu_watchdog_mark_causes_cleared(&watchdog);
     check(report, machine.state == MCU_STATE_FAULT);
     check(report, !watchdog.watchdog_cause_active);
-    check(report, mcu_watchdog_should_feed_hardware(&watchdog, &machine));
+    check(report, !mcu_watchdog_should_feed_hardware(&watchdog, &machine));
+
+    mcu_sm_init(&machine);
+    event.kind = MCU_EVENT_RAISE_FAULT;
+    event.fault_code = MCU_FAULT_MALFORMED_FRAME;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(&machine, &event, &transition);
+    check(report, machine.state == MCU_STATE_FAULT);
+    check(report, !watchdog.watchdog_cause_active);
+    check(report, !watchdog.stop_timeout_cause_active);
+    check(report, !mcu_watchdog_should_feed_hardware(&watchdog, &machine));
 }
 
 static void test_invalid_inputs_and_hardware_feed_gate(mcu_test_report_t *report)
@@ -376,6 +444,7 @@ void mcu_watchdog_run_tests(mcu_test_report_t *report)
     test_watchdog_deadline_and_single_record(report);
     test_uint64_wraparound(report);
     test_stop_ack_within_bound(report);
+    test_stop_ack_retry_replays_original_after_fault(report);
     test_stop_timeout_is_distinct_and_latched(report);
     test_watchdog_reset_requires_live_cause_clear(report);
     test_hardware_feed_policy_in_latched_fault(report);

--- a/firmware/mcu/tests/watchdog_tests.h
+++ b/firmware/mcu/tests/watchdog_tests.h
@@ -1,0 +1,8 @@
+#ifndef MCU_WATCHDOG_TESTS_H
+#define MCU_WATCHDOG_TESTS_H
+
+#include "state_machine_tests.h"
+
+void mcu_watchdog_run_tests(mcu_test_report_t *report);
+
+#endif /* MCU_WATCHDOG_TESTS_H */


### PR DESCRIPTION
## Summary

Implements Issue #60 by adding the MCU heartbeat watchdog and bounded STOP acknowledgement timing path.

## Changes

- Added the platform-independent `watchdog.[ch]` core module.
- Defined controlled timing constants for:
  - Heartbeat period: `50 ms`
  - Software link watchdog timeout: `150 ms`
  - STOP ACK deadline: `10 ms`
  - Hardware watchdog period: `500 ms`
- Only completely validated and serially new ordinary activity can refresh the software watchdog.
- Retries, duplicates, stale frames, malformed frames, and STOP frames cannot extend the execution deadline.
- Watchdog expiration:
  - Dispatches `MCU_EVENT_WATCHDOG_EXPIRED`
  - Enters the latched `FAULT/watchdog_expired` state
  - Emits exactly one correlated telemetry record
- STOP handling:
  - Immediately transitions the state machine to `SAFE_STOP`
  - Preserves STOP command correlation
  - Generates a bounded `STOP_ACK`
  - Accepts confirmation at the exact deadline
  - Rejects late confirmation
  - Emits a distinct local `STOP_TIMEOUT` result when confirmation is not received
- Added overflow-safe `uint64_t` deadline comparisons.
- Added Host fake-clock HAL support.
- Added QEMU machine-timer interrupt handling and modeled hardware-watchdog start/feed/expiry behavior.
- Added shared Host/QEMU watchdog timing tests.
- Added the Issue #60 Task Packet and timing architecture documentation.
- Fixed the MCU `size-check` `.bss` section parsing.

## Verification

- Host tests:
  - State machine: `436 assertions, 0 failures`
  - Frame codec: `20637 assertions, 0 failures`
  - Watchdog: `120 assertions, 0 failures`
- ASan/UBSan tests: passed
- QEMU tests: passed
- QEMU timing evidence:
  - `timer interrupts=12`
  - `fault_records=1`
  - `wdt_feeds=2`
  - `wdt_expired=1`
- Firmware size:
  - `.text=13716`
  - `.bss=156`
- No floating-point instructions or allocator symbols
- Full repository test suite: `458 passed`
- Passed contract, scenario, context, lint/format, strict documentation build, Task Packet, and diff checks

## Scope and limitations

This PR does not include:

- CH32V307 physical interrupt-latency validation
- Physical E-stop or mechanical stopping-time measurement
- CAN HAL driver implementation
- Host transport implementation from Issue #55
- Command deduplication from Issue #61
- Bus-off recovery
- Physical CAN bus validation

QEMU evidence validates the shared timing logic, timer-interrupt routing, and watchdog feed decision only. It does not represent physical hardware or mechanical safety evidence.

Closes #60