### PR TITLE
fix(hardware): reject dangling URDF transmission references

### DIFF
--- a/docs/task_packets/issue-185-urdf-transmission-references.json
+++ b/docs/task_packets/issue-185-urdf-transmission-references.json
@@ -1,0 +1,53 @@
+{
+  "issue": 185,
+  "human_owner": "TH3478",
+  "objective": "Make the expanded-URDF motor configuration parser reject dangling, unsupported, duplicate, blank, or otherwise ambiguous transmission joint references before publishing motor configuration.",
+  "allowed_paths": [
+    "libs/hardware/workbench/hardware/urdf_parser.py",
+    "tests/unit/test_hardware_urdf.py",
+    "docs/task_packets/issue-185-urdf-transmission-references.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "libs/hardware/README.md",
+    "docs/task_packets/hw1-urdf-parser.json",
+    "robot/control/**",
+    "robot/description/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**",
+    "libs/hardware/workbench/hardware/can_driver_safe.py"
+  ],
+  "acceptance": [
+    "Every transmission joint references exactly one declared continuous or revolute joint in the expanded URDF.",
+    "Dangling, blank, fixed, unsupported, duplicate, and structurally ambiguous transmission references fail with UrdfMotorConfigError that identifies the transmission and relevant joint reference.",
+    "A valid transmission for a supported actuated joint outside the requested joint_names selection remains valid.",
+    "An expanded URDF with no transmissions remains valid and reports mechanical_reduction as unknown.",
+    "Selected joints retain validated finite positive mechanical reductions from valid transmissions.",
+    "Focused tests cover the dangling-reference reproduction, invalid reference classes, unselected valid transmissions, no-transmission input, and valid multi-joint reductions."
+  ],
+  "commands": [
+    "python3 -m pytest tests/unit/test_hardware_urdf.py -v",
+    "python3 -m ruff check libs/hardware/workbench/hardware/urdf_parser.py tests/unit/test_hardware_urdf.py",
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-185-urdf-transmission-references.json",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "Focused URDF parser regression output covering invalid and valid transmission references.",
+    "Task Packet validation and changed-path boundary output.",
+    "Full repository test, contract, scenario, and context-check output.",
+    "Final git diff --check and changed-path review."
+  ],
+  "stop_conditions": [
+    "The fix requires a general URDF or Xacro evaluator.",
+    "The fix requires changing interfaces, firmware, robot control, CAN transport, or motion safety behavior.",
+    "A transmission reference would need to be guessed or normalized instead of validated against the expanded URDF.",
+    "A write outside the allowed paths is required.",
+    "The existing valid official UR5e extraction can no longer be represented without inventing hardware data."
+  ]
+}

--- a/libs/hardware/workbench/hardware/urdf_parser.py
+++ b/libs/hardware/workbench/hardware/urdf_parser.py
@@ -34,7 +34,10 @@ def _required_float(value: str | None, field: str, joint_name: str, *, positive:
     return parsed
 
 
-def _transmission_reductions(root: ElementTree.Element) -> dict[str, float]:
+def _transmission_reductions(
+    root: ElementTree.Element,
+    supported_joint_names: set[str],
+) -> dict[str, float]:
     reductions: dict[str, float] = {}
     transmission_joints: set[str] = set()
     for transmission in root.findall("./transmission"):
@@ -47,9 +50,15 @@ def _transmission_reductions(root: ElementTree.Element) -> dict[str, float]:
             )
         joint_name = joint_elements[0].get("name")
         if not joint_name or not joint_name.strip():
-            raise UrdfMotorConfigError("a transmission joint is missing its name")
+            raise UrdfMotorConfigError(f"transmission {transmission_name!r} has a blank joint reference")
+        if joint_name not in supported_joint_names:
+            raise UrdfMotorConfigError(
+                f"transmission {transmission_name!r} references unknown or unsupported joint {joint_name!r}"
+            )
         if joint_name in transmission_joints:
-            raise UrdfMotorConfigError(f"joint {joint_name!r} has multiple transmission declarations")
+            raise UrdfMotorConfigError(
+                f"transmission {transmission_name!r} duplicates transmission reference to joint {joint_name!r}"
+            )
         transmission_joints.add(joint_name)
 
         actuator = actuator_elements[0]
@@ -121,7 +130,7 @@ def parse_urdf_motor_config(
     if not selected_names:
         raise UrdfMotorConfigError("expanded URDF contains no actuated joints")
 
-    reductions = _transmission_reductions(root)
+    reductions = _transmission_reductions(root, set(joints))
     configs: list[MotorConfig] = []
     for joint_name in selected_names:
         joint = joints.get(joint_name)

--- a/tests/unit/test_hardware_urdf.py
+++ b/tests/unit/test_hardware_urdf.py
@@ -112,8 +112,99 @@ class HardwareUrdfTests(unittest.TestCase):
 """,
         )
 
-        with self.assertRaises(UrdfMotorConfigError):
+        with self.assertRaisesRegex(
+            UrdfMotorConfigError,
+            "shoulder_pan_trans_duplicate.*shoulder_pan_joint",
+        ):
             parse_urdf_motor_config(duplicate, ARM_JOINTS)
+
+    def test_rejects_dangling_transmission_joint_reference(self) -> None:
+        dangling = UR5E_SHAPE_URDF.replace(
+            '<joint name="shoulder_pan_joint"/>',
+            '<joint name="typo_joint"/>',
+            1,
+        )
+
+        with self.assertRaisesRegex(UrdfMotorConfigError, "shoulder_pan_trans.*typo_joint"):
+            parse_urdf_motor_config(dangling, ARM_JOINTS)
+
+    def test_rejects_unsupported_and_blank_transmission_joint_references(self) -> None:
+        cases = {
+            "fixed joint": (
+                UR5E_SHAPE_URDF.replace(
+                    '<joint name="shoulder_pan_joint"/>',
+                    '<joint name="world_joint"/>',
+                    1,
+                ),
+                "world_joint",
+            ),
+            "unknown joint": (
+                UR5E_SHAPE_URDF.replace(
+                    '<joint name="shoulder_pan_joint"/>',
+                    '<joint name="not_declared"/>',
+                    1,
+                ),
+                "not_declared",
+            ),
+            "blank joint": (
+                UR5E_SHAPE_URDF.replace(
+                    '<joint name="shoulder_pan_joint"/>',
+                    '<joint name="   "/>',
+                    1,
+                ),
+                "blank joint reference",
+            ),
+        }
+
+        for label, (urdf_xml, expected_reference) in cases.items():
+            with (
+                self.subTest(label=label),
+                self.assertRaisesRegex(
+                    UrdfMotorConfigError,
+                    f"shoulder_pan_trans.*{expected_reference}",
+                ),
+            ):
+                parse_urdf_motor_config(urdf_xml, ARM_JOINTS)
+
+    def test_valid_unselected_transmission_is_validated_but_not_selected(self) -> None:
+        with_reduction = UR5E_SHAPE_URDF.replace(
+            "</robot>",
+            """
+  <transmission name="elbow_trans">
+    <joint name="elbow_joint"/>
+    <actuator name="elbow_motor"><mechanicalReduction>2</mechanicalReduction></actuator>
+  </transmission>
+</robot>
+""",
+        )
+
+        configs = parse_urdf_motor_config(with_reduction, ("shoulder_pan_joint",))
+
+        self.assertEqual(len(configs), 1)
+        self.assertEqual(configs[0].name, "shoulder_pan_joint")
+        self.assertEqual(configs[0].mechanical_reduction, 1.0)
+
+        selected_configs = parse_urdf_motor_config(
+            with_reduction,
+            ("shoulder_pan_joint", "elbow_joint"),
+        )
+        self.assertEqual(
+            tuple(config.mechanical_reduction for config in selected_configs),
+            (1.0, 2.0),
+        )
+
+    def test_urdf_without_transmissions_keeps_reduction_unknown(self) -> None:
+        without_transmissions = UR5E_SHAPE_URDF.replace(
+            '  <transmission name="shoulder_pan_trans">\n'
+            '    <joint name="shoulder_pan_joint"/>\n'
+            '    <actuator name="shoulder_pan_motor"><mechanicalReduction>1</mechanicalReduction></actuator>\n'
+            "  </transmission>\n",
+            "",
+        )
+
+        configs = parse_urdf_motor_config(without_transmissions, ("shoulder_pan_joint",))
+
+        self.assertIsNone(configs[0].mechanical_reduction)
 
     def test_rejects_duplicate_limit_elements(self) -> None:
         duplicate = UR5E_SHAPE_URDF.replace(


### PR DESCRIPTION
## Summary

Fixes #185.

Make the expanded URDF motor configuration parser fail closed when a transmission references an invalid joint.

## Changes

- Validate every transmission joint against all declared `continuous` and `revolute` joints.
- Reject dangling, blank, fixed/unsupported, duplicate, and ambiguous references.
- Include the offending transmission and joint in `UrdfMotorConfigError` messages.
- Preserve valid transmissions for actuated joints not selected by `joint_names`.
- Preserve `mechanical_reduction=None` when the URDF has no transmissions.
- Add focused regression tests and an Issue #185 Task Packet.

## Verification

- Focused URDF tests: 13 passed
- Full test suite: 462 passed
- `make lint`
- `make contract`
- `make scenario-check`
- `make context-check`
- Task Packet validation
- `git diff --check`

## Scope

This change is limited to the URDF parser, its unit tests, and one Task Packet. It does not modify firmware, CAN transport, robot control, interfaces, or motion safety behavior.