### PR TITLE
fix(kernel): preserve generated MCU frame round trips

### DIFF
--- a/docs/task_packets/kernel-schema-mcu-branch-validation.json
+++ b/docs/task_packets/kernel-schema-mcu-branch-validation.json
@@ -23,6 +23,7 @@
     "generated MCU frames enforce branch-required fields",
     "generated MCU frames reject branch-forbidden fields including legacy sent_at",
     "generated MCU frames enforce current branch const and enum relationships",
+    "generated MCU frames serialize without absent branch fields and round-trip through their own validator",
     "valid repository MCU frame vectors remain accepted",
     "general schema compiler behavior remains bounded"
   ],
@@ -34,7 +35,7 @@
     "make context-check"
   ],
   "evidence": [
-    "generated-model acceptance matches the canonical MCU schema corpus",
+    "generated-model acceptance and serialization round trips match the canonical MCU schema corpus",
     "focused unit and contract checks",
     "Task Packet boundary validation"
   ],

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -341,6 +341,10 @@ def _conditional_validators(schema: dict[str, Any], name: str) -> tuple[list[str
                 "    def _validate_mcu_protocol(cls, value):",
                 "        validate_schema_instance(value, MCU_PROTOCOL_SCHEMA)",
                 "        return value",
+                "",
+                '    @model_serializer(mode="wrap")',
+                "    def _serialize_mcu_protocol(self, handler):",
+                "        return {key: item for key, item in handler(self).items() if item is not None}",
             ],
             schema.get("allOf", []),
         )
@@ -538,10 +542,10 @@ class SchemaCompiler:
             _, conditional_metadata = _conditional_validators(schema, name)
             class_blocks: list[str] = []
             self._append_python_model(model_name, schema, name, class_blocks, {})
-            python_code = (
-                "from typing import Annotated, Any, Literal\n\n"
-                "from pydantic import BaseModel, ConfigDict, Field, model_validator\n"
-            )
+            pydantic_imports = "BaseModel, ConfigDict, Field, model_validator"
+            if name == "mcu_protocol":
+                pydantic_imports = "BaseModel, ConfigDict, Field, model_serializer, model_validator"
+            python_code = f"from typing import Annotated, Any, Literal\n\nfrom pydantic import {pydantic_imports}\n"
             if name == "mcu_protocol":
                 python_code += "from workbench.kernel.schema_compiler import validate_schema_instance\n"
                 python_code += f"\n\nMCU_PROTOCOL_SCHEMA = {schema!r}\n"

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -103,6 +103,7 @@ def test_generated_mcu_model_enforces_protocol_branches(tmp_path: Path) -> None:
         invalid.append(payload)
     for updates in (
         {"sent_at": "legacy"},
+        {"sequence_no": None},
         {"opcode": "hold"},
         {"result_code": 0, "fault_code": "stop_rejected", "device_mode": "faulted"},
         {"result_code": 1, "fault_code": "none", "device_mode": "stopped"},
@@ -110,7 +111,10 @@ def test_generated_mcu_model_enforces_protocol_branches(tmp_path: Path) -> None:
         payload = {**valid, **updates}
         invalid.append(payload)
 
-    assert mcu_frame.model_validate(valid)
+    frame = mcu_frame.model_validate(valid)
+    serialized = frame.model_dump(mode="json")
+    assert serialized == valid
+    assert mcu_frame.model_validate(serialized) == frame
     for payload in invalid:
         assert list(Draft202012Validator(schema).iter_errors(payload))
         with pytest.raises(ValueError):

--- a/tests/unit/test_mcu_protocol_contract.py
+++ b/tests/unit/test_mcu_protocol_contract.py
@@ -261,7 +261,10 @@ def test_repository_schema_compiler_enforces_protocol_branches(tmp_path: Path) -
     exec(compile(generated.read_text(encoding="utf-8"), str(generated), "exec"), namespace)
     generated_model = namespace["McuFrame"]
     for label, payload in VALID_FRAMES.items():
-        assert generated_model.model_validate(payload), label
+        frame = generated_model.model_validate(payload)
+        serialized = frame.model_dump(mode="json")
+        assert serialized == payload, label
+        assert generated_model.model_validate(serialized) == frame, label
     for payload in INVALID_FRAMES.values():
         with pytest.raises(ValidationError):
             generated_model.model_validate(payload)


### PR DESCRIPTION
Follow-up to #212: generated McuFrame.model_dump() emitted None for absent branch fields, then the strict validator rejected its own serialized output. This change omits unset optional branch fields during generated MCU serialization, keeps explicit null and forbidden-field rejection, and adds round-trip coverage. Verification: 65 focused schema/compiler and MCU contract tests passed; Ruff, Task Packet, contract, and context checks passed. Fixes #212.