### PR TITLE
fix(backend): constrain remote event-source egress

### DIFF
--- a/docs/task_packets/issue-71-backend-egress-policy.json
+++ b/docs/task_packets/issue-71-backend-egress-policy.json
@@ -1,0 +1,113 @@
+{
+  "issue": 71,
+  "human_owner": "kukuboring",
+  "objective": "Constrain the Backend remote Dashboard event-source HTTP client to loopback or an explicit IP/CIDR allow-list, pin validated DNS results to the actual connection, disable redirects, bound remote responses and timeouts, and make invalid configuration fail readiness closed without changing deployment wiring or public data contracts.",
+  "allowed_paths": [
+    "services/backend/workbench_backend/remote_http.py",
+    "services/backend/workbench_backend/read_model.py",
+    "services/backend/workbench_backend/server.py",
+    "tests/unit/test_multi_host.py",
+    "docs/task_packets/issue-71-backend-egress-policy.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "Makefile",
+    "docs/architecture/system.md",
+    "docs/api-openapi-v1.json",
+    "services/backend/workbench_backend/api-openapi-v1.json",
+    "interfaces/json_schema/world_event.schema.json",
+    "apps/dashboard/data/run-confirmed.jsonl",
+    "apps/dashboard/data/run-uncertain.jsonl",
+    "tests/unit/test_dashboard_backend.py",
+    "deploy/multi-host/compose.controller.yaml",
+    "docs/deployment/multi-host.md",
+    "docs/task_packets/example-001-world-reducer.json"
+  ],
+  "forbidden": [
+    "libs/contracts/**",
+    "services/world_model/**",
+    "services/agent_runtime/**",
+    "robot/control/**",
+    "firmware/**",
+    "sim/**",
+    ".github/**"
+  ],
+  "input_refs": [
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "Makefile",
+    "docs/architecture/system.md",
+    "docs/api-openapi-v1.json",
+    "services/backend/workbench_backend/api-openapi-v1.json",
+    "interfaces/json_schema/world_event.schema.json",
+    "apps/dashboard/data/run-confirmed.jsonl",
+    "apps/dashboard/data/run-uncertain.jsonl",
+    "services/backend/workbench_backend/read_model.py",
+    "services/backend/workbench_backend/server.py",
+    "tests/unit/test_multi_host.py",
+    "tests/unit/test_dashboard_backend.py",
+    "deploy/multi-host/compose.controller.yaml",
+    "docs/deployment/multi-host.md",
+    "docs/task_packets/example-001-world-reducer.json"
+  ],
+  "acceptance": [
+    "IPv4 loopback, IPv6 loopback, and localhost are accepted without an allow-list.",
+    "Every non-loopback resolved address must match an explicit comma-separated IP or CIDR allow-list supplied to the Backend application.",
+    "Missing or malformed allow-list configuration rejects every non-loopback target fail closed.",
+    "The Phase A allow-list is supplied only through create_server(..., event_source_allowlist=...) and the --event-source-allowlist CLI argument; this Packet does not add or read WORKBENCH_EVENT_SOURCE_ALLOWLIST and does not modify Compose.",
+    "Credentials, query strings, fragments, non-HTTP schemes, invalid ports, and non-root base paths are rejected.",
+    "Unspecified, link-local, multicast, and reserved addresses are rejected even when mistakenly included in the allow-list.",
+    "Every IPv4 and IPv6 DNS result is validated; mixed permitted and forbidden results fail closed.",
+    "IPv4-mapped IPv6 addresses are evaluated using their effective IPv4 address, and mixed permitted and forbidden effective addresses fail closed.",
+    "The HTTP connection uses the already validated resolved address and does not perform a second unvalidated DNS lookup.",
+    "HTTP redirects are never followed, and a local redirect target receives zero requests.",
+    "Remote responses require an application/json media type with optional charset parameters; a valid JSON response whose complete encoded body is 4194304 bytes is accepted and a 4194305-byte response is rejected, with or without Content-Length.",
+    "A timeout of 2 seconds is accepted; zero, negative, NaN, infinity, and values greater than 2 seconds are rejected before network access.",
+    "Network connection and read timeouts are converted to ReadModelError without retrying an unvalidated destination.",
+    "Invalid remote configuration keeps healthz live while readyz and remote data endpoints fail closed with HTTP 503.",
+    "Existing duplicate JSON key rejection, ordered event handling, read-only API behavior, WorldEvent shape, and OpenAPI v1 contract remain unchanged."
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_multi_host.py tests/unit/test_dashboard_backend.py -v",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "make demo-scripted",
+    "make check",
+    "git diff --check",
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-71-backend-egress-policy.json --base main"
+  ],
+  "evidence": [
+    "Targeted pytest output names and passes every new URL, address, DNS, redirect, content-type, size, timeout, and readiness test.",
+    "Verbose targeted pytest output includes the exact 4194304-byte and 4194305-byte response boundary cases.",
+    "Verbose targeted pytest output includes the accepted 2-second timeout and rejected zero, negative, NaN, infinity, and greater-than-2-second cases.",
+    "Verbose targeted pytest output includes IPv4, IPv6, IPv4-mapped IPv6, and mixed permitted-and-forbidden DNS cases.",
+    "The local redirect test records zero requests at the redirect target.",
+    "The DNS pinning test proves the connected IP is the same IP that passed policy validation.",
+    "HTTP evidence shows healthz returns 200 while readyz and data endpoints return 503 for invalid remote configuration.",
+    "The existing remote duplicate-key and controller peer-down tests continue to pass through the new HTTP client.",
+    "make check completes successfully.",
+    "git diff --check produces no output.",
+    "Task Packet diff-boundary validation confirms every changed path is allowed."
+  ],
+  "stop_conditions": [
+    "A change to deploy/multi-host/compose.controller.yaml, the deployment environment contract, or multi-host deployment documentation is required.",
+    "The Phase A implementation reads WORKBENCH_EVENT_SOURCE_ALLOWLIST instead of accepting the allow-list only through the Python and CLI parameters.",
+    "A change to interfaces, OpenAPI, Pydantic models, WorldEvent fields, or Dashboard fixtures is required.",
+    "A non-loopback target is reachable without an explicit matching allow-list entry.",
+    "The implementation validates one DNS result but connects through a second unvalidated resolution.",
+    "The redirect test cannot prove that the target received zero requests.",
+    "Testing requires public network access, real external DNS, or timing sleeps.",
+    "The work expands into Issue #66 inbound exposure controls or Issue #74 partition and recovery semantics.",
+    "The timeout bound, allow-list format, or prohibited address policy must change beyond the approved acceptance behavior.",
+    "Unrelated user changes overlap an allowed path.",
+    "The Task Packet has not received explicit approval for this bounded security behavior."
+  ],
+  "risks_and_fallbacks": [
+    "Fail closed if URL parsing, allow-list parsing, DNS resolution, address validation, content-type validation, redirect handling, or timeout enforcement is ambiguous.",
+    "Do not fall back from a rejected remote source to Dashboard fixture data.",
+    "Keep deployment wiring for a separate Task Packet under the same Issue."
+  ]
+}

--- a/services/backend/workbench_backend/read_model.py
+++ b/services/backend/workbench_backend/read_model.py
@@ -1,12 +1,11 @@
 import json
 import threading
-import urllib.error
 import urllib.parse
-import urllib.request
 from pathlib import Path
 from typing import Any
 
 from .expression import ALLOWED_TRANSITIONS, ExpressionState, derive_expression
+from .remote_http import RemoteHttpClient, RemoteHttpError, RemoteHttpResponseTooLarge
 
 STATUS_LABELS = {
     "confirmed": "已确认",
@@ -40,7 +39,6 @@ EVENT_TYPES = {
 MAX_EVENT_LOG_BYTES = 10 * 1024 * 1024
 MAX_EVENTS_PER_RUN = 10_000
 MAX_READ_ATTEMPTS = 2
-MAX_REMOTE_RESPONSE_BYTES = 4 * 1024 * 1024
 
 
 class ReadModelError(ValueError):
@@ -220,30 +218,36 @@ class RemoteDashboardReadModel(DashboardReadModel):
 
     data_source = "remote-simulation-event-source"
 
-    def __init__(self, base_url: str, timeout_s: float = 1.0) -> None:
-        parsed = urllib.parse.urlparse(base_url)
-        if parsed.scheme != "http" or not parsed.hostname or parsed.username or parsed.password:
-            raise ValueError("event source URL must be an unauthenticated http URL")
-        self.base_url = base_url.rstrip("/")
-        self.timeout_s = timeout_s
+    def __init__(
+        self,
+        base_url: str,
+        timeout_s: float = 1.0,
+        event_source_allowlist: str | None = None,
+    ) -> None:
+        self._http = RemoteHttpClient(
+            base_url,
+            allowlist=event_source_allowlist,
+            timeout_s=timeout_s,
+        )
+        self.base_url = self._http.base_url
+        self.timeout_s = self._http.timeout_s
 
     def _request(self, path: str) -> dict[str, Any]:
-        request = urllib.request.Request(f"{self.base_url}{path}", headers={"Accept": "application/json"})
         try:
-            with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
-                body = response.read(MAX_REMOTE_RESPONSE_BYTES + 1)
-                if len(body) > MAX_REMOTE_RESPONSE_BYTES:
-                    raise ReadModelError("remote event source response is too large")
-                payload = json.loads(body, object_pairs_hook=_object_without_duplicates)
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:
-                raise KeyError(path) from None
-            if exc.code == 413:
-                raise ReadModelResponseTooLarge("remote event source response is too large") from None
+            response = self._http.get(path)
+        except RemoteHttpResponseTooLarge as exc:
+            raise ReadModelResponseTooLarge("remote event source response is too large") from exc
+        except RemoteHttpError as exc:
             raise ReadModelError(f"remote event source unavailable: {self.base_url}") from exc
+        if response.status == 404:
+            raise KeyError(path)
+        if not 200 <= response.status < 300:
+            raise ReadModelError(f"remote event source unavailable: {self.base_url}")
+        try:
+            payload = json.loads(response.body, object_pairs_hook=_object_without_duplicates)
         except _DuplicateJsonKey as exc:
             raise ReadModelError(f"remote event source returned {exc}: {self.base_url}") from exc
-        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        except (UnicodeError, json.JSONDecodeError) as exc:
             raise ReadModelError(f"remote event source unavailable: {self.base_url}") from exc
         if not isinstance(payload, dict):
             raise ReadModelError("remote event source returned a non-object payload")
@@ -252,7 +256,7 @@ class RemoteDashboardReadModel(DashboardReadModel):
     def ready(self) -> bool:
         try:
             payload = self._request("/readyz")
-        except ReadModelError:
+        except (KeyError, ReadModelError):
             return False
         return payload.get("status") == "ready"
 
@@ -284,3 +288,21 @@ class RemoteDashboardReadModel(DashboardReadModel):
                 for state, transitions in ALLOWED_TRANSITIONS.items()
             },
         }
+
+
+class UnavailableRemoteDashboardReadModel(RemoteDashboardReadModel):
+    """Keep the Backend live while rejecting an invalid remote configuration."""
+
+    def __init__(self, error: Exception) -> None:
+        self._configuration_error = str(error)
+        self.base_url = "invalid-remote-event-source"
+        self.timeout_s = 0.0
+
+    def ready(self) -> bool:
+        return False
+
+    def list_runs(self) -> list[dict[str, Any]]:
+        raise ReadModelError("remote event source configuration is invalid")
+
+    def list_events(self, run_id: str) -> list[dict[str, Any]]:
+        raise ReadModelError("remote event source configuration is invalid")

--- a/services/backend/workbench_backend/remote_http.py
+++ b/services/backend/workbench_backend/remote_http.py
@@ -1,0 +1,309 @@
+import http.client
+import ipaddress
+import math
+import socket
+import time
+import urllib.parse
+from dataclasses import dataclass
+
+MAX_REMOTE_RESPONSE_BYTES = 4 * 1024 * 1024
+MAX_REMOTE_TIMEOUT_SECONDS = 2.0
+_READ_CHUNK_BYTES = 64 * 1024
+
+
+class RemoteHttpError(RuntimeError):
+    """Raised when a remote event-source request cannot be trusted."""
+
+
+class RemoteHttpConfigurationError(RemoteHttpError, ValueError):
+    """Raised when a remote event-source URL or policy is invalid."""
+
+
+class RemoteHttpResponseTooLarge(RemoteHttpError):
+    """Raised when a remote response exceeds the configured byte limit."""
+
+
+@dataclass(frozen=True)
+class RemoteHttpResponse:
+    status: int
+    body: bytes
+
+
+@dataclass(frozen=True)
+class ResolvedEndpoint:
+    family: int
+    sockaddr: tuple
+    address: str
+    effective_address: str
+
+
+def _effective_address(
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None:
+        return address.ipv4_mapped
+    return address
+
+
+def _parse_allowlist(
+    value: str | None,
+) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, str):
+        raise RemoteHttpConfigurationError("remote event source allow-list must be a string")
+    if not value.strip():
+        return ()
+    tokens = value.split(",")
+    if any(not token.strip() for token in tokens):
+        raise RemoteHttpConfigurationError("remote event source allow-list contains an empty entry")
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for token in tokens:
+        try:
+            network = ipaddress.ip_network(token.strip(), strict=False)
+        except ValueError as exc:
+            raise RemoteHttpConfigurationError("remote event source allow-list is malformed") from exc
+        if network not in networks:
+            networks.append(network)
+    return tuple(networks)
+
+
+def _parse_origin(base_url: str) -> tuple[str, int, str, str]:
+    if not isinstance(base_url, str) or not base_url or any(ord(character) < 32 for character in base_url):
+        raise RemoteHttpConfigurationError("remote event source URL is invalid")
+    try:
+        parsed = urllib.parse.urlsplit(base_url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise RemoteHttpConfigurationError("remote event source URL is invalid") from exc
+    if parsed.scheme.lower() != "http":
+        raise RemoteHttpConfigurationError("remote event source URL must use http")
+    if not parsed.netloc or not hostname:
+        raise RemoteHttpConfigurationError("remote event source URL must include a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise RemoteHttpConfigurationError("remote event source URL must not contain credentials")
+    if "?" in base_url or "#" in base_url:
+        raise RemoteHttpConfigurationError("remote event source URL must not contain query or fragment data")
+    if parsed.path not in {"", "/"}:
+        raise RemoteHttpConfigurationError("remote event source URL must be an origin without a path")
+    if parsed.netloc.endswith(":"):
+        raise RemoteHttpConfigurationError("remote event source URL contains an invalid port")
+    if "%" in hostname:
+        raise RemoteHttpConfigurationError("remote event source URL contains an unsupported scoped address")
+    if not hostname.isascii():
+        raise RemoteHttpConfigurationError("remote event source URL hostname must contain only ASCII characters")
+    port = 80 if port is None else port
+    if not 1 <= port <= 65535:
+        raise RemoteHttpConfigurationError("remote event source URL contains an invalid port")
+    try:
+        literal = ipaddress.ip_address(hostname)
+    except ValueError:
+        normalized_host = hostname.lower()
+        host_header = normalized_host
+    else:
+        normalized_host = literal.compressed
+        host_header = f"[{normalized_host}]" if isinstance(literal, ipaddress.IPv6Address) else normalized_host
+    if port != 80:
+        host_header = f"{host_header}:{port}"
+    return normalized_host, port, host_header, f"http://{host_header}"
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, host: str, port: int, endpoint: ResolvedEndpoint, timeout: float) -> None:
+        super().__init__(host, port=port, timeout=timeout)
+        self._endpoint = endpoint
+
+    def connect(self) -> None:
+        sock = socket.socket(self._endpoint.family, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(self.timeout)
+            sock.connect(self._endpoint.sockaddr)
+        except BaseException:
+            sock.close()
+            raise
+        self.sock = sock
+
+
+class RemoteHttpClient:
+    def __init__(self, base_url: str, *, allowlist: str | None = None, timeout_s: float = 1.0) -> None:
+        if (
+            isinstance(timeout_s, bool)
+            or not isinstance(timeout_s, (int, float))
+            or not math.isfinite(timeout_s)
+            or not 0 < timeout_s <= MAX_REMOTE_TIMEOUT_SECONDS
+        ):
+            raise RemoteHttpConfigurationError(
+                f"remote event source timeout must be finite and between 0 and {MAX_REMOTE_TIMEOUT_SECONDS} seconds"
+            )
+        self.host, self.port, self.host_header, self.base_url = _parse_origin(base_url)
+        self.timeout_s = float(timeout_s)
+        self.allowlist = _parse_allowlist(allowlist)
+        try:
+            literal = ipaddress.ip_address(self.host)
+        except ValueError:
+            self._literal_address = None
+        else:
+            self._literal_address = literal
+            self._validate_address(literal)
+
+    def _validate_address(self, address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
+        effective = _effective_address(address)
+        if effective.is_loopback:
+            return
+        is_deprecated_site_local = isinstance(effective, ipaddress.IPv6Address) and effective.is_site_local
+        if (
+            effective.is_unspecified
+            or effective.is_link_local
+            or effective.is_multicast
+            or effective.is_reserved
+            or is_deprecated_site_local
+        ):
+            raise RemoteHttpError(f"remote event source address is prohibited: {effective.compressed}")
+        if not any(effective.version == network.version and effective in network for network in self.allowlist):
+            raise RemoteHttpError(
+                f"remote event source address is not present in the allow-list: {effective.compressed}"
+            )
+
+    def _endpoint(
+        self,
+        family: int,
+        sockaddr: tuple,
+    ) -> ResolvedEndpoint:
+        raw_address = sockaddr[0]
+        if not isinstance(raw_address, str) or "%" in raw_address:
+            raise RemoteHttpError("remote event source resolved to an unsupported scoped address")
+        try:
+            address = ipaddress.ip_address(raw_address)
+        except ValueError as exc:
+            raise RemoteHttpError("remote event source resolved to an invalid address") from exc
+        self._validate_address(address)
+        normalized_sockaddr: tuple
+        if family == socket.AF_INET:
+            normalized_sockaddr = (address.compressed, self.port)
+        elif family == socket.AF_INET6:
+            flowinfo = sockaddr[2] if len(sockaddr) > 2 else 0
+            scope_id = sockaddr[3] if len(sockaddr) > 3 else 0
+            normalized_sockaddr = (address.compressed, self.port, flowinfo, scope_id)
+        else:
+            raise RemoteHttpError("remote event source resolved to an unsupported address family")
+        return ResolvedEndpoint(
+            family=family,
+            sockaddr=normalized_sockaddr,
+            address=address.compressed,
+            effective_address=_effective_address(address).compressed,
+        )
+
+    def _resolve_endpoints(self) -> tuple[ResolvedEndpoint, ...]:
+        if self._literal_address is not None:
+            family = socket.AF_INET6 if isinstance(self._literal_address, ipaddress.IPv6Address) else socket.AF_INET
+            sockaddr = (
+                (self._literal_address.compressed, self.port, 0, 0)
+                if family == socket.AF_INET6
+                else (self._literal_address.compressed, self.port)
+            )
+            return (self._endpoint(family, sockaddr),)
+        try:
+            results = socket.getaddrinfo(
+                self.host,
+                self.port,
+                family=socket.AF_UNSPEC,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+            )
+        except OSError as exc:
+            raise RemoteHttpError("remote event source DNS resolution failed") from exc
+        endpoints: list[ResolvedEndpoint] = []
+        for family, socktype, _protocol, _canonical_name, sockaddr in results:
+            if family not in {socket.AF_INET, socket.AF_INET6} or socktype != socket.SOCK_STREAM:
+                continue
+            endpoint = self._endpoint(family, sockaddr)
+            if endpoint not in endpoints:
+                endpoints.append(endpoint)
+        if not endpoints:
+            raise RemoteHttpError("remote event source DNS resolution returned no usable addresses")
+        return tuple(endpoints)
+
+    def _resolve_endpoint(self) -> ResolvedEndpoint:
+        return self._resolve_endpoints()[0]
+
+    def get(self, path: str) -> RemoteHttpResponse:
+        parsed_path = urllib.parse.urlsplit(path)
+        if (
+            not path.startswith("/")
+            or path.startswith("//")
+            or parsed_path.scheme
+            or parsed_path.netloc
+            or parsed_path.fragment
+        ):
+            raise RemoteHttpConfigurationError("remote event source request path is invalid")
+        deadline = time.monotonic() + self.timeout_s
+        endpoint = self._resolve_endpoint()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RemoteHttpError("remote event source request timed out")
+        connection = _PinnedHTTPConnection(self.host, self.port, endpoint, remaining)
+        try:
+            connection.request(
+                "GET",
+                path,
+                headers={
+                    "Accept": "application/json",
+                    "Connection": "close",
+                    "Host": self.host_header,
+                },
+            )
+            response = connection.getresponse()
+            if 300 <= response.status < 400:
+                raise RemoteHttpError("remote event source redirect is prohibited")
+            if response.status == 413:
+                raise RemoteHttpResponseTooLarge("remote event source response is too large")
+            content_type = response.getheader("Content-Type", "")
+            content_type_parts = [part.strip() for part in content_type.split(";")]
+            media_type = content_type_parts[0].lower()
+            if media_type != "application/json":
+                raise RemoteHttpError("remote event source response Content-Type must be application/json")
+            parameters = content_type_parts[1:]
+            if parameters:
+                parameter_name, separator, parameter_value = parameters[0].partition("=")
+                if (
+                    len(parameters) != 1
+                    or not separator
+                    or parameter_name.strip().lower() != "charset"
+                    or not parameter_value.strip()
+                ):
+                    raise RemoteHttpError("remote event source response Content-Type permits only a charset parameter")
+            content_length = response.getheader("Content-Length")
+            if content_length is not None:
+                try:
+                    declared_length = int(content_length)
+                except ValueError as exc:
+                    raise RemoteHttpError("remote event source response Content-Length is invalid") from exc
+                if declared_length < 0:
+                    raise RemoteHttpError("remote event source response Content-Length is invalid")
+                if declared_length > MAX_REMOTE_RESPONSE_BYTES:
+                    raise RemoteHttpResponseTooLarge("remote event source response is too large")
+            body = bytearray()
+            while len(body) <= MAX_REMOTE_RESPONSE_BYTES:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RemoteHttpError("remote event source request timed out")
+                if response.fp is not None and getattr(response.fp, "raw", None) is not None:
+                    response_socket = getattr(response.fp.raw, "_sock", None)
+                    if response_socket is not None:
+                        response_socket.settimeout(remaining)
+                chunk = response.read(min(_READ_CHUNK_BYTES, MAX_REMOTE_RESPONSE_BYTES + 1 - len(body)))
+                if not chunk:
+                    break
+                body.extend(chunk)
+            if len(body) > MAX_REMOTE_RESPONSE_BYTES:
+                raise RemoteHttpResponseTooLarge("remote event source response is too large")
+            return RemoteHttpResponse(status=response.status, body=bytes(body))
+        except RemoteHttpError:
+            raise
+        except TimeoutError as exc:
+            raise RemoteHttpError("remote event source request timed out") from exc
+        except (OSError, http.client.HTTPException) as exc:
+            raise RemoteHttpError("remote event source request failed") from exc
+        finally:
+            connection.close()

--- a/services/backend/workbench_backend/server.py
+++ b/services/backend/workbench_backend/server.py
@@ -15,7 +15,9 @@ from .read_model import (
     ReadModelError,
     ReadModelResponseTooLarge,
     RemoteDashboardReadModel,
+    UnavailableRemoteDashboardReadModel,
 )
+from .remote_http import RemoteHttpError
 
 SOURCE_ROOT = Path(__file__).resolve().parents[3]
 ROOT = Path.cwd() if (Path.cwd() / "apps" / "dashboard").is_dir() else SOURCE_ROOT
@@ -198,10 +200,18 @@ def create_server(
     data_dir: str | Path = DEFAULT_DATA_DIR,
     static_dir: str | Path = DEFAULT_STATIC_DIR,
     event_source_url: str | None = None,
+    event_source_allowlist: str | None = None,
 ) -> ThreadingHTTPServer:
-    configured_read_model = (
-        RemoteDashboardReadModel(event_source_url) if event_source_url else DashboardReadModel(data_dir)
-    )
+    if event_source_url:
+        try:
+            configured_read_model = RemoteDashboardReadModel(
+                event_source_url,
+                event_source_allowlist=event_source_allowlist,
+            )
+        except RemoteHttpError as exc:
+            configured_read_model = UnavailableRemoteDashboardReadModel(exc)
+    else:
+        configured_read_model = DashboardReadModel(data_dir)
     configured_static_dir = Path(static_dir)
 
     class ConfiguredHandler(DashboardHandler):
@@ -218,8 +228,15 @@ def main() -> int:
     parser.add_argument("--port", type=int, default=8080)
     parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
     parser.add_argument("--event-source-url", default=os.environ.get("WORKBENCH_EVENT_SOURCE_URL"))
+    parser.add_argument("--event-source-allowlist")
     args = parser.parse_args()
-    server = create_server(args.host, args.port, data_dir=args.data_dir, event_source_url=args.event_source_url)
+    server = create_server(
+        args.host,
+        args.port,
+        data_dir=args.data_dir,
+        event_source_url=args.event_source_url,
+        event_source_allowlist=args.event_source_allowlist,
+    )
     DashboardHandler.logger.emit(
         "service_started",
         f"dashboard listening on http://{args.host}:{args.port}",

--- a/tests/unit/test_multi_host.py
+++ b/tests/unit/test_multi_host.py
@@ -1,20 +1,79 @@
-import io
+import contextlib
 import json
+import math
+import os
+import socket
+import sys
 import tempfile
 import threading
 import unittest
 import urllib.error
+import urllib.parse
 import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest import mock
 
 from workbench_backend.read_model import ReadModelError, RemoteDashboardReadModel
-from workbench_backend.server import create_server
+from workbench_backend.remote_http import (
+    MAX_REMOTE_RESPONSE_BYTES,
+    RemoteHttpClient,
+    RemoteHttpConfigurationError,
+    RemoteHttpError,
+    RemoteHttpResponseTooLarge,
+)
+from workbench_backend.server import create_server, main
+
+
+@contextlib.contextmanager
+def response_server(responder):
+    hits: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args) -> None:
+            pass
+
+        def do_GET(self) -> None:
+            hits.append(self.path)
+            status, headers, body = responder(self.path)
+            self.send_response(status)
+            for name, value in headers:
+                self.send_header(name, value)
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}", hits
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def json_headers(body: bytes, *, content_type: str = "application/json", include_length: bool = True):
+    headers = [("Content-Type", content_type)]
+    if include_length:
+        headers.append(("Content-Length", str(len(body))))
+    return headers
+
+
+def json_body_with_size(size: int) -> bytes:
+    prefix = b'{"value":"'
+    suffix = b'"}'
+    body = prefix + (b"x" * (size - len(prefix) - len(suffix))) + suffix
+    if len(body) != size:
+        raise AssertionError("incorrect test body size")
+    return body
 
 
 class MultiHostReadModelTests(unittest.TestCase):
     def test_remote_json_rejects_top_level_and_nested_duplicate_keys(self) -> None:
-        model = RemoteDashboardReadModel("http://127.0.0.1:1")
         cases = {
             "runs": b'{"runs":[],"runs":[]}',
             "task_id": b'{"runs":[{"task_id":"secret-marker","task_id":"trusted"}]}',
@@ -22,17 +81,16 @@ class MultiHostReadModelTests(unittest.TestCase):
         for duplicate_key, body in cases.items():
             with (
                 self.subTest(duplicate_key=duplicate_key),
-                mock.patch("workbench_backend.read_model.urllib.request.urlopen", return_value=io.BytesIO(body)),
-                self.assertRaisesRegex(ReadModelError, rf"duplicate JSON key: '{duplicate_key}'") as caught,
+                response_server(lambda path, body=body: (200, json_headers(body), body)) as (base_url, _),
             ):
-                model.list_runs()
+                model = RemoteDashboardReadModel(base_url)
+                with self.assertRaisesRegex(ReadModelError, rf"duplicate JSON key: '{duplicate_key}'") as caught:
+                    model.list_runs()
             self.assertNotIn("secret-marker", str(caught.exception))
 
-        with mock.patch(
-            "workbench_backend.read_model.urllib.request.urlopen",
-            return_value=io.BytesIO(b'{"status":"not_ready","status":"ready"}'),
-        ):
-            self.assertFalse(model.ready())
+        body = b'{"status":"not_ready","status":"ready"}'
+        with response_server(lambda path: (200, json_headers(body), body)) as (base_url, _):
+            self.assertFalse(RemoteDashboardReadModel(base_url).ready())
 
     def test_controller_reads_remote_source_and_fails_ready_when_peer_is_down(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -99,6 +157,313 @@ class MultiHostReadModelTests(unittest.TestCase):
                     sim.shutdown()
                     sim.server_close()
                     sim_thread.join(timeout=2)
+
+
+class RemoteHttpSecurityTests(unittest.TestCase):
+    def test_remote_source_accepts_ipv4_and_ipv6_loopback_without_allowlist(self) -> None:
+        ipv4 = RemoteHttpClient("http://127.0.0.1:8090")
+        ipv6 = RemoteHttpClient("http://[::1]:8090/")
+        self.assertEqual(ipv4._resolve_endpoint().address, "127.0.0.1")
+        self.assertEqual(ipv6._resolve_endpoint().address, "::1")
+
+        localhost = RemoteHttpClient("http://localhost:8090")
+        resolved = [
+            (socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("::1", 8090, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", 8090)),
+        ]
+        with mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=resolved):
+            self.assertIn(localhost._resolve_endpoint().address, {"127.0.0.1", "::1"})
+
+    def test_remote_source_requires_allowlist_for_non_loopback_addresses(self) -> None:
+        resolved = [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("10.20.30.40", 8090)),
+        ]
+        with mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=resolved):
+            with self.assertRaisesRegex(RemoteHttpError, "allow-list"):
+                RemoteHttpClient("http://simulation.internal:8090")._resolve_endpoint()
+            endpoint = RemoteHttpClient(
+                "http://simulation.internal:8090", allowlist="10.20.30.40/32"
+            )._resolve_endpoint()
+        self.assertEqual(endpoint.address, "10.20.30.40")
+
+        for malformed in ("not-an-address", "10.0.0.1,,10.0.0.2", "10.0.0.1/999"):
+            with self.subTest(malformed=malformed), self.assertRaises(RemoteHttpConfigurationError):
+                RemoteHttpClient("http://127.0.0.1", allowlist=malformed)
+        with self.assertRaises(RemoteHttpConfigurationError):
+            RemoteHttpClient("http://127.0.0.1", allowlist=123)  # type: ignore[arg-type]
+
+    def test_remote_source_rejects_unsafe_url_forms(self) -> None:
+        unsafe_urls = (
+            "https://127.0.0.1",
+            "http://user@127.0.0.1",
+            "http://user:password@127.0.0.1",
+            "http://127.0.0.1/?query=value",
+            "http://127.0.0.1/#fragment",
+            "http://127.0.0.1/api/v1/runs",
+            "http://127.0.0.1:0",
+            "http://127.0.0.1:65536",
+            "http://127.0.0.1:not-a-port",
+            "http://127.0.0.1:",
+            "http://☃.example:8090",
+        )
+        for url in unsafe_urls:
+            with self.subTest(url=url), self.assertRaises(RemoteHttpConfigurationError):
+                RemoteHttpClient(url)
+
+    def test_remote_source_rejects_disallowed_address_ranges(self) -> None:
+        cases = (
+            (socket.AF_INET, "0.0.0.0", ("0.0.0.0", 8090)),
+            (socket.AF_INET, "169.254.169.254", ("169.254.169.254", 8090)),
+            (socket.AF_INET, "224.0.0.1", ("224.0.0.1", 8090)),
+            (socket.AF_INET, "240.0.0.1", ("240.0.0.1", 8090)),
+            (socket.AF_INET6, "::", ("::", 8090, 0, 0)),
+            (socket.AF_INET6, "fe80::1", ("fe80::1", 8090, 0, 0)),
+            (socket.AF_INET6, "ff02::1", ("ff02::1", 8090, 0, 0)),
+            (socket.AF_INET6, "fec0::1", ("fec0::1", 8090, 0, 0)),
+        )
+        for family, address, sockaddr in cases:
+            resolved = [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
+            with (
+                self.subTest(address=address),
+                mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=resolved),
+                self.assertRaisesRegex(RemoteHttpError, "prohibited"),
+            ):
+                RemoteHttpClient("http://simulation.internal:8090", allowlist="0.0.0.0/0,::/0")._resolve_endpoint()
+
+    def test_remote_source_validates_ipv4_mapped_and_every_dns_address(self) -> None:
+        mapped_loopback = [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("::ffff:127.0.0.1", 8090, 0, 0),
+            )
+        ]
+        with mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=mapped_loopback):
+            endpoint = RemoteHttpClient("http://simulation.internal:8090")._resolve_endpoint()
+        self.assertEqual(endpoint.effective_address, "127.0.0.1")
+
+        mapped_private = [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("::ffff:10.20.30.40", 8090, 0, 0),
+            )
+        ]
+        with mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=mapped_private):
+            endpoint = RemoteHttpClient(
+                "http://simulation.internal:8090", allowlist="10.20.30.0/24"
+            )._resolve_endpoint()
+        self.assertEqual(endpoint.effective_address, "10.20.30.40")
+
+        mixed = [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", 8090)),
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("169.254.169.254", 8090)),
+        ]
+        with (
+            mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=mixed),
+            self.assertRaisesRegex(RemoteHttpError, "prohibited"),
+        ):
+            RemoteHttpClient("http://simulation.internal:8090")._resolve_endpoint()
+
+        mapped_mixed = [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("::ffff:127.0.0.1", 8090, 0, 0),
+            ),
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("::ffff:169.254.169.254", 8090, 0, 0),
+            ),
+        ]
+        with (
+            mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=mapped_mixed),
+            self.assertRaisesRegex(RemoteHttpError, "prohibited"),
+        ):
+            RemoteHttpClient("http://simulation.internal:8090", allowlist="0.0.0.0/0")._resolve_endpoint()
+
+    def test_remote_source_pins_the_validated_dns_address(self) -> None:
+        body = b'{"status":"ready"}'
+        with response_server(lambda path: (200, json_headers(body), body)) as (base_url, hits):
+            port = urllib.parse.urlsplit(base_url).port
+            resolved = [
+                (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", port)),
+            ]
+            with mock.patch("workbench_backend.remote_http.socket.getaddrinfo", return_value=resolved) as resolver:
+                response = RemoteHttpClient(f"http://safe.example:{port}").get("/readyz")
+        self.assertEqual(response.body, body)
+        self.assertEqual(hits, ["/readyz"])
+        self.assertEqual(resolver.call_count, 1)
+
+    def test_remote_redirect_does_not_reach_second_local_server(self) -> None:
+        target_body = b'{"runs":[]}'
+        with response_server(lambda path: (200, json_headers(target_body), target_body)) as (
+            target_url,
+            target_hits,
+        ):
+
+            def redirect(path):
+                return 302, [("Location", f"{target_url}/forbidden")], b""
+
+            with response_server(redirect) as (redirect_url, redirect_hits):
+                with self.assertRaisesRegex(RemoteHttpError, "redirect"):
+                    RemoteHttpClient(redirect_url).get("/api/v1/runs")
+        self.assertEqual(redirect_hits, ["/api/v1/runs"])
+        self.assertEqual(target_hits, [])
+
+    def test_remote_response_enforces_json_content_type(self) -> None:
+        body = b'{"runs":[]}'
+        with response_server(
+            lambda path: (200, json_headers(body, content_type="application/json; charset=utf-8"), body)
+        ) as (base_url, _):
+            self.assertEqual(RemoteHttpClient(base_url).get("/api/v1/runs").body, body)
+
+        for content_type in ("text/html", "application/problem+json", "application/json; boundary=unsafe", ""):
+            headers = (
+                json_headers(body, content_type=content_type) if content_type else [("Content-Length", str(len(body)))]
+            )
+            with (
+                self.subTest(content_type=content_type),
+                response_server(lambda path, headers=headers: (200, headers, body)) as (base_url, _),
+                self.assertRaisesRegex(RemoteHttpError, "Content-Type"),
+            ):
+                RemoteHttpClient(base_url).get("/api/v1/runs")
+
+    def test_remote_response_enforces_exact_size_boundary(self) -> None:
+        exact = json_body_with_size(MAX_REMOTE_RESPONSE_BYTES)
+        oversized = json_body_with_size(MAX_REMOTE_RESPONSE_BYTES + 1)
+        for include_length in (True, False):
+            with (
+                self.subTest(exact=True, include_length=include_length),
+                response_server(
+                    lambda path, include_length=include_length: (
+                        200,
+                        json_headers(exact, include_length=include_length),
+                        exact,
+                    )
+                ) as (base_url, _),
+            ):
+                response = RemoteHttpClient(base_url, timeout_s=2.0).get("/api/v1/runs")
+                self.assertEqual(len(response.body), MAX_REMOTE_RESPONSE_BYTES)
+                self.assertIsInstance(json.loads(response.body), dict)
+
+        for include_length in (True, False):
+            with (
+                self.subTest(include_length=include_length),
+                response_server(
+                    lambda path, include_length=include_length: (
+                        200,
+                        json_headers(oversized, include_length=include_length),
+                        oversized,
+                    )
+                ) as (base_url, _),
+                self.assertRaises(RemoteHttpResponseTooLarge),
+            ):
+                RemoteHttpClient(base_url, timeout_s=2.0).get("/api/v1/runs")
+
+    def test_remote_source_enforces_timeout_configuration_and_errors(self) -> None:
+        self.assertEqual(RemoteHttpClient("http://127.0.0.1", timeout_s=2.0).timeout_s, 2.0)
+        for timeout in (0.0, -1.0, math.nan, math.inf, -math.inf, 2.000001):
+            with self.subTest(timeout=timeout), self.assertRaises(RemoteHttpConfigurationError):
+                RemoteHttpClient("http://127.0.0.1", timeout_s=timeout)
+
+        client = RemoteHttpClient("http://127.0.0.1:1")
+        with (
+            mock.patch("workbench_backend.remote_http._PinnedHTTPConnection.request", side_effect=TimeoutError),
+            self.assertRaisesRegex(RemoteHttpError, "timed out"),
+        ):
+            client.get("/readyz")
+
+        model = RemoteDashboardReadModel("http://127.0.0.1:1")
+        with (
+            mock.patch("workbench_backend.remote_http._PinnedHTTPConnection.request", side_effect=TimeoutError),
+            self.assertRaisesRegex(ReadModelError, "unavailable"),
+        ):
+            model.list_runs()
+
+        read_timeout_response = mock.Mock(status=200, fp=None)
+        read_timeout_response.getheader.side_effect = lambda name, default=None: (
+            "application/json" if name == "Content-Type" else default
+        )
+        read_timeout_response.read.side_effect = TimeoutError
+        with (
+            mock.patch("workbench_backend.remote_http._PinnedHTTPConnection.request"),
+            mock.patch(
+                "workbench_backend.remote_http._PinnedHTTPConnection.getresponse",
+                return_value=read_timeout_response,
+            ),
+            self.assertRaisesRegex(ReadModelError, "unavailable"),
+        ):
+            model.list_runs()
+        read_timeout_response.read.assert_called_once()
+
+    def test_invalid_remote_configuration_is_live_but_not_ready(self) -> None:
+        cases = (
+            {"event_source_url": "https://simulation.internal:8090"},
+            {
+                "event_source_url": "http://10.20.30.40:8090",
+                "event_source_allowlist": None,
+            },
+            {
+                "event_source_url": "http://10.20.30.40:8090",
+                "event_source_allowlist": "not-a-network",
+            },
+            {
+                "event_source_url": "http://10.20.30.40:8090",
+                "event_source_allowlist": 123,
+            },
+            {"event_source_url": "http://☃.example:8090"},
+        )
+        for options in cases:
+            with self.subTest(options=options):
+                server = create_server("127.0.0.1", 0, **options)
+                thread = threading.Thread(target=server.serve_forever, daemon=True)
+                thread.start()
+                base_url = f"http://127.0.0.1:{server.server_address[1]}"
+                try:
+                    with urllib.request.urlopen(f"{base_url}/healthz", timeout=2) as response:
+                        self.assertEqual(response.status, 200)
+                    for path in ("/readyz", "/api/v1/runs"):
+                        with self.assertRaises(urllib.error.HTTPError) as caught:
+                            urllib.request.urlopen(f"{base_url}{path}", timeout=2)
+                        self.assertEqual(caught.exception.code, 503)
+                finally:
+                    server.shutdown()
+                    server.server_close()
+                    thread.join(timeout=2)
+
+    def test_cli_allowlist_is_explicit_and_does_not_read_environment(self) -> None:
+        event_source_url = "http://10.20.30.40:8090"
+        for cli_arguments, expected_allowlist in (
+            ([], None),
+            (["--event-source-allowlist", "10.20.30.40/32"], "10.20.30.40/32"),
+        ):
+            fake_server = mock.Mock()
+            fake_server.serve_forever.side_effect = KeyboardInterrupt
+            argv = ["workbench-backend", "--event-source-url", event_source_url, *cli_arguments]
+            with (
+                self.subTest(cli_arguments=cli_arguments),
+                mock.patch.dict(
+                    os.environ,
+                    {"WORKBENCH_EVENT_SOURCE_ALLOWLIST": "192.0.2.1/32"},
+                    clear=False,
+                ),
+                mock.patch.object(sys, "argv", argv),
+                mock.patch("workbench_backend.server.create_server", return_value=fake_server) as factory,
+            ):
+                self.assertEqual(main(), 0)
+            self.assertEqual(factory.call_args.kwargs["event_source_url"], event_source_url)
+            self.assertEqual(factory.call_args.kwargs["event_source_allowlist"], expected_allowlist)
+            fake_server.server_close.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

Refs #71.

这是 Issue #71 的 Backend Phase A，只处理应用层远程事件源出站策略。本 PR 不关闭 #71；环境变量和 Compose 接线由 Phase B 继续处理。

## Summary

为 `RemoteDashboardReadModel` 增加受限的远程 HTTP 客户端：

- IPv4/IPv6 loopback 和 `localhost` 无需白名单；
- 其他地址必须匹配显式 IP/CIDR allow-list；
- 校验全部 DNS 解析结果，并固定连接已经校验的地址；
- 拒绝凭据、query、fragment、非 HTTP、非法端口及非根路径；
- 拒绝 unspecified、link-local、multicast、reserved 和 deprecated IPv6 site-local 地址；
- 按有效 IPv4 地址检查 IPv4-mapped IPv6；
- 禁止 HTTP redirect；
- 响应必须为 `application/json`，仅允许可选 `charset` 参数；
- 响应大小限制为 4 MiB；
- 连接和读取超时限制为不超过 2 秒；
- 配置非法时 `/healthz` 保持 200，`/readyz` 和远程数据接口返回 503；
- 保持重复 JSON key、事件顺序、只读 API、WorldEvent 和 OpenAPI 行为不变。

## Changed files

- `services/backend/workbench_backend/remote_http.py`
  - 新增 URL、allow-list、DNS、IP、redirect、Content-Type、大小和超时策略。
- `services/backend/workbench_backend/read_model.py`
  - 使用受限 HTTP 客户端并将网络错误转换为 `ReadModelError`。
- `services/backend/workbench_backend/server.py`
  - 增加 `event_source_allowlist` Python 参数和 `--event-source-allowlist` CLI 参数。
  - 无效远程配置使用 fail-closed read model。
- `tests/unit/test_multi_host.py`
  - 增加正常、边界、失败和安全回归测试。
- `docs/task_packets/issue-71-backend-egress-policy.json`
  - 已批准的 Issue #71 Phase A Task Packet。

## Scope boundaries

本 PR 没有修改：

- `deploy/**`
- Compose 或部署环境变量契约
- `interfaces/**`
- OpenAPI
- `libs/contracts/**`
- World Model
- Agent Runtime
- `robot/control/**`
- firmware
- sim
- Dashboard 写入或机器人控制能力

本阶段不会读取 `WORKBENCH_EVENT_SOURCE_ALLOWLIST`。白名单只能通过：

- `create_server(..., event_source_allowlist=...)`
- `--event-source-allowlist`

传入。

## Test evidence

测试先行证据：

```text
审查修复实现前：5 failed, 9 passed
修复后安全专项：14 passed
```

准确专项测试：

```bash
python -m pytest tests/unit/test_multi_host.py tests/unit/test_dashboard_backend.py -v
```

结果：

```text
33 passed
```

公共门禁：

```bash
make test
make contract
make scenario-check
make context-check
make demo-scripted
make check
```

结果：

```text
make test: 497 passed
make contract: contract validation passed
make scenario-check: 12 frozen and 24 expanded manifests passed
make context-check: context validation passed
make demo-scripted: passed

make check:
- ruff check passed
- ruff format check passed
- 497 tests passed
- contract passed
- scenario passed
- golden set passed
- context passed
- demo-scripted passed
- demo-offline passed
```

边界和格式证据：

```bash
git diff --check

python tools/scripts/check_task_packet.py \
  docs/task_packets/issue-71-backend-egress-policy.json \
  --base main
```

结果：

```text
git diff --check: no output
Task Packet validation passed
```

## Behavioral evidence

- redirect 测试证明目标服务器收到零次请求；
- DNS pinning 测试证明解析器只调用一次，实际连接使用已校验地址；
- 覆盖 IPv4、IPv6、IPv4-mapped IPv6 和 mixed permitted/forbidden DNS；
- 精确 4 MiB 在有、无 `Content-Length` 时均被接受；
- 4 MiB + 1 在有、无 `Content-Length` 时均被拒绝；
- connection/request timeout 和 `response.read()` timeout 均转换为 `ReadModelError`；
- 非字符串 allow-list、Unicode hostname 和非法 URL 均 fail closed；
- 非法配置下 `/healthz` 返回 200，`/readyz` 和 `/api/v1/runs` 返回 503；
- CLI 测试证明 allow-list 仅由显式参数传入，不读取 allow-list 环境变量。

## Risks

- Phase A 尚未接入部署环境变量和 Compose。非 loopback 部署若没有通过 Python/CLI 显式提供白名单，会按设计返回 503。
- Unicode/IDN hostname 当前被明确拒绝；如未来需要支持，应单独设计 IDNA 规范化和安全测试。
- DNS 总超时及多个安全 IP 的故障切换不属于本 PR，由 #74 处理。
- 本 PR 只使用第一个通过全部策略检查的 DNS 地址，不实现多地址重试。

## Rollback

可以通过 revert 本 PR 的合并提交回滚。

由于回滚会恢复原先可能跟随 redirect、访问任意远程 HTTP 地址的行为，执行回滚前必须先：

1. 禁用远程 `WORKBENCH_EVENT_SOURCE_URL`；或
2. 在部署网络层阻断不受信任的出站访问。

不得在仍启用不受信任远程事件源的情况下直接回滚安全限制。

## Owner review

- Backend/World Model Owner：`@kukuboring`，确认模块范围、行为和安全边界；
- 独立人类 Reviewer/Maintainer：邀请 `@Quchaosheng`，负责最终 diff、CI 和合并判断。

本 PR 不修改 Compose、环境变量契约或部署文档，因此 Phase A 不要求 Integration Owner 或 Linux Owner 审批。

## Final human checklist

- [ ] 人工检查完整 diff
- [ ] 确认所有修改都在 Task Packet `allowed_paths`
- [ ] 确认本地测试结果
- [ ] 确认 Conventional Commit 消息
- [ ] 确认 DCO 姓名和邮箱
- [ ] 确认 PR 描述准确
- [ ] 确认需要邀请的 Reviewer/Owner
- [ ] 推送后确认 GitHub Actions CI
- [ ] 人工决定是否满足 Issue #71 Phase A
- [ ] 人工决定是否合并