### PR TITLE
fix(virtual-mcu): reject unknown commands

### DIFF
--- a/docs/task_packets/issue-63-virtual-mcu-command-rejection.json
+++ b/docs/task_packets/issue-63-virtual-mcu-command-rejection.json
@@ -1,0 +1,50 @@
+{
+  "issue": "63",
+  "human_owner": "TH3478",
+  "objective": "Make the Python VirtualMcu reject unknown and malformed commands with an explicit typed result without mutating state.",
+  "allowed_paths": [
+    "firmware/virtual_mcu/workbench_virtual_mcu/state_machine.py",
+    "firmware/virtual_mcu/workbench_virtual_mcu/__init__.py",
+    "tests/unit/test_virtual_mcu.py",
+    "docs/task_packets/issue-63-virtual-mcu-command-rejection.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "firmware/mcu/README.md",
+    "docs/task_packets/issue-53-mcu-safety-state-machine.json"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/mcu/**",
+    "robot/control/**",
+    "libs/contracts/**"
+  ],
+  "acceptance": [
+    "Unknown, empty, non-string, whitespace-padded, and state-invalid commands return a typed rejected result.",
+    "Rejected commands preserve both the current state and fault code.",
+    "Accepted command/state transitions are explicit and tested for every state.",
+    "STOP remains accepted from every state and remains idempotent without clearing a watchdog fault.",
+    "Reset clears a fault only through the existing accepted SAFE_STOP or FAULT transition.",
+    "The Python model change does not claim parity with authoritative C firmware or physical MCU behavior."
+  ],
+  "commands": [
+    "python3 -m pytest tests/unit/test_virtual_mcu.py -v",
+    "python3 -m ruff check firmware/virtual_mcu/workbench_virtual_mcu tests/unit/test_virtual_mcu.py",
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-63-virtual-mcu-command-rejection.json",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "VirtualMcu focused tests cover malformed inputs, state preservation, STOP idempotence, and the complete command matrix.",
+    "Task Packet validation output.",
+    "Full repository test, contract, scenario, context, lint, and diff-check output."
+  ],
+  "stop_conditions": [
+    "C firmware or firmware/mcu changes are required.",
+    "A protocol schema or canonical Pydantic contract change is required.",
+    "The model would need to be presented as a safety reference or C parity oracle.",
+    "A write outside allowed_paths is required."
+  ]
+}

--- a/firmware/virtual_mcu/workbench_virtual_mcu/__init__.py
+++ b/firmware/virtual_mcu/workbench_virtual_mcu/__init__.py
@@ -1,3 +1,15 @@
-from .state_machine import McuState, VirtualMcu
+from .state_machine import (
+    McuCommandRejection,
+    McuCommandResult,
+    McuCommandStatus,
+    McuState,
+    VirtualMcu,
+)
 
-__all__ = ["McuState", "VirtualMcu"]
+__all__ = [
+    "McuCommandRejection",
+    "McuCommandResult",
+    "McuCommandStatus",
+    "McuState",
+    "VirtualMcu",
+]

--- a/firmware/virtual_mcu/workbench_virtual_mcu/state_machine.py
+++ b/firmware/virtual_mcu/workbench_virtual_mcu/state_machine.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import StrEnum
 
 
@@ -8,6 +9,48 @@ class McuState(StrEnum):
     FAULT = "fault"
 
 
+class McuCommandStatus(StrEnum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+class McuCommandRejection(StrEnum):
+    NON_STRING = "non_string_command"
+    EMPTY = "empty_command"
+    MALFORMED = "malformed_command"
+    UNKNOWN = "unknown_command"
+    INVALID_STATE = "invalid_state_transition"
+
+
+@dataclass(frozen=True)
+class McuCommandResult:
+    status: McuCommandStatus
+    state: McuState
+    reason: McuCommandRejection | None = None
+
+    def __post_init__(self) -> None:
+        if self.status is McuCommandStatus.ACCEPTED and self.reason is not None:
+            raise ValueError("accepted command results cannot have a rejection reason")
+        if self.status is McuCommandStatus.REJECTED and self.reason is None:
+            raise ValueError("rejected command results require a rejection reason")
+
+    @property
+    def accepted(self) -> bool:
+        return self.status is McuCommandStatus.ACCEPTED
+
+    @property
+    def rejected(self) -> bool:
+        return self.status is McuCommandStatus.REJECTED
+
+
+_COMMAND_ALLOWED_STATES: dict[str, frozenset[McuState]] = {
+    "stop": frozenset(McuState),
+    "reset": frozenset({McuState.SAFE_STOP, McuState.FAULT}),
+    "execute": frozenset({McuState.IDLE}),
+    "complete": frozenset({McuState.EXECUTING}),
+}
+
+
 class VirtualMcu:
     """Tiny deterministic model of the P0 safety boundary."""
 
@@ -15,17 +58,32 @@ class VirtualMcu:
         self.state = McuState.IDLE
         self.fault_code: str | None = None
 
-    def command(self, command: str) -> McuState:
+    def command(self, command: object) -> McuCommandResult:
+        if not isinstance(command, str):
+            return self._reject(McuCommandRejection.NON_STRING)
+        if not command:
+            return self._reject(McuCommandRejection.EMPTY)
+        if command != command.strip():
+            return self._reject(McuCommandRejection.MALFORMED)
+        allowed_states = _COMMAND_ALLOWED_STATES.get(command)
+        if allowed_states is None:
+            return self._reject(McuCommandRejection.UNKNOWN)
+        if self.state not in allowed_states:
+            return self._reject(McuCommandRejection.INVALID_STATE)
+
         if command == "stop":
             self.state = McuState.SAFE_STOP
-        elif command == "reset" and self.state in {McuState.SAFE_STOP, McuState.FAULT}:
+        elif command == "reset":
             self.state = McuState.IDLE
             self.fault_code = None
-        elif command == "execute" and self.state == McuState.IDLE:
+        elif command == "execute":
             self.state = McuState.EXECUTING
-        elif command == "complete" and self.state == McuState.EXECUTING:
+        elif command == "complete":
             self.state = McuState.IDLE
-        return self.state
+        return McuCommandResult(McuCommandStatus.ACCEPTED, self.state)
+
+    def _reject(self, reason: McuCommandRejection) -> McuCommandResult:
+        return McuCommandResult(McuCommandStatus.REJECTED, self.state, reason)
 
     def watchdog_timeout(self) -> McuState:
         self.state = McuState.FAULT

--- a/tests/unit/test_virtual_mcu.py
+++ b/tests/unit/test_virtual_mcu.py
@@ -5,18 +5,126 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "firmware/virtual_mcu"))
 
-from workbench_virtual_mcu import McuState, VirtualMcu
+from workbench_virtual_mcu import (
+    McuCommandRejection,
+    McuCommandStatus,
+    McuState,
+    VirtualMcu,
+)
 
 
 class VirtualMcuTests(unittest.TestCase):
     def test_stop_and_watchdog_enter_safe_states(self) -> None:
         mcu = VirtualMcu()
-        self.assertEqual(mcu.command("execute"), McuState.EXECUTING)
-        self.assertEqual(mcu.command("complete"), McuState.IDLE)
-        self.assertEqual(mcu.command("execute"), McuState.EXECUTING)
-        self.assertEqual(mcu.command("stop"), McuState.SAFE_STOP)
-        self.assertEqual(mcu.command("reset"), McuState.IDLE)
+        self.assertEqual(mcu.command("execute").state, McuState.EXECUTING)
+        self.assertEqual(mcu.command("complete").state, McuState.IDLE)
+        self.assertEqual(mcu.command("execute").state, McuState.EXECUTING)
+        self.assertEqual(mcu.command("stop").state, McuState.SAFE_STOP)
+        self.assertEqual(mcu.command("reset").state, McuState.IDLE)
         self.assertEqual(mcu.watchdog_timeout(), McuState.FAULT)
+
+    def test_unknown_empty_non_string_and_malformed_commands_are_rejected(self) -> None:
+        for command, reason in (
+            ("typo", McuCommandRejection.UNKNOWN),
+            ("", McuCommandRejection.EMPTY),
+            (None, McuCommandRejection.NON_STRING),
+            (" execute", McuCommandRejection.MALFORMED),
+        ):
+            with self.subTest(command=command):
+                mcu = VirtualMcu()
+                result = mcu.command(command)
+
+                self.assertEqual(result.status, McuCommandStatus.REJECTED)
+                self.assertTrue(result.rejected)
+                self.assertFalse(result.accepted)
+                self.assertEqual(result.reason, reason)
+                self.assertEqual(result.state, McuState.IDLE)
+                self.assertIsNone(mcu.fault_code)
+
+    def test_rejected_state_transitions_do_not_mutate_state_or_fault(self) -> None:
+        cases = (
+            (McuState.IDLE, None, "complete"),
+            (McuState.EXECUTING, None, "execute"),
+            (McuState.EXECUTING, None, "reset"),
+            (McuState.SAFE_STOP, None, "execute"),
+            (McuState.FAULT, "WATCHDOG_TIMEOUT", "execute"),
+        )
+        for state, fault_code, command in cases:
+            with self.subTest(state=state, command=command):
+                mcu = VirtualMcu()
+                mcu.state = state
+                mcu.fault_code = fault_code
+
+                result = mcu.command(command)
+
+                self.assertEqual(result.status, McuCommandStatus.REJECTED)
+                self.assertEqual(result.reason, McuCommandRejection.INVALID_STATE)
+                self.assertEqual(result.state, state)
+                self.assertEqual(mcu.state, state)
+                self.assertEqual(mcu.fault_code, fault_code)
+
+    def test_reset_from_fault_is_the_only_fault_clear_path(self) -> None:
+        mcu = VirtualMcu()
+        mcu.watchdog_timeout()
+
+        result = mcu.command("reset")
+
+        self.assertEqual(result.status, McuCommandStatus.ACCEPTED)
+        self.assertEqual(result.state, McuState.IDLE)
+        self.assertIsNone(mcu.fault_code)
+
+    def test_stop_is_accepted_from_every_state_and_is_idempotent(self) -> None:
+        for state in McuState:
+            with self.subTest(state=state):
+                mcu = VirtualMcu()
+                mcu.state = state
+                mcu.fault_code = "WATCHDOG_TIMEOUT" if state is McuState.FAULT else None
+
+                first = mcu.command("stop")
+                second = mcu.command("stop")
+
+                self.assertEqual(first.status, McuCommandStatus.ACCEPTED)
+                self.assertEqual(second.status, McuCommandStatus.ACCEPTED)
+                self.assertEqual(first.state, McuState.SAFE_STOP)
+                self.assertEqual(second.state, McuState.SAFE_STOP)
+                self.assertEqual(mcu.fault_code, "WATCHDOG_TIMEOUT" if state is McuState.FAULT else None)
+
+    def test_command_matrix_has_one_explicit_outcome_per_state(self) -> None:
+        expected = {
+            McuState.IDLE: {
+                "stop": True,
+                "reset": False,
+                "execute": True,
+                "complete": False,
+            },
+            McuState.EXECUTING: {
+                "stop": True,
+                "reset": False,
+                "execute": False,
+                "complete": True,
+            },
+            McuState.SAFE_STOP: {
+                "stop": True,
+                "reset": True,
+                "execute": False,
+                "complete": False,
+            },
+            McuState.FAULT: {
+                "stop": True,
+                "reset": True,
+                "execute": False,
+                "complete": False,
+            },
+        }
+        for state, commands in expected.items():
+            for command, accepted in commands.items():
+                with self.subTest(state=state, command=command):
+                    mcu = VirtualMcu()
+                    mcu.state = state
+                    mcu.fault_code = "WATCHDOG_TIMEOUT" if state is McuState.FAULT else None
+                    result = mcu.command(command)
+
+                    self.assertEqual(result.accepted, accepted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add typed command results for `VirtualMcu.command()`.
- Explicitly reject unknown, empty, non-string, whitespace-padded, malformed, and state-invalid commands.
- Preserve the current state and fault code when a command is rejected.
- Define and test the complete state-by-command transition matrix.
- Keep `STOP` accepted and idempotent from every state.
- Allow `reset` only from `SAFE_STOP` or `FAULT`, clearing the fault only on an accepted reset.

## Testing

- `make PYTHON=.venv/bin/python test` — 490 passed
- Ruff checks and formatting passed
- `make contract` passed
- `make scenario-check` passed
- `make context-check` passed
- Task Packet validation passed
- `git diff --check` passed

## Scope

This change is limited to the Python VirtualMcu model, its unit tests, and the Issue #63 Task Packet. It does not modify the C firmware, protocol schemas, or canonical contracts.

Closes #63