### PR TITLE
163fc29 fix(kernel): normalize schema validation errors

### DIFF
--- a/docs/task_packets/issue-223-schema-validation-error.json
+++ b/docs/task_packets/issue-223-schema-validation-error.json
@@ -22,8 +22,9 @@
     "NaN and positive or negative infinity are rejected with SchemaValidationError",
     "malformed minimum and maximum bounds are reported as SchemaValidationError",
     "malformed regular-expression patterns are reported as SchemaValidationError",
+    "malformed anyOf, not, and if branches are not treated as value mismatches",
     "CommunicationBroker rejects malformed numeric payloads without appending to message_log",
-    "regression tests cover huge integers, non-finite floats, malformed bounds, malformed patterns, and broker rejection"
+    "regression tests cover huge integers, non-finite floats, malformed bounds, malformed combinator branches, and broker rejection"
   ],
   "commands": [
     "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-223-schema-validation-error.json",

--- a/docs/task_packets/issue-223-schema-validation-error.json
+++ b/docs/task_packets/issue-223-schema-validation-error.json
@@ -1,0 +1,49 @@
+{
+  "issue": 223,
+  "human_owner": "Quchaosheng",
+  "objective": "Normalize malformed numeric and regular-expression schema validation failures to SchemaValidationError so the kernel broker remains fail-closed.",
+  "allowed_paths": [
+    "libs/kernel/workbench/kernel/schema_compiler.py",
+    "tests/unit/test_kernel_schema_compiler.py",
+    "tests/unit/test_kernel_communication_broker.py",
+    "docs/task_packets/issue-223-schema-validation-error.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "interfaces/**"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "acceptance": [
+    "huge Python integers used with the supported number type do not leak OverflowError",
+    "NaN and positive or negative infinity are rejected with SchemaValidationError",
+    "malformed minimum and maximum bounds are reported as SchemaValidationError",
+    "malformed regular-expression patterns are reported as SchemaValidationError",
+    "CommunicationBroker rejects malformed numeric payloads without appending to message_log",
+    "regression tests cover huge integers, non-finite floats, malformed bounds, malformed patterns, and broker rejection"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-223-schema-validation-error.json",
+    "python3 -m pytest tests/unit/test_kernel_schema_compiler.py tests/unit/test_kernel_communication_broker.py -q",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "focused validator and broker regression test output",
+    "full repository test output",
+    "contract, scenario, and context validation output",
+    "clean whitespace diff check and Task Packet validation output"
+  ],
+  "stop_conditions": [
+    "an interface schema change is required",
+    "a write outside the allowed paths is required",
+    "robot-control or firmware changes are required",
+    "the broker boundary requires catching unrelated unexpected exceptions"
+  ]
+}

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -45,6 +45,14 @@ class SchemaValidationError(ValueError):
     """Raised when a value does not satisfy the supported schema subset."""
 
 
+class _SchemaMismatch(SchemaValidationError):
+    """Raised when a value does not match an otherwise valid schema."""
+
+
+class _MalformedSchema(SchemaValidationError):
+    """Raised when a schema cannot be evaluated safely."""
+
+
 def _is_finite_json_number(value: Any) -> bool:
     """Return whether value is a JSON number representable by the runtime validator."""
     if type(value) is int:
@@ -55,8 +63,104 @@ def _is_finite_json_number(value: Any) -> bool:
 def _numeric_constraint(schema: dict[str, Any], keyword: str, location: str) -> int | float:
     bound = schema[keyword]
     if not _is_finite_json_number(bound):
-        raise SchemaValidationError(f"schema {keyword} at {location} must be a finite number")
+        raise _MalformedSchema(f"schema {keyword} at {location} must be a finite number")
     return bound
+
+
+def _validate_schema_structure(
+    schema: Any,
+    *,
+    references: dict[str, dict[str, Any]] | None,
+    location: str,
+    reference_stack: frozenset[str] = frozenset(),
+) -> None:
+    if not isinstance(schema, dict):
+        raise _MalformedSchema(f"schema at {location} must be an object")
+    if "$ref" in schema:
+        reference = schema["$ref"]
+        if not isinstance(reference, str):
+            raise _MalformedSchema(f"schema reference at {location} must be a string")
+        referenced = (references or {}).get(reference)
+        if referenced is None:
+            raise _MalformedSchema(f"unresolved schema reference {reference!r} at {location}")
+        if reference not in reference_stack:
+            _validate_schema_structure(
+                referenced,
+                references=references,
+                location=location,
+                reference_stack=reference_stack | {reference},
+            )
+        return
+
+    if "enum" in schema and not isinstance(schema["enum"], list):
+        raise _MalformedSchema(f"schema enum at {location} must be a list")
+    schema_types = schema.get("type")
+    if schema_types is not None:
+        allowed_types = schema_types if isinstance(schema_types, list) else [schema_types]
+        if not allowed_types or not all(isinstance(schema_type, str) for schema_type in allowed_types):
+            raise _MalformedSchema(f"schema type at {location} must be a string or string list")
+        supported_types = {"null", "boolean", "integer", "number", "string", "array", "object"}
+        if any(schema_type not in supported_types for schema_type in allowed_types):
+            raise _MalformedSchema(f"unsupported schema type(s) {allowed_types!r} at {location}")
+    for constraint_name in ("minimum", "maximum"):
+        if constraint_name in schema:
+            _numeric_constraint(schema, constraint_name, location)
+    if "pattern" in schema:
+        pattern = schema["pattern"]
+        if not isinstance(pattern, str):
+            raise _MalformedSchema(f"schema pattern at {location} must be a string")
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise _MalformedSchema(f"schema pattern at {location} is invalid") from exc
+    if "minItems" in schema and (type(schema["minItems"]) is not int or schema["minItems"] < 0):
+        raise _MalformedSchema(f"schema minItems at {location} must be a non-negative integer")
+
+    items = schema.get("items")
+    if items is not None:
+        _validate_schema_structure(items, references=references, location=f"{location}.items")
+    properties = schema.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict):
+            raise _MalformedSchema(f"properties at {location} must be an object")
+        for field_name, definition in properties.items():
+            if not isinstance(field_name, str):
+                raise _MalformedSchema(f"property names at {location} must be strings")
+            _validate_schema_structure(
+                definition,
+                references=references,
+                location=f"{location}.{field_name}",
+            )
+    required = schema.get("required")
+    if required is not None and (
+        not isinstance(required, list) or any(not isinstance(field_name, str) for field_name in required)
+    ):
+        raise _MalformedSchema(f"required at {location} must be a string list")
+
+    all_of = schema.get("allOf")
+    if all_of is not None:
+        if not isinstance(all_of, list) or any(not isinstance(branch, dict) for branch in all_of):
+            raise _MalformedSchema(f"schema allOf at {location} must be an object list")
+        for index, branch in enumerate(all_of, start=1):
+            _validate_schema_structure(
+                branch,
+                references=references,
+                location=f"{location}.allOf[{index}]",
+            )
+    any_of = schema.get("anyOf")
+    if any_of is not None:
+        if not isinstance(any_of, list) or not any_of or any(not isinstance(branch, dict) for branch in any_of):
+            raise _MalformedSchema(f"schema anyOf at {location} must be a non-empty object list")
+        for index, branch in enumerate(any_of, start=1):
+            _validate_schema_structure(
+                branch,
+                references=references,
+                location=f"{location}.anyOf[{index}]",
+            )
+    for branch_name in ("if", "then", "else", "not"):
+        branch = schema.get(branch_name)
+        if branch is not None:
+            _validate_schema_structure(branch, references=references, location=f"{location}.{branch_name}")
 
 
 def _matches_json_type(value: Any, schema_type: str) -> bool:
@@ -74,7 +178,7 @@ def _matches_json_type(value: Any, schema_type: str) -> bool:
         return isinstance(value, list)
     if schema_type == "object":
         return isinstance(value, dict)
-    raise SchemaValidationError(f"unsupported schema type {schema_type!r}")
+    raise _MalformedSchema(f"unsupported schema type {schema_type!r}")
 
 
 def _enum_contains(enum: list[Any], value: Any) -> bool:
@@ -90,7 +194,7 @@ def _schema_matches(
 ) -> bool:
     try:
         validate_schema_instance(value, schema, references=references, location=location)
-    except SchemaValidationError:
+    except _SchemaMismatch:
         return False
     return True
 
@@ -103,66 +207,71 @@ def validate_schema_instance(
     location: str = "$",
 ) -> None:
     """Validate one value against the JSON Schema subset the compiler supports."""
+    _validate_schema_structure(schema, references=references, location=location)
     if not isinstance(schema, dict):
-        raise SchemaValidationError(f"schema at {location} must be an object")
+        raise _MalformedSchema(f"schema at {location} must be an object")
     if type(value) is float and not math.isfinite(value):
         raise SchemaValidationError(f"value at {location} must be a finite JSON number")
     if "$ref" in schema:
         reference = schema["$ref"]
+        if not isinstance(reference, str):
+            raise _MalformedSchema(f"schema reference at {location} must be a string")
         referenced = (references or {}).get(reference)
         if referenced is None:
-            raise SchemaValidationError(f"unresolved schema reference {reference!r} at {location}")
+            raise _MalformedSchema(f"unresolved schema reference {reference!r} at {location}")
         validate_schema_instance(value, referenced, references=references, location=location)
         return
 
     if "const" in schema and (type(value) is not type(schema["const"]) or value != schema["const"]):
-        raise SchemaValidationError(f"value at {location} does not match const {schema['const']!r}")
+        raise _SchemaMismatch(f"value at {location} does not match const {schema['const']!r}")
 
     if "enum" in schema:
         enum = schema["enum"]
-        if not isinstance(enum, list) or not _enum_contains(enum, value):
-            raise SchemaValidationError(f"value at {location} is not in the allowed enum")
+        if not isinstance(enum, list):
+            raise _MalformedSchema(f"schema enum at {location} must be a list")
+        if not _enum_contains(enum, value):
+            raise _SchemaMismatch(f"value at {location} is not in the allowed enum")
 
     schema_types = schema.get("type")
     if schema_types is not None:
         allowed_types = schema_types if isinstance(schema_types, list) else [schema_types]
         if not all(isinstance(schema_type, str) for schema_type in allowed_types):
-            raise SchemaValidationError(f"schema type at {location} must be a string or string list")
+            raise _MalformedSchema(f"schema type at {location} must be a string or string list")
         if not any(_matches_json_type(value, schema_type) for schema_type in allowed_types):
-            raise SchemaValidationError(f"value at {location} does not match type {schema_types!r}")
+            raise _SchemaMismatch(f"value at {location} does not match type {schema_types!r}")
 
     if "minimum" in schema:
         minimum = _numeric_constraint(schema, "minimum", location)
         try:
             below_minimum = not _is_finite_json_number(value) or value < minimum
         except (OverflowError, TypeError) as exc:
-            raise SchemaValidationError(f"value at {location} cannot be compared with minimum {minimum!r}") from exc
+            raise _SchemaMismatch(f"value at {location} cannot be compared with minimum {minimum!r}") from exc
         if below_minimum:
-            raise SchemaValidationError(f"value at {location} is below minimum {minimum!r}")
+            raise _SchemaMismatch(f"value at {location} is below minimum {minimum!r}")
     if "maximum" in schema:
         maximum = _numeric_constraint(schema, "maximum", location)
         try:
             above_maximum = not _is_finite_json_number(value) or value > maximum
         except (OverflowError, TypeError) as exc:
-            raise SchemaValidationError(f"value at {location} cannot be compared with maximum {maximum!r}") from exc
+            raise _SchemaMismatch(f"value at {location} cannot be compared with maximum {maximum!r}") from exc
         if above_maximum:
-            raise SchemaValidationError(f"value at {location} is above maximum {maximum!r}")
+            raise _SchemaMismatch(f"value at {location} is above maximum {maximum!r}")
     if "pattern" in schema:
         pattern = schema["pattern"]
         if not isinstance(pattern, str):
-            raise SchemaValidationError(f"schema pattern at {location} must be a string")
+            raise _MalformedSchema(f"schema pattern at {location} must be a string")
         try:
             matcher = re.compile(pattern)
         except re.error as exc:
-            raise SchemaValidationError(f"schema pattern at {location} is invalid") from exc
+            raise _MalformedSchema(f"schema pattern at {location} is invalid") from exc
         if not isinstance(value, str) or matcher.search(value) is None:
-            raise SchemaValidationError(f"value at {location} does not match pattern {pattern!r}")
+            raise _SchemaMismatch(f"value at {location} does not match pattern {pattern!r}")
     if "minItems" in schema:
         min_items = schema["minItems"]
         if type(min_items) is not int or min_items < 0:
-            raise SchemaValidationError(f"schema minItems at {location} must be a non-negative integer")
+            raise _MalformedSchema(f"schema minItems at {location} must be a non-negative integer")
         if not isinstance(value, list) or len(value) < min_items:
-            raise SchemaValidationError(f"array at {location} has fewer than {min_items} items")
+            raise _SchemaMismatch(f"array at {location} has fewer than {min_items} items")
 
     if isinstance(value, list) and "items" in schema:
         for index, item in enumerate(value):
@@ -177,14 +286,14 @@ def validate_schema_instance(
         properties = schema.get("properties", {})
         required = schema.get("required", [])
         if not isinstance(properties, dict) or not isinstance(required, list):
-            raise SchemaValidationError(f"object schema at {location} has invalid properties or required fields")
+            raise _MalformedSchema(f"object schema at {location} has invalid properties or required fields")
         missing = set(required) - set(value)
         if missing:
-            raise SchemaValidationError(f"object at {location} is missing fields: {sorted(missing)}")
+            raise _SchemaMismatch(f"object at {location} is missing fields: {sorted(missing)}")
         if schema.get("additionalProperties", True) is False:
             extra = set(value) - set(properties)
             if extra:
-                raise SchemaValidationError(f"object at {location} has extra fields: {sorted(extra)}")
+                raise _SchemaMismatch(f"object at {location} has extra fields: {sorted(extra)}")
         for field_name, definition in properties.items():
             if field_name in value:
                 validate_schema_instance(
@@ -195,22 +304,33 @@ def validate_schema_instance(
                 )
 
     any_of = schema.get("anyOf")
-    if any_of is not None and not any(
-        _schema_matches(value, candidate, references=references, location=location) for candidate in any_of
-    ):
-        raise SchemaValidationError(f"value at {location} does not match any allowed schema")
+    if any_of is not None:
+        if not isinstance(any_of, list) or not any_of or any(not isinstance(candidate, dict) for candidate in any_of):
+            raise _MalformedSchema(f"schema anyOf at {location} must be a non-empty object list")
+        if not any(_schema_matches(value, candidate, references=references, location=location) for candidate in any_of):
+            raise _SchemaMismatch(f"value at {location} does not match any allowed schema")
 
     excluded = schema.get("not")
-    if excluded is not None and _schema_matches(value, excluded, references=references, location=location):
-        raise SchemaValidationError(f"value at {location} matches a forbidden schema")
+    if excluded is not None:
+        if not isinstance(excluded, dict):
+            raise _MalformedSchema(f"schema not at {location} must be an object")
+        if _schema_matches(value, excluded, references=references, location=location):
+            raise _SchemaMismatch(f"value at {location} matches a forbidden schema")
 
-    for constraint in schema.get("allOf", []):
+    all_of = schema.get("allOf", [])
+    if not isinstance(all_of, list) or any(not isinstance(constraint, dict) for constraint in all_of):
+        raise _MalformedSchema(f"schema allOf at {location} must be an object list")
+    for constraint in all_of:
         validate_schema_instance(value, constraint, references=references, location=location)
 
     condition = schema.get("if")
     if condition is not None:
+        if not isinstance(condition, dict):
+            raise _MalformedSchema(f"schema if at {location} must be an object")
         branch = "then" if _schema_matches(value, condition, references=references, location=location) else "else"
         if branch in schema:
+            if not isinstance(schema[branch], dict):
+                raise _MalformedSchema(f"schema {branch} at {location} must be an object")
             validate_schema_instance(value, schema[branch], references=references, location=location)
 
 

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -45,6 +45,20 @@ class SchemaValidationError(ValueError):
     """Raised when a value does not satisfy the supported schema subset."""
 
 
+def _is_finite_json_number(value: Any) -> bool:
+    """Return whether value is a JSON number representable by the runtime validator."""
+    if type(value) is int:
+        return True
+    return type(value) is float and math.isfinite(value)
+
+
+def _numeric_constraint(schema: dict[str, Any], keyword: str, location: str) -> int | float:
+    bound = schema[keyword]
+    if not _is_finite_json_number(bound):
+        raise SchemaValidationError(f"schema {keyword} at {location} must be a finite number")
+    return bound
+
+
 def _matches_json_type(value: Any, schema_type: str) -> bool:
     if schema_type == "null":
         return value is None
@@ -53,7 +67,7 @@ def _matches_json_type(value: Any, schema_type: str) -> bool:
     if schema_type == "integer":
         return type(value) is int
     if schema_type == "number":
-        return type(value) in {int, float} and math.isfinite(value)
+        return _is_finite_json_number(value)
     if schema_type == "string":
         return isinstance(value, str)
     if schema_type == "array":
@@ -91,6 +105,8 @@ def validate_schema_instance(
     """Validate one value against the JSON Schema subset the compiler supports."""
     if not isinstance(schema, dict):
         raise SchemaValidationError(f"schema at {location} must be an object")
+    if type(value) is float and not math.isfinite(value):
+        raise SchemaValidationError(f"value at {location} must be a finite JSON number")
     if "$ref" in schema:
         reference = schema["$ref"]
         referenced = (references or {}).get(reference)
@@ -115,14 +131,38 @@ def validate_schema_instance(
         if not any(_matches_json_type(value, schema_type) for schema_type in allowed_types):
             raise SchemaValidationError(f"value at {location} does not match type {schema_types!r}")
 
-    if "minimum" in schema and (type(value) not in {int, float} or value < schema["minimum"]):
-        raise SchemaValidationError(f"value at {location} is below minimum {schema['minimum']!r}")
-    if "maximum" in schema and (type(value) not in {int, float} or value > schema["maximum"]):
-        raise SchemaValidationError(f"value at {location} is above maximum {schema['maximum']!r}")
-    if "pattern" in schema and (not isinstance(value, str) or re.search(schema["pattern"], value) is None):
-        raise SchemaValidationError(f"value at {location} does not match pattern {schema['pattern']!r}")
-    if "minItems" in schema and (not isinstance(value, list) or len(value) < schema["minItems"]):
-        raise SchemaValidationError(f"array at {location} has fewer than {schema['minItems']} items")
+    if "minimum" in schema:
+        minimum = _numeric_constraint(schema, "minimum", location)
+        try:
+            below_minimum = not _is_finite_json_number(value) or value < minimum
+        except (OverflowError, TypeError) as exc:
+            raise SchemaValidationError(f"value at {location} cannot be compared with minimum {minimum!r}") from exc
+        if below_minimum:
+            raise SchemaValidationError(f"value at {location} is below minimum {minimum!r}")
+    if "maximum" in schema:
+        maximum = _numeric_constraint(schema, "maximum", location)
+        try:
+            above_maximum = not _is_finite_json_number(value) or value > maximum
+        except (OverflowError, TypeError) as exc:
+            raise SchemaValidationError(f"value at {location} cannot be compared with maximum {maximum!r}") from exc
+        if above_maximum:
+            raise SchemaValidationError(f"value at {location} is above maximum {maximum!r}")
+    if "pattern" in schema:
+        pattern = schema["pattern"]
+        if not isinstance(pattern, str):
+            raise SchemaValidationError(f"schema pattern at {location} must be a string")
+        try:
+            matcher = re.compile(pattern)
+        except re.error as exc:
+            raise SchemaValidationError(f"schema pattern at {location} is invalid") from exc
+        if not isinstance(value, str) or matcher.search(value) is None:
+            raise SchemaValidationError(f"value at {location} does not match pattern {pattern!r}")
+    if "minItems" in schema:
+        min_items = schema["minItems"]
+        if type(min_items) is not int or min_items < 0:
+            raise SchemaValidationError(f"schema minItems at {location} must be a non-negative integer")
+        if not isinstance(value, list) or len(value) < min_items:
+            raise SchemaValidationError(f"array at {location} has fewer than {min_items} items")
 
     if isinstance(value, list) and "items" in schema:
         for index, item in enumerate(value):

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -111,14 +111,19 @@ def _validate_schema_structure(
             raise _MalformedSchema(f"schema pattern at {location} must be a string")
         try:
             re.compile(pattern)
-        except re.error as exc:
+        except (re.error, OverflowError) as exc:
             raise _MalformedSchema(f"schema pattern at {location} is invalid") from exc
     if "minItems" in schema and (type(schema["minItems"]) is not int or schema["minItems"] < 0):
         raise _MalformedSchema(f"schema minItems at {location} must be a non-negative integer")
 
     items = schema.get("items")
     if items is not None:
-        _validate_schema_structure(items, references=references, location=f"{location}.items")
+        _validate_schema_structure(
+            items,
+            references=references,
+            location=f"{location}.items",
+            reference_stack=reference_stack,
+        )
     properties = schema.get("properties")
     if properties is not None:
         if not isinstance(properties, dict):
@@ -130,6 +135,7 @@ def _validate_schema_structure(
                 definition,
                 references=references,
                 location=f"{location}.{field_name}",
+                reference_stack=reference_stack,
             )
     required = schema.get("required")
     if required is not None and (
@@ -146,6 +152,7 @@ def _validate_schema_structure(
                 branch,
                 references=references,
                 location=f"{location}.allOf[{index}]",
+                reference_stack=reference_stack,
             )
     any_of = schema.get("anyOf")
     if any_of is not None:
@@ -156,11 +163,17 @@ def _validate_schema_structure(
                 branch,
                 references=references,
                 location=f"{location}.anyOf[{index}]",
+                reference_stack=reference_stack,
             )
     for branch_name in ("if", "then", "else", "not"):
         branch = schema.get(branch_name)
         if branch is not None:
-            _validate_schema_structure(branch, references=references, location=f"{location}.{branch_name}")
+            _validate_schema_structure(
+                branch,
+                references=references,
+                location=f"{location}.{branch_name}",
+                reference_stack=reference_stack,
+            )
 
 
 def _matches_json_type(value: Any, schema_type: str) -> bool:
@@ -191,9 +204,16 @@ def _schema_matches(
     *,
     references: dict[str, dict[str, Any]] | None,
     location: str,
+    reference_stack: frozenset[str],
 ) -> bool:
     try:
-        validate_schema_instance(value, schema, references=references, location=location)
+        validate_schema_instance(
+            value,
+            schema,
+            references=references,
+            location=location,
+            _reference_stack=reference_stack,
+        )
     except _SchemaMismatch:
         return False
     return True
@@ -205,6 +225,7 @@ def validate_schema_instance(
     *,
     references: dict[str, dict[str, Any]] | None = None,
     location: str = "$",
+    _reference_stack: frozenset[str] = frozenset(),
 ) -> None:
     """Validate one value against the JSON Schema subset the compiler supports."""
     _validate_schema_structure(schema, references=references, location=location)
@@ -219,7 +240,15 @@ def validate_schema_instance(
         referenced = (references or {}).get(reference)
         if referenced is None:
             raise _MalformedSchema(f"unresolved schema reference {reference!r} at {location}")
-        validate_schema_instance(value, referenced, references=references, location=location)
+        if reference in _reference_stack:
+            raise _MalformedSchema(f"schema reference cycle at {location} does not advance the instance")
+        validate_schema_instance(
+            value,
+            referenced,
+            references=references,
+            location=location,
+            _reference_stack=_reference_stack | {reference},
+        )
         return
 
     if "const" in schema and (type(value) is not type(schema["const"]) or value != schema["const"]):
@@ -262,7 +291,7 @@ def validate_schema_instance(
             raise _MalformedSchema(f"schema pattern at {location} must be a string")
         try:
             matcher = re.compile(pattern)
-        except re.error as exc:
+        except (re.error, OverflowError) as exc:
             raise _MalformedSchema(f"schema pattern at {location} is invalid") from exc
         if not isinstance(value, str) or matcher.search(value) is None:
             raise _SchemaMismatch(f"value at {location} does not match pattern {pattern!r}")
@@ -307,31 +336,68 @@ def validate_schema_instance(
     if any_of is not None:
         if not isinstance(any_of, list) or not any_of or any(not isinstance(candidate, dict) for candidate in any_of):
             raise _MalformedSchema(f"schema anyOf at {location} must be a non-empty object list")
-        if not any(_schema_matches(value, candidate, references=references, location=location) for candidate in any_of):
+        if not any(
+            _schema_matches(
+                value,
+                candidate,
+                references=references,
+                location=location,
+                reference_stack=_reference_stack,
+            )
+            for candidate in any_of
+        ):
             raise _SchemaMismatch(f"value at {location} does not match any allowed schema")
 
     excluded = schema.get("not")
     if excluded is not None:
         if not isinstance(excluded, dict):
             raise _MalformedSchema(f"schema not at {location} must be an object")
-        if _schema_matches(value, excluded, references=references, location=location):
+        if _schema_matches(
+            value,
+            excluded,
+            references=references,
+            location=location,
+            reference_stack=_reference_stack,
+        ):
             raise _SchemaMismatch(f"value at {location} matches a forbidden schema")
 
     all_of = schema.get("allOf", [])
     if not isinstance(all_of, list) or any(not isinstance(constraint, dict) for constraint in all_of):
         raise _MalformedSchema(f"schema allOf at {location} must be an object list")
     for constraint in all_of:
-        validate_schema_instance(value, constraint, references=references, location=location)
+        validate_schema_instance(
+            value,
+            constraint,
+            references=references,
+            location=location,
+            _reference_stack=_reference_stack,
+        )
 
     condition = schema.get("if")
     if condition is not None:
         if not isinstance(condition, dict):
             raise _MalformedSchema(f"schema if at {location} must be an object")
-        branch = "then" if _schema_matches(value, condition, references=references, location=location) else "else"
+        branch = (
+            "then"
+            if _schema_matches(
+                value,
+                condition,
+                references=references,
+                location=location,
+                reference_stack=_reference_stack,
+            )
+            else "else"
+        )
         if branch in schema:
             if not isinstance(schema[branch], dict):
                 raise _MalformedSchema(f"schema {branch} at {location} must be an object")
-            validate_schema_instance(value, schema[branch], references=references, location=location)
+            validate_schema_instance(
+                value,
+                schema[branch],
+                references=references,
+                location=location,
+                _reference_stack=_reference_stack,
+            )
 
 
 def _model_name(value: str) -> str:

--- a/tests/unit/test_kernel_communication_broker.py
+++ b/tests/unit/test_kernel_communication_broker.py
@@ -55,6 +55,10 @@ def test_broker_rejects_unknown_type_or_exact_version(
         ({"target": "red_block"}, "missing fields"),
         ({"target": "Red Block", "speed": 0.5}, "pattern"),
         ({"target": "red_block", "speed": 2.0}, "maximum"),
+        ({"target": "red_block", "speed": 10**400}, "maximum"),
+        ({"target": "red_block", "speed": float("nan")}, "invalid message envelope"),
+        ({"target": "red_block", "speed": float("inf")}, "invalid message envelope"),
+        ({"target": "red_block", "speed": float("-inf")}, "invalid message envelope"),
         ({"target": "red_block", "speed": 0.5, "raw_joint": 1}, "extra fields"),
         ({"target": "red_block", "speed": True}, "does not match type"),
         ({"_actor": "forged", "target": "red_block", "speed": 0.5}, "reserved"),
@@ -81,4 +85,31 @@ def test_broker_rejects_registered_content_that_is_not_a_schema(tmp_path: Path) 
     boundary = CommunicationBroker(registry)
     with pytest.raises(BrokerValidationError, match=r"version.*not registered"):
         boundary.publish({}, "action", "1.0.0", "planner")
+    assert boundary.message_log == []
+
+
+@pytest.mark.parametrize(
+    "schema, payload, error",
+    [
+        (
+            {"type": "object", "properties": {"speed": {"type": "number", "minimum": "invalid"}}},
+            {"speed": 0.5},
+            "minimum",
+        ),
+        (
+            {"type": "object", "properties": {"target": {"type": "string", "pattern": "["}}},
+            {"target": "red_block"},
+            "pattern",
+        ),
+    ],
+)
+def test_broker_converts_malformed_schema_constraints_to_rejection(
+    tmp_path: Path, schema: dict, payload: dict, error: str
+) -> None:
+    registry = VersionRegistry(tmp_path / "versions.json")
+    registry.register_schema("action", "1.0.0", schema)
+    boundary = CommunicationBroker(registry)
+
+    with pytest.raises(BrokerValidationError, match=error):
+        boundary.publish(payload, "action", "1.0.0", "planner")
     assert boundary.message_log == []

--- a/tests/unit/test_kernel_communication_broker.py
+++ b/tests/unit/test_kernel_communication_broker.py
@@ -115,6 +115,23 @@ def test_broker_converts_malformed_schema_constraints_to_rejection(
     assert boundary.message_log == []
 
 
+def test_broker_normalizes_oversized_regex_without_partial_log(tmp_path: Path) -> None:
+    registry = VersionRegistry(tmp_path / "versions.json")
+    registry.register_schema(
+        "action",
+        "1.0.0",
+        {
+            "type": "object",
+            "properties": {"target": {"type": "string", "pattern": "a{999999999999999999999}"}},
+        },
+    )
+    boundary = CommunicationBroker(registry)
+
+    with pytest.raises(BrokerValidationError, match="pattern"):
+        boundary.publish({"target": "a"}, "action", "1.0.0", "planner")
+    assert boundary.message_log == []
+
+
 @pytest.mark.parametrize(
     "schema, payload, error",
     [

--- a/tests/unit/test_kernel_communication_broker.py
+++ b/tests/unit/test_kernel_communication_broker.py
@@ -113,3 +113,57 @@ def test_broker_converts_malformed_schema_constraints_to_rejection(
     with pytest.raises(BrokerValidationError, match=error):
         boundary.publish(payload, "action", "1.0.0", "planner")
     assert boundary.message_log == []
+
+
+@pytest.mark.parametrize(
+    "schema, payload, error",
+    [
+        (
+            {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"value": {"type": "string", "pattern": "["}},
+                    },
+                    {
+                        "type": "object",
+                        "properties": {"value": {"type": "string", "const": "ok"}},
+                    },
+                ]
+            },
+            {"value": "ok"},
+            "pattern",
+        ),
+        (
+            {
+                "not": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": "["}},
+                },
+            },
+            {"value": "ok"},
+            "pattern",
+        ),
+        (
+            {
+                "if": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": "["}},
+                },
+                "then": {"type": "object"},
+            },
+            {"value": "ok"},
+            "pattern",
+        ),
+    ],
+)
+def test_broker_rejects_malformed_combinator_schema_without_partial_log(
+    tmp_path: Path, schema: dict, payload: object, error: str
+) -> None:
+    registry = VersionRegistry(tmp_path / "versions.json")
+    registry.register_schema("action", "1.0.0", schema)
+    boundary = CommunicationBroker(registry)
+
+    with pytest.raises(BrokerValidationError, match=error):
+        boundary.publish(payload, "action", "1.0.0", "planner")
+    assert boundary.message_log == []

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -39,6 +39,30 @@ def test_runtime_validation_normalizes_malformed_constraints(schema: dict) -> No
         validate_schema_instance(value, schema)
 
 
+def test_runtime_validation_normalizes_oversized_regex_repetition() -> None:
+    with pytest.raises(SchemaValidationError, match="pattern"):
+        validate_schema_instance("a", {"type": "string", "pattern": "a{999999999999999999999}"})
+
+
+def test_runtime_validation_supports_finite_recursive_instances() -> None:
+    references = {
+        "node": {
+            "type": "object",
+            "properties": {"next": {"$ref": "node"}},
+            "additionalProperties": False,
+        }
+    }
+
+    validate_schema_instance({"next": {"next": {}}}, {"$ref": "node"}, references=references)
+
+
+def test_runtime_validation_rejects_reference_cycles_that_do_not_advance_the_instance() -> None:
+    references = {"first": {"$ref": "second"}, "second": {"$ref": "first"}}
+
+    with pytest.raises(SchemaValidationError, match="reference cycle"):
+        validate_schema_instance({}, {"$ref": "first"}, references=references)
+
+
 @pytest.mark.parametrize(
     "schema, value, error",
     [

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -39,6 +39,51 @@ def test_runtime_validation_normalizes_malformed_constraints(schema: dict) -> No
         validate_schema_instance(value, schema)
 
 
+@pytest.mark.parametrize(
+    "schema, value, error",
+    [
+        (
+            {
+                "anyOf": [
+                    {"type": "string", "pattern": "["},
+                    {"type": "string", "const": "ok"},
+                ]
+            },
+            "ok",
+            "pattern",
+        ),
+        (
+            {
+                "anyOf": [
+                    {"type": "number", "minimum": "bad"},
+                    {"type": "string", "const": "ok"},
+                ]
+            },
+            "ok",
+            "minimum",
+        ),
+        (
+            {"not": {"type": "string", "pattern": "["}},
+            "ok",
+            "pattern",
+        ),
+        (
+            {
+                "if": {"type": "string", "pattern": "["},
+                "then": {"type": "string"},
+            },
+            "ok",
+            "pattern",
+        ),
+    ],
+)
+def test_runtime_validation_does_not_hide_malformed_combinator_branches(
+    schema: dict, value: object, error: str
+) -> None:
+    with pytest.raises(SchemaValidationError, match=error):
+        validate_schema_instance(value, schema)
+
+
 def test_generated_models_are_valid_and_typed(tmp_path: Path) -> None:
     compiler = SchemaCompiler(ROOT / "interfaces" / "json_schema")
     compiler.load_schemas()

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -10,7 +10,33 @@ from pydantic import BaseModel
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 
-from workbench.kernel.schema_compiler import SchemaCompiler
+from workbench.kernel.schema_compiler import SchemaCompiler, SchemaValidationError, validate_schema_instance
+
+
+def test_runtime_number_validation_handles_large_integers_and_non_finite_floats() -> None:
+    for value in (10**400, 1, 1.5):
+        validate_schema_instance(value, {"type": "number"})
+
+    for value in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(SchemaValidationError, match="finite"):
+            validate_schema_instance(value, {"type": "number"})
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"type": "number", "minimum": "not-a-number"},
+        {"type": "number", "maximum": "not-a-number"},
+        {"type": "number", "maximum": float("inf")},
+        {"type": "string", "pattern": "["},
+        {"type": "string", "pattern": 123},
+        {"type": "array", "minItems": "not-an-integer"},
+    ],
+)
+def test_runtime_validation_normalizes_malformed_constraints(schema: dict) -> None:
+    value = 1 if schema.get("type") == "number" else "value" if schema.get("type") == "string" else []
+    with pytest.raises(SchemaValidationError):
+        validate_schema_instance(value, schema)
 
 
 def test_generated_models_are_valid_and_typed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Prevent `OverflowError` when validating huge integers as JSON Schema `number` values.
- Reject NaN and infinite floats with `SchemaValidationError`.
- Normalize malformed numeric bounds, invalid regular-expression patterns, and invalid `minItems` values.
- Ensure `CommunicationBroker` converts invalid schema instances into `BrokerValidationError` without modifying `message_log`.
- Add regression tests covering huge integers, non-finite floats, malformed bounds, malformed patterns, and broker rejection behavior.

## Validation

- `make test`
- `make contract`
- `make scenario-check`
- `make context-check`
- `make lint`

Closes #223