### PR TITLE
docs(hardware): define unified device runtime boundary

### DIFF
--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -30,6 +30,24 @@ emit the `TaskGraph`. A model response never becomes a joint, velocity, firmware
 5. World Model verifies the expected result. Only it emits `VerificationResult`.
 6. Backend/replay displays facts and evidence; it does not derive a second WorldState or accept control writes.
 
+## Hardware runtime boundary (planned)
+
+The physical path is intentionally a separate, owner-gated layer:
+
+```text
+device / Linux driver -> DeviceAdapter -> bounded DeviceRuntime
+  -> ROS 2 typed boundary -> selected RMW (Fast DDS deployment)
+  -> validation + provenance -> World Model / evidence -> read-only API
+```
+
+CAN, camera/touch, arm and safety adapters share lifecycle, cancellation,
+queue and provenance rules, but remain separate plugins. Fast DDS is a
+deployment transport choice, not a dependency of the adapter contract. E-stop,
+watchdog, safe-enable and direct motion authority remain outside DDS. This
+boundary is proposed in [ADR-0005](../decisions/ADR-0005-hardware-device-runtime.md);
+no Fast DDS or physical hardware implementation is present in this repository
+yet.
+
 ## Operational boundary
 
 - `/healthz` reports process health; `/readyz` checks that the event source is readable.

--- a/docs/decisions/ADR-0005-hardware-device-runtime.md
+++ b/docs/decisions/ADR-0005-hardware-device-runtime.md
@@ -40,6 +40,10 @@ physical device / Linux driver
   envelope. It does not write WorldState, call HTTP, or expose a raw handle.
 - `DeviceRuntime` owns `configure -> activate -> deactivate -> cleanup`,
   cancellation, worker joins, queue limits, backpressure and health counters.
+- A ROS 2 wrapper should use `rclcpp_lifecycle::LifecycleNode` (or the
+  equivalent lifecycle API) so lifecycle transitions create and destroy the
+  adapter workers and DDS entities as one idempotent operation. A failed
+  activation must not leave a half-active publisher or device handle.
 - Each device's mutable state has one writer. Callbacks hand work to a bounded
   queue instead of mutating state concurrently.
 - Bridge, device and touch implementations are plugins of the same port; their

--- a/docs/decisions/ADR-0005-hardware-device-runtime.md
+++ b/docs/decisions/ADR-0005-hardware-device-runtime.md
@@ -53,11 +53,16 @@ physical device / Linux driver
 
 - Use one blocking I/O worker per device or a documented bounded worker pool;
   never create an unbounded thread per message.
-- ROS 2 callback groups and a bounded `MultiThreadedExecutor` may dispatch
-  callbacks, but a DDS callback must not block on hardware I/O.
-- Every queue has a fixed capacity and an explicit policy: reject commands,
-  retry boundedly, or drop old telemetry with a counter. Queue-full, deadline,
-  link-loss, duplicate and late-frame outcomes are observable.
+- ROS 2 callback groups and a fixed-size `MultiThreadedExecutor` may dispatch
+  callbacks, but the executor is not a queue bound by itself. The implementation
+  must record its thread count, callback-group assignment, DDS History/Depth and
+  adapter queue capacity; a DDS callback must not block on hardware I/O.
+- Command/ACK, telemetry and health/provenance use separate bounded data
+  planes. A high-rate camera or touch stream must not consume the queue or
+  executor capacity needed to receive a drive ACK. Each plane has a fixed
+  capacity and explicit policy: reject commands, retry boundedly, or drop old
+  telemetry with counters for depth, drops, deadline misses and oldest age.
+  Queue-full, link-loss, duplicate and late-frame outcomes are observable.
 - Shutdown cancels producers first, drains or rejects according to the port
   contract, joins workers with a deadline, then destroys the DDS participant,
   timers and file descriptors. A timeout is an error, not a silent daemon.
@@ -87,6 +92,14 @@ the existing distinction between dispatch state, device state, verification
 state and evidence. Direct framework exposure is allowed only for validated,
 read-only telemetry and health. Commands continue through trusted Motion,
 MCU and Safety owners; the dashboard and HTTP API never gain a device writer.
+
+The envelope is immutable after ingress and contains source/interface identity,
+per-source sequence, monotonic timestamp, wall-clock observation time, health
+state and evidence references. Clock rollback, sequence reset/restart, duplicate
+and late-frame rules are explicit adapter errors or drop outcomes; they are not
+silently normalized. The external projection uses an allowlist of telemetry and
+health fields. Raw DDS topics, device handles and arbitrary `device_state`
+objects are never serialized directly into HTTP.
 
 Hardware and simulation adapters must emit the same consumer contract. A fake
 transport and ROS loopback can prove ordering, lifecycle and metadata, but they

--- a/docs/decisions/ADR-0005-hardware-device-runtime.md
+++ b/docs/decisions/ADR-0005-hardware-device-runtime.md
@@ -1,0 +1,120 @@
+# ADR-0005: Unified Hardware Device Runtime and DDS Boundary
+
+Status: **proposed** (Issue #230; requires Linux, Integration, Motion and
+Perception owner review)
+
+Date: 2026-08-22
+
+## Context
+
+The repository has several planned hardware inputs and outputs: SocketCAN,
+cameras and touch devices, arm drivers, and a hardware safety bridge. Their
+README files currently describe separate adapters, while the runtime and
+backend only have a simulation/event-store path. There is no shared contract
+for worker lifecycle, queue bounds, cancellation, provenance, or external
+exposure. Fast DDS is not a current project dependency.
+
+The kernel `wbcan` module is a virtual SocketCAN fault harness. It must not be
+turned into a hardware framework, and a DDS path must not become a substitute
+for the independent E-stop, watchdog, or safe-enable circuit.
+
+## Decision
+
+Introduce a transport-neutral `DeviceRuntime` boundary in a later, separately
+reviewed implementation slice:
+
+```text
+physical device / Linux driver
+  -> DeviceAdapter (CAN, camera, touch, arm, safety monitor)
+  -> bounded DeviceRuntime (lifecycle, workers, queues)
+  -> typed ROS 2 topic/service/action boundary
+  -> selected RMW (Fast DDS in the target deployment)
+  -> validation + provenance envelope
+  -> World Model / ActionResult / evidence sink
+  -> read-only external projection
+```
+
+### Adapter and runtime ownership
+
+- A `DeviceAdapter` owns blocking device I/O and translates it to a typed
+  envelope. It does not write WorldState, call HTTP, or expose a raw handle.
+- `DeviceRuntime` owns `configure -> activate -> deactivate -> cleanup`,
+  cancellation, worker joins, queue limits, backpressure and health counters.
+- Each device's mutable state has one writer. Callbacks hand work to a bounded
+  queue instead of mutating state concurrently.
+- Bridge, device and touch implementations are plugins of the same port; their
+  hardware-specific code stays outside the common runtime.
+
+### Threads and queues
+
+- Use one blocking I/O worker per device or a documented bounded worker pool;
+  never create an unbounded thread per message.
+- ROS 2 callback groups and a bounded `MultiThreadedExecutor` may dispatch
+  callbacks, but a DDS callback must not block on hardware I/O.
+- Every queue has a fixed capacity and an explicit policy: reject commands,
+  retry boundedly, or drop old telemetry with a counter. Queue-full, deadline,
+  link-loss, duplicate and late-frame outcomes are observable.
+- Shutdown cancels producers first, drains or rejects according to the port
+  contract, joins workers with a deadline, then destroys the DDS participant,
+  timers and file descriptors. A timeout is an error, not a silent daemon.
+
+### DDS and ROS 2 boundary
+
+The core depends on typed ROS 2 interfaces and an injected transport port, not
+on Fast DDS symbols. Deployment may select Fast DDS with
+`RMW_IMPLEMENTATION=rmw_fastrtps_cpp`; another supported RMW must remain a
+possible test backend. The bridge Task Packet must record domain ID, topic or
+service names, QoS, security/permissions and discovery behavior.
+
+Default QoS policy is explicit and per data class:
+
+| Data class | Default policy | Failure meaning |
+| --- | --- | --- |
+| sensor/touch telemetry | bounded best-effort, keep-last | dropped sample is counted and freshness can expire |
+| command/ACK | reliable, bounded depth, deadline and correlation | no ACK is timeout/fault, never success |
+| health/provenance | reliable, bounded and sequence-checked | missing or regressed record is not ready |
+| E-stop/watchdog | hardware/out-of-band authority | DDS is monitor-only, never the sole stop path |
+
+### Validation and external exposure
+
+The runtime validates frame kind, source/interface identity, sequence, clocks,
+payload and freshness before publishing a consumer-visible record. It preserves
+the existing distinction between dispatch state, device state, verification
+state and evidence. Direct framework exposure is allowed only for validated,
+read-only telemetry and health. Commands continue through trusted Motion,
+MCU and Safety owners; the dashboard and HTTP API never gain a device writer.
+
+Hardware and simulation adapters must emit the same consumer contract. A fake
+transport and ROS loopback can prove ordering, lifecycle and metadata, but they
+cannot prove physical CAN, actuator, touch-safety or hard-real-time behavior.
+
+## Rollout
+
+1. Define the transport-neutral port and envelope without changing frozen
+   public schemas.
+2. Add a fake adapter and one SocketCAN adapter with lifecycle, saturation,
+   cancellation, duplicate/late-frame and callback-failure tests.
+3. Add the ROS 2 bridge and Fast DDS deployment configuration with recorded QoS
+   and security settings.
+4. Add camera/touch and arm plugins independently; do not combine their
+   bring-up or safety evidence with the CAN PR.
+5. Feed only validated records to the existing event/evidence path and expose
+   them through the existing read-only projection.
+
+## Alternatives rejected
+
+- **Device directly to HTTP.** Bypasses validation, provenance and the
+  read-only boundary.
+- **Fast DDS types in every adapter.** Couples hardware code to one middleware
+  and makes deterministic fake testing harder.
+- **One global unbounded thread/queue.** Hides backpressure and lets a noisy
+  sensor starve command or safety diagnostics.
+- **DDS as the safety channel.** Discovery, scheduling and network failures do
+  not replace the hardware E-stop/watchdog path.
+
+## Open decisions
+
+The implementation PR must settle the concrete ROS 2 message package, DDS
+domain/security profile, executor sizing, queue capacities and physical device
+permissions with the named owners. Until then this ADR is a design proposal,
+not a claim that Fast DDS or physical hardware is implemented.

--- a/docs/task_packets/issue-230-hardware-device-runtime.json
+++ b/docs/task_packets/issue-230-hardware-device-runtime.json
@@ -1,0 +1,49 @@
+{
+  "issue": 230,
+  "human_owner": "TH3478",
+  "objective": "Document a transport-neutral, bounded hardware DeviceRuntime boundary with ROS 2 and Fast DDS deployment guidance without claiming physical implementation.",
+  "allowed_paths": [
+    "docs/decisions/ADR-0005-hardware-device-runtime.md",
+    "docs/architecture/system.md",
+    "docs/task_packets/issue-230-hardware-device-runtime.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/**",
+    "libs/hardware/**",
+    "services/**"
+  ],
+  "acceptance": [
+    "the ADR describes adapter, runtime, ROS 2, RMW/Fast DDS, validation and read-only exposure boundaries",
+    "the ADR defines bounded worker and queue lifecycle, cancellation, backpressure and shutdown semantics",
+    "the ADR keeps E-stop, watchdog, safe-enable and direct motion authority outside DDS",
+    "the ADR distinguishes simulation or loopback evidence from physical and hard-real-time evidence",
+    "the system architecture names the proposed hardware runtime as planned rather than implemented",
+    "no public schema, firmware, robot-control, hardware adapter or service implementation changes are made"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-230-hardware-device-runtime.json --base origin/main",
+    "make docs",
+    "git diff --check origin/main...HEAD"
+  ],
+  "evidence": [
+    "validated Task Packet output",
+    "strict MkDocs build output",
+    "clean whitespace diff",
+    "owner review of ADR open decisions and protected boundaries"
+  ],
+  "stop_conditions": [
+    "a public schema or ROS interface change is required before the design is reviewed",
+    "Fast DDS is treated as the only transport or safety channel",
+    "an unbounded worker, queue or callback is proposed",
+    "physical or hard-real-time evidence would be inferred from documentation or loopback"
+  ]
+}


### PR DESCRIPTION
Refs #230.

## Summary

- add proposed ADR-0005 for a transport-neutral hardware DeviceRuntime;
- define adapter/plugin, bounded worker/queue, lifecycle, cancellation, provenance and read-only exposure boundaries;
- document ROS 2 typed interfaces with Fast DDS as a deployment-selected RMW, not a hard-coded safety dependency;
- state explicit QoS classes and keep E-stop/watchdog/safe-enable outside DDS;
- update the system architecture diagram and add a validating Task Packet.

This is documentation/design only. It does not add Fast DDS, ROS 2 nodes, hardware drivers, firmware, schemas, or physical claims.

## Verification

- `python tools/scripts/check_task_packet.py docs/task_packets/issue-230-hardware-device-runtime.json --base origin/main` passed;
- `python -m mkdocs build --strict` passed (existing unlisted-page warnings only);
- `git diff --check origin/main...HEAD` passed.

Please review the open decisions with Linux/Integration/Motion/Perception owners before implementing the first runtime slice.