### PR TITLE
test(linux): add structured wbcan driver test evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,17 +101,33 @@ jobs:
 
       - name: Run the fault suite
         id: fault_suite
-        run: sudo ./kernel/wbcan/test_wbcan.sh wbcan0
+        env:
+          WBCAN_TEST_REPORT: ${{ runner.temp }}/wbcan-test-report.tsv
+        run: sudo env WBCAN_TEST_REPORT="$WBCAN_TEST_REPORT" ./kernel/wbcan/test_wbcan.sh wbcan0
+
+      - name: Validate structured driver test report
+        id: fault_report
+        if: always()
+        run: python3 kernel/wbcan/validate_test_report.py "$RUNNER_TEMP/wbcan-test-report.tsv"
+
+      - name: Upload driver test report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: wbcan-driver-test-report
+          path: ${{ runner.temp }}/wbcan-test-report.tsv
+          if-no-files-found: error
 
       - name: Report runtime fault result
         if: always()
         env:
           MODULE_LOAD_OUTCOME: ${{ steps.module_load.outcome }}
           FAULT_SUITE_OUTCOME: ${{ steps.fault_suite.outcome }}
+          REPORT_VALIDATION_OUTCOME: ${{ steps.fault_report.outcome }}
         run: |
-          case "$FAULT_SUITE_OUTCOME" in
-            success) status=PASS ;;
-            failure) status=FAIL ;;
+          case "$FAULT_SUITE_OUTCOME:$REPORT_VALIDATION_OUTCOME" in
+            success:success) status=PASS ;;
+            *:failure|failure:*) status=FAIL ;;
             *) status=NOT_EXECUTED ;;
           esac
           {
@@ -123,6 +139,7 @@ jobs:
             echo "| --- | --- |"
             echo "| Module insertion | $MODULE_LOAD_OUTCOME |"
             echo "| Fault suite | $FAULT_SUITE_OUTCOME |"
+            echo "| Structured report | $REPORT_VALIDATION_OUTCOME |"
             if [ "$MODULE_LOAD_OUTCOME" = success ] && [ "$FAULT_SUITE_OUTCOME" = success ]; then
               echo "| Fault-plane readiness | PASS |"
             elif [ "$MODULE_LOAD_OUTCOME" = skipped ] || [ "$FAULT_SUITE_OUTCOME" = skipped ]; then

--- a/docs/task_packets/linux-driver-tests.json
+++ b/docs/task_packets/linux-driver-tests.json
@@ -1,0 +1,49 @@
+{
+  "issue": "LINUX9",
+  "human_owner": "Quchaosheng",
+  "objective": "Make the wbcan driver test suite produce validated, machine-readable evidence that CI archives without treating skipped or partial execution as a pass.",
+  "allowed_paths": [
+    "kernel/wbcan/test_wbcan.sh",
+    "kernel/wbcan/validate_test_report.py",
+    ".github/workflows/ci.yml",
+    "tests/unit/test_linux_driver_tests.py",
+    "tests/unit/test_release_workflow.py",
+    "docs/task_packets/linux-driver-tests.json"
+  ],
+  "read_only_paths": [
+    "firmware/**",
+    "interfaces/**",
+    "robot/control/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "interfaces/**",
+    "robot/control/**"
+  ],
+  "acceptance": [
+    "every wbcan assertion is recorded with a unique test id, expected value and actual value",
+    "the report validator rejects missing, malformed, duplicate or failed rows and enforces a minimum check count",
+    "CI validates and uploads the report even when the privileged suite fails",
+    "CI cannot report a passing structured suite when the report is missing or incomplete",
+    "the report remains software-driver evidence and does not claim physical throughput, latency or jitter"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_linux_driver_tests.py tests/unit/test_release_workflow.py -v",
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "sudo make -C kernel/wbcan test",
+    "git diff --check"
+  ],
+  "evidence": [
+    "unit test output for report validation and CI wiring",
+    "kernel module build and checkpatch output",
+    "privileged wbcan suite output",
+    "uploaded wbcan-driver-test-report artifact"
+  ],
+  "stop_conditions": [
+    "the hosted runner cannot execute privileged kernel-module tests",
+    "a physical CAN controller or hardware performance measurement is required",
+    "the change would require firmware, interface or robot-control writes"
+  ]
+}

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -15,7 +15,6 @@ DBG="/sys/kernel/debug/wbcan/${IFACE}"
 FAIL_ERROR_SKB="/sys/module/wbcan/parameters/fail_error_skb"
 PASS=0
 FAIL=0
-CHECK_NO=0
 REPORT_FILE="${WBCAN_TEST_REPORT:-}"
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
@@ -31,10 +30,22 @@ fi
 report_check() {
 	local result="$1" name="$2" want="$3" got="$4" slug
 	[ -n "$REPORT_FILE" ] || return 0
-	CHECK_NO=$((CHECK_NO + 1))
 	slug=$(printf '%s' "$name" | tr '[:upper:] ' '[:lower:]_' | tr -cd '[:alnum:]_-')
-	printf '%s\twbcan-%03d-%s\t%s\t%s\t%s\n' \
-		"$result" "$CHECK_NO" "$slug" "$name" "$want" "$got" >> "$REPORT_FILE"
+	printf '%s\twbcan-%s\t%s\t%s\t%s\n' \
+		"$result" "$slug" "$name" "$want" "$got" >> "$REPORT_FILE"
+}
+
+check() {
+	local name="$1" want="$2" got="$3"
+	if [ "$want" = "$got" ]; then
+		green "PASS  $name"
+		PASS=$((PASS + 1))
+		report_check PASS "$name" "$want" "$got"
+	else
+		red   "FAIL  $name: want '$want' got '$got'"
+		FAIL=$((FAIL + 1))
+		report_check FAIL "$name" "$want" "$got"
+	fi
 }
 
 need() {
@@ -55,19 +66,17 @@ trap restore_error_skb_allocation EXIT
 [ -d "$DBG" ] || { red "no debugfs dir at $DBG - is the module loaded?"; exit 1; }
 ip link show "$IFACE" >/dev/null 2>&1 || { red "no interface $IFACE"; exit 1; }
 if [ -w "$DBG/inject" ] && [ -r "$DBG/status" ]; then
-	green "PASS  fault-plane readiness: PASS"
-	PASS=$((PASS + 1))
+	fault_plane_readiness=PASS
 else
-	red "FAIL  fault-plane readiness: FAIL"
-	FAIL=$((FAIL + 1))
+	fault_plane_readiness=FAIL
 fi
+check "fault-plane readiness" "PASS" "$fault_plane_readiness"
 if [ -w "$FAIL_ERROR_SKB" ] && [ -r "$FAIL_ERROR_SKB" ]; then
-	green "PASS  error-SKB failure injection readiness: PASS"
-	PASS=$((PASS + 1))
+	error_skb_readiness=PASS
 else
-	red "FAIL  error-SKB failure injection readiness: FAIL"
-	FAIL=$((FAIL + 1))
+	error_skb_readiness=FAIL
 fi
+check "error-SKB failure injection readiness" "PASS" "$error_skb_readiness"
 
 arm()   { echo "$*" > "$DBG/inject"; }
 clear_fault() { arm "none 0"; }
@@ -112,19 +121,6 @@ capture() {
 	candump -L -T "$ms" -n 100 "$IFACE,0:0,#FFFFFFFF" 2>/dev/null
 }
 
-check() {
-	local name="$1" want="$2" got="$3"
-	if [ "$want" = "$got" ]; then
-		green "PASS  $name"
-		PASS=$((PASS + 1))
-		report_check PASS "$name" "$want" "$got"
-	else
-		red   "FAIL  $name: want '$want' got '$got'"
-		FAIL=$((FAIL + 1))
-		report_check FAIL "$name" "$want" "$got"
-	fi
-}
-
 # wbcan is a module-load singleton, not an RTNL-created link kind.
 if ip link add dev wbcan-test type wbcan 2>/dev/null; then
 	check "RTNL creation is rejected for singleton wbcan" "rejected" "accepted"
@@ -133,12 +129,11 @@ else
 	check "RTNL creation is rejected for singleton wbcan" "rejected" "rejected"
 fi
 if ip link show wbcan-test >/dev/null 2>&1; then
-	red "FAIL  RTNL probe left an unexpected wbcan-test device"
-	FAIL=$((FAIL + 1))
+	singleton_probe=present
 else
-	green "PASS  RTNL probe leaves singleton lifecycle unchanged"
-	PASS=$((PASS + 1))
+	singleton_probe=absent
 fi
+check "RTNL probe leaves singleton lifecycle unchanged" "absent" "$singleton_probe"
 
 restart_if_bus_off() {
 	if [ "$(stat state)" = "bus-off" ]; then

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -15,9 +15,27 @@ DBG="/sys/kernel/debug/wbcan/${IFACE}"
 FAIL_ERROR_SKB="/sys/module/wbcan/parameters/fail_error_skb"
 PASS=0
 FAIL=0
+CHECK_NO=0
+REPORT_FILE="${WBCAN_TEST_REPORT:-}"
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+if [ -n "$REPORT_FILE" ]; then
+	printf 'result\ttest_id\tname\texpected\tactual\n' > "$REPORT_FILE" || {
+		red "cannot create test report at $REPORT_FILE"
+		exit 1
+	}
+fi
+
+report_check() {
+	local result="$1" name="$2" want="$3" got="$4" slug
+	[ -n "$REPORT_FILE" ] || return 0
+	CHECK_NO=$((CHECK_NO + 1))
+	slug=$(printf '%s' "$name" | tr '[:upper:] ' '[:lower:]_' | tr -cd '[:alnum:]_-')
+	printf '%s\twbcan-%03d-%s\t%s\t%s\t%s\n' \
+		"$result" "$CHECK_NO" "$slug" "$name" "$want" "$got" >> "$REPORT_FILE"
+}
 
 need() {
 	command -v "$1" >/dev/null 2>&1 || {
@@ -99,9 +117,11 @@ check() {
 	if [ "$want" = "$got" ]; then
 		green "PASS  $name"
 		PASS=$((PASS + 1))
+		report_check PASS "$name" "$want" "$got"
 	else
 		red   "FAIL  $name: want '$want' got '$got'"
 		FAIL=$((FAIL + 1))
+		report_check FAIL "$name" "$want" "$got"
 	fi
 }
 

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -32,7 +32,10 @@ report_check() {
 	[ -n "$REPORT_FILE" ] || return 0
 	slug=$(printf '%s' "$name" | tr '[:upper:] ' '[:lower:]_' | tr -cd '[:alnum:]_-')
 	printf '%s\twbcan-%s\t%s\t%s\t%s\n' \
-		"$result" "$slug" "$name" "$want" "$got" >> "$REPORT_FILE"
+		"$result" "$slug" "$name" "$want" "$got" >> "$REPORT_FILE" || {
+		red "cannot append to test report at $REPORT_FILE"
+		exit 1
+	}
 }
 
 check() {

--- a/kernel/wbcan/validate_test_report.py
+++ b/kernel/wbcan/validate_test_report.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Validate the machine-readable report emitted by test_wbcan.sh."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+EXPECTED_FIELDS = ("result", "test_id", "name", "expected", "actual")
+
+
+class ReportError(ValueError):
+    """A report is malformed or contains a failed assertion."""
+
+
+def validate_report(path: Path, minimum_checks: int) -> int:
+    if not path.is_file():
+        raise ReportError(f"report does not exist: {path}")
+
+    with path.open(newline="", encoding="utf-8") as stream:
+        reader = csv.DictReader(stream, delimiter="\t")
+        if tuple(reader.fieldnames or ()) != EXPECTED_FIELDS:
+            raise ReportError(
+                f"header must be tab-separated {EXPECTED_FIELDS!r}; got {reader.fieldnames!r}"
+            )
+
+        rows = list(reader)
+
+    if len(rows) < minimum_checks:
+        raise ReportError(f"expected at least {minimum_checks} checks; got {len(rows)}")
+
+    seen: set[str] = set()
+    failures: list[str] = []
+    for line_no, row in enumerate(rows, start=2):
+        if None in row:
+            raise ReportError(f"line {line_no}: unexpected extra report fields")
+        if any(value is None or value == "" for value in row.values()):
+            raise ReportError(f"line {line_no}: all report fields are required")
+        test_id = row["test_id"]
+        if test_id in seen:
+            raise ReportError(f"line {line_no}: duplicate test_id {test_id!r}")
+        seen.add(test_id)
+        if row["result"] not in {"PASS", "FAIL"}:
+            raise ReportError(f"line {line_no}: invalid result {row['result']!r}")
+        if row["result"] == "FAIL":
+            failures.append(f"{test_id} ({row['name']})")
+
+    if failures:
+        raise ReportError("failed checks: " + ", ".join(failures))
+
+    return len(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--min-checks", type=int, default=60)
+    args = parser.parse_args()
+    if args.min_checks < 1:
+        parser.error("--min-checks must be positive")
+
+    try:
+        count = validate_report(args.report, args.min_checks)
+    except ReportError as exc:
+        parser.error(str(exc))
+    print(f"wbcan test report valid: {count} checks, all PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kernel/wbcan/validate_test_report.py
+++ b/kernel/wbcan/validate_test_report.py
@@ -5,25 +5,44 @@ from __future__ import annotations
 
 import argparse
 import csv
+import re
 from pathlib import Path
 
 EXPECTED_FIELDS = ("result", "test_id", "name", "expected", "actual")
+SUITE_PATH = Path(__file__).with_name("test_wbcan.sh")
 
 
 class ReportError(ValueError):
     """A report is malformed or contains a failed assertion."""
 
 
-def validate_report(path: Path, minimum_checks: int) -> int:
+def _test_id(name: str) -> str:
+    slug = "".join(
+        character for character in name.lower().replace(" ", "_") if character.isalnum() or character in "_-"
+    )
+    return f"wbcan-{slug}"
+
+
+def expected_checks(path: Path = SUITE_PATH) -> dict[str, str]:
+    names = re.findall(r'^\s*check "([^"]+)"', path.read_text(encoding="utf-8"), flags=re.MULTILINE)
+    checks = {_test_id(name): name for name in names}
+    if len(checks) != len(set(names)):
+        raise ReportError("wbcan suite contains duplicate or colliding check identities")
+    return checks
+
+
+def validate_report(
+    path: Path,
+    minimum_checks: int,
+    required_test_ids: set[str] | frozenset[str] | None = None,
+) -> int:
     if not path.is_file():
         raise ReportError(f"report does not exist: {path}")
 
     with path.open(newline="", encoding="utf-8") as stream:
         reader = csv.DictReader(stream, delimiter="\t")
         if tuple(reader.fieldnames or ()) != EXPECTED_FIELDS:
-            raise ReportError(
-                f"header must be tab-separated {EXPECTED_FIELDS!r}; got {reader.fieldnames!r}"
-            )
+            raise ReportError(f"header must be tab-separated {EXPECTED_FIELDS!r}; got {reader.fieldnames!r}")
 
         rows = list(reader)
 
@@ -43,11 +62,21 @@ def validate_report(path: Path, minimum_checks: int) -> int:
         seen.add(test_id)
         if row["result"] not in {"PASS", "FAIL"}:
             raise ReportError(f"line {line_no}: invalid result {row['result']!r}")
-        if row["result"] == "FAIL":
+        if test_id != _test_id(row["name"]):
+            raise ReportError(f"line {line_no}: test_id does not match check name")
+        if row["result"] == "PASS" and row["expected"] != row["actual"]:
+            failures.append(f"{test_id} ({row['name']}: PASS contradicts expected/actual)")
+        elif row["result"] == "FAIL":
             failures.append(f"{test_id} ({row['name']})")
 
     if failures:
         raise ReportError("failed checks: " + ", ".join(failures))
+
+    required = set(expected_checks()) if required_test_ids is None else set(required_test_ids)
+    missing = sorted(required - seen)
+    unexpected = sorted(seen - required)
+    if missing or unexpected:
+        raise ReportError(f"test_id set mismatch: missing={missing}; unexpected={unexpected}")
 
     return len(rows)
 

--- a/tests/unit/test_linux_driver_tests.py
+++ b/tests/unit/test_linux_driver_tests.py
@@ -5,6 +5,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "kernel" / "wbcan" / "validate_test_report.py"
+TEST_SCRIPT = ROOT / "kernel" / "wbcan" / "test_wbcan.sh"
 SPEC = importlib.util.spec_from_file_location("validate_wbcan_report", MODULE_PATH)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -74,3 +75,10 @@ def test_report_rejects_missing_or_unexpected_test_ids(tmp_path: Path) -> None:
             minimum_checks=1,
             required_test_ids={"wbcan-first", "wbcan-second"},
         )
+
+
+def test_fault_suite_fails_if_report_append_fails() -> None:
+    script = TEST_SCRIPT.read_text(encoding="utf-8")
+
+    assert '>> "$REPORT_FILE" || {' in script
+    assert "cannot append to test report" in script

--- a/tests/unit/test_linux_driver_tests.py
+++ b/tests/unit/test_linux_driver_tests.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "kernel" / "wbcan" / "validate_test_report.py"
 SPEC = importlib.util.spec_from_file_location("validate_wbcan_report", MODULE_PATH)
@@ -21,15 +20,10 @@ def _write_report(path: Path, rows: list[str]) -> None:
 
 def test_report_accepts_unique_passing_checks(tmp_path: Path) -> None:
     report = tmp_path / "report.tsv"
-    _write_report(
-        report,
-        [
-            "PASS\twbcan-001\tbaseline delivers frame\t1\t1\n",
-            "PASS\twbcan-002\tbus-off recovers\terror-active\terror-active\n",
-        ],
-    )
+    checks = MODULE.expected_checks()
+    _write_report(report, [f"PASS\t{test_id}\t{name}\t1\t1\n" for test_id, name in checks.items()])
 
-    assert MODULE.validate_report(report, minimum_checks=2) == 2
+    assert MODULE.validate_report(report, minimum_checks=2) == len(checks)
 
 
 def test_report_rejects_duplicate_ids(tmp_path: Path) -> None:
@@ -37,26 +31,46 @@ def test_report_rejects_duplicate_ids(tmp_path: Path) -> None:
     _write_report(
         report,
         [
-            "PASS\twbcan-001\tfirst\t1\t1\n",
-            "PASS\twbcan-001\tsecond\t1\t1\n",
+            "PASS\twbcan-first\tfirst\t1\t1\n",
+            "PASS\twbcan-first\tfirst\t1\t1\n",
         ],
     )
 
     with pytest.raises(MODULE.ReportError, match="duplicate test_id"):
-        MODULE.validate_report(report, minimum_checks=1)
+        MODULE.validate_report(report, minimum_checks=1, required_test_ids={"wbcan-first"})
 
 
 def test_report_rejects_failed_checks(tmp_path: Path) -> None:
     report = tmp_path / "report.tsv"
-    _write_report(report, ["FAIL\twbcan-001\tbroken\t1\t0\n"])
+    _write_report(report, ["FAIL\twbcan-broken\tbroken\t1\t0\n"])
 
     with pytest.raises(MODULE.ReportError, match="failed checks"):
-        MODULE.validate_report(report, minimum_checks=1)
+        MODULE.validate_report(report, minimum_checks=1, required_test_ids={"wbcan-broken"})
 
 
 def test_report_requires_the_expected_check_count(tmp_path: Path) -> None:
     report = tmp_path / "report.tsv"
-    _write_report(report, ["PASS\twbcan-001\tonly check\t1\t1\n"])
+    _write_report(report, ["PASS\twbcan-only_check\tonly check\t1\t1\n"])
 
     with pytest.raises(MODULE.ReportError, match="at least 2 checks"):
-        MODULE.validate_report(report, minimum_checks=2)
+        MODULE.validate_report(report, minimum_checks=2, required_test_ids={"wbcan-only_check"})
+
+
+def test_report_rejects_pass_when_expected_and_actual_differ(tmp_path: Path) -> None:
+    report = tmp_path / "report.tsv"
+    _write_report(report, ["PASS\twbcan-broken\tbroken\t1\t0\n"])
+
+    with pytest.raises(MODULE.ReportError, match="contradicts"):
+        MODULE.validate_report(report, minimum_checks=1, required_test_ids={"wbcan-broken"})
+
+
+def test_report_rejects_missing_or_unexpected_test_ids(tmp_path: Path) -> None:
+    report = tmp_path / "report.tsv"
+    _write_report(report, ["PASS\twbcan-first\tfirst\t1\t1\n"])
+
+    with pytest.raises(MODULE.ReportError, match=r"missing=.*wbcan-second"):
+        MODULE.validate_report(
+            report,
+            minimum_checks=1,
+            required_test_ids={"wbcan-first", "wbcan-second"},
+        )

--- a/tests/unit/test_linux_driver_tests.py
+++ b/tests/unit/test_linux_driver_tests.py
@@ -1,0 +1,62 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "kernel" / "wbcan" / "validate_test_report.py"
+SPEC = importlib.util.spec_from_file_location("validate_wbcan_report", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+HEADER = "result\ttest_id\tname\texpected\tactual\n"
+
+
+def _write_report(path: Path, rows: list[str]) -> None:
+    path.write_text(HEADER + "".join(rows), encoding="utf-8")
+
+
+def test_report_accepts_unique_passing_checks(tmp_path: Path) -> None:
+    report = tmp_path / "report.tsv"
+    _write_report(
+        report,
+        [
+            "PASS\twbcan-001\tbaseline delivers frame\t1\t1\n",
+            "PASS\twbcan-002\tbus-off recovers\terror-active\terror-active\n",
+        ],
+    )
+
+    assert MODULE.validate_report(report, minimum_checks=2) == 2
+
+
+def test_report_rejects_duplicate_ids(tmp_path: Path) -> None:
+    report = tmp_path / "report.tsv"
+    _write_report(
+        report,
+        [
+            "PASS\twbcan-001\tfirst\t1\t1\n",
+            "PASS\twbcan-001\tsecond\t1\t1\n",
+        ],
+    )
+
+    with pytest.raises(MODULE.ReportError, match="duplicate test_id"):
+        MODULE.validate_report(report, minimum_checks=1)
+
+
+def test_report_rejects_failed_checks(tmp_path: Path) -> None:
+    report = tmp_path / "report.tsv"
+    _write_report(report, ["FAIL\twbcan-001\tbroken\t1\t0\n"])
+
+    with pytest.raises(MODULE.ReportError, match="failed checks"):
+        MODULE.validate_report(report, minimum_checks=1)
+
+
+def test_report_requires_the_expected_check_count(tmp_path: Path) -> None:
+    report = tmp_path / "report.tsv"
+    _write_report(report, ["PASS\twbcan-001\tonly check\t1\t1\n"])
+
+    with pytest.raises(MODULE.ReportError, match="at least 2 checks"):
+        MODULE.validate_report(report, minimum_checks=2)

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -63,7 +63,7 @@ def test_kernel_fault_suite_publishes_and_validates_structured_report() -> None:
     assert "wbcan-driver-test-report" in artifact_step
     assert "if-no-files-found: error" in artifact_step
     assert "REPORT_VALIDATION_OUTCOME" in kernel_job
-    assert 'success:success) status=PASS' in kernel_job
+    assert "success:success) status=PASS" in kernel_job
 
 
 def test_kernel_module_builds_against_lts_and_runner_headers() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -63,7 +63,8 @@ def test_kernel_fault_suite_publishes_and_validates_structured_report() -> None:
     assert "wbcan-driver-test-report" in artifact_step
     assert "if-no-files-found: error" in artifact_step
     assert "REPORT_VALIDATION_OUTCOME" in kernel_job
-    assert "success:success) status=PASS" in kernel_job
+    assert "success:success)" in kernel_job
+    assert "status=PASS" in kernel_job
 
 
 def test_kernel_module_builds_against_lts_and_runner_headers() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -47,6 +47,25 @@ def test_kernel_fault_suite_cannot_be_skipped_as_green() -> None:
     assert "GITHUB_STEP_SUMMARY" in summary_step
 
 
+def test_kernel_fault_suite_publishes_and_validates_structured_report() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    kernel_job = workflow.split("  kernel-module:", maxsplit=1)[1].split("\n  mcu-qemu:", maxsplit=1)[0]
+    fault_step = _step_block(kernel_job, "name: Run the fault suite")
+    validate_step = _step_block(kernel_job, "name: Validate structured driver test report")
+    artifact_step = _step_block(kernel_job, "name: Upload driver test report")
+
+    assert "WBCAN_TEST_REPORT" in fault_step
+    assert "sudo env WBCAN_TEST_REPORT" in fault_step
+    assert "kernel/wbcan/validate_test_report.py" in validate_step
+    assert "id: fault_report" in validate_step
+    assert "if: always()" in validate_step
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in artifact_step
+    assert "wbcan-driver-test-report" in artifact_step
+    assert "if-no-files-found: error" in artifact_step
+    assert "REPORT_VALIDATION_OUTCOME" in kernel_job
+    assert 'success:success) status=PASS' in kernel_job
+
+
 def test_kernel_module_builds_against_lts_and_runner_headers() -> None:
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     kernel_job = workflow.split("  kernel-module:", maxsplit=1)[1].split("\n  mcu-qemu:", maxsplit=1)[0]


### PR DESCRIPTION
## Summary

- Add machine-readable wbcan test reports
- Add fail-closed report validation
- Upload the driver test report from CI
- Add unit and workflow regression coverage
- Add the LINUX9 Task Packet

## Validation

- 9 targeted Python tests passed
- Bash syntax check passed
- Task Packet JSON syntax passed
- CI YAML parsing passed
- git diff --check passed

Kernel module build, checkpatch and privileged wbcan execution are delegated to the Ubuntu GitHub Actions runner.