### PR TITLE
fix(kernel): preserve wbcan software TX timestamps

### DIFF
--- a/docs/task_packets/linux-wbcan-software-tx-timestamps.json
+++ b/docs/task_packets/linux-wbcan-software-tx-timestamps.json
@@ -1,0 +1,52 @@
+{
+  "issue": 184,
+  "human_owner": "TH3478",
+  "objective": "Preserve standard SocketCAN software TX timestamp semantics for every frame accepted by wbcan without timestamping rejected or retried SKBs.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/test_wbcan.sh",
+    "kernel/wbcan/test_tx_timestamp.py",
+    "docs/task_packets/linux-wbcan-software-tx-timestamps.json"
+  ],
+  "read_only_paths": [
+    ".github/workflows/ci.yml",
+    "AGENTS.md",
+    "docs/task_packets/linux-wbcan-state-serialization.json"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**"
+  ],
+  "acceptance": [
+    "every normal, dropped, or injected-error SKB accepted by wbcan requests exactly one standard software TX timestamp",
+    "NETDEV_TX_BUSY and invalid frames produce no timestamp before a successful retry or acceptance",
+    "loopback, own-message, drop, error, counter, ownership, and fault semantics remain unchanged",
+    "ethtool reports software TX and RX timestamping with no PHC or hardware timestamp capability",
+    "a bounded CAN_RAW SO_TIMESTAMPING and MSG_ERRQUEUE probe compares wbcan with vcan",
+    "the timestamp probe closes every socket and removes its temporary vcan interface",
+    "all evidence is labelled as host software enqueue timing rather than wire, MCU, actuator, or hard-real-time timing"
+  ],
+  "commands": [
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test",
+    "python tools/scripts/check_task_packet.py docs/task_packets/linux-wbcan-software-tx-timestamps.json --base origin/fix/153-wbcan-state-serialization",
+    "git diff --check origin/fix/153-wbcan-state-serialization...HEAD"
+  ],
+  "evidence": [
+    "kernel module build and checkpatch output",
+    "vcan comparison and wbcan MSG_ERRQUEUE timestamp counts",
+    "software-only ethtool capability assertion",
+    "normal, loopback-disabled, own-message, drop, injected-error, TX-full retry, and invalid-frame results",
+    "existing privileged wbcan fault and concurrency suite output",
+    "clean readable marker-delimited kernel diagnostics"
+  ],
+  "stop_conditions": [
+    "the #153 state-serialization base changes incompatibly",
+    "the target kernel lacks standard skb_tx_timestamp or ethtool timestamp helpers",
+    "firmware, interfaces, hardware timestamp emulation, or physical CAN claims are required",
+    "the privileged runner cannot load wbcan, create vcan, or read MSG_ERRQUEUE"
+  ]
+}

--- a/kernel/wbcan/test_tx_timestamp.py
+++ b/kernel/wbcan/test_tx_timestamp.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Privileged SocketCAN software TX timestamp regression probe."""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import select
+import socket
+import struct
+import subprocess
+import sys
+import time
+
+
+SO_TIMESTAMPING = 37
+SOF_TIMESTAMPING_TX_HARDWARE = 1 << 0
+SOF_TIMESTAMPING_TX_SOFTWARE = 1 << 1
+SOF_TIMESTAMPING_RX_HARDWARE = 1 << 2
+SOF_TIMESTAMPING_RX_SOFTWARE = 1 << 3
+SOF_TIMESTAMPING_SOFTWARE = 1 << 4
+SOF_TIMESTAMPING_RAW_HARDWARE = 1 << 6
+SOF_TIMESTAMPING_OPT_ID = 1 << 7
+SOF_TIMESTAMPING_OPT_TSONLY = 1 << 11
+ETHTOOL_GET_TS_INFO = 0x00000041
+SIOCETHTOOL = 0x8946
+IFNAMSIZ = 16
+CAN_FRAME = struct.Struct("=IB3x8s")
+
+
+class EthtoolTsInfo(ctypes.Structure):
+    _fields_ = [
+        ("cmd", ctypes.c_uint32),
+        ("so_timestamping", ctypes.c_uint32),
+        ("phc_index", ctypes.c_int32),
+        ("tx_types", ctypes.c_uint32),
+        ("tx_reserved", ctypes.c_uint32 * 3),
+        ("rx_filters", ctypes.c_uint32),
+        ("rx_reserved", ctypes.c_uint32 * 3),
+    ]
+
+
+class Ifreq(ctypes.Structure):
+    _fields_ = [("name", ctypes.c_char * IFNAMSIZ), ("data", ctypes.c_void_p)]
+
+
+def run(*args: str) -> None:
+    subprocess.run(args, check=True, stdout=subprocess.DEVNULL)
+
+
+def raw_socket(iface: str, *, loopback: bool = True, own_messages: bool = False) -> socket.socket:
+    sock = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+    sock.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_LOOPBACK, int(loopback))
+    sock.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_RECV_OWN_MSGS, int(own_messages))
+    flags = (
+        SOF_TIMESTAMPING_TX_SOFTWARE
+        | SOF_TIMESTAMPING_SOFTWARE
+        | SOF_TIMESTAMPING_OPT_ID
+        | SOF_TIMESTAMPING_OPT_TSONLY
+    )
+    sock.setsockopt(socket.SOL_SOCKET, SO_TIMESTAMPING, flags)
+    sock.bind((iface,))
+    sock.setblocking(False)
+    return sock
+
+
+def collect_timestamps(sock: socket.socket, timeout: float = 0.8) -> int:
+    deadline = time.monotonic() + timeout
+    timestamps = 0
+    while time.monotonic() < deadline:
+        select.select([], [], [sock], min(0.05, deadline - time.monotonic()))
+        try:
+            _, ancillary, _, _ = sock.recvmsg(256, 512, socket.MSG_ERRQUEUE)
+        except BlockingIOError:
+            continue
+        for level, kind, data in ancillary:
+            if level != socket.SOL_SOCKET or kind != SO_TIMESTAMPING:
+                continue
+            if any(data):
+                timestamps += 1
+    return timestamps
+
+
+def send_and_count(
+    iface: str,
+    can_id: int,
+    *,
+    loopback: bool = True,
+    own_messages: bool = False,
+    invalid: bool = False,
+) -> tuple[bool, int]:
+    with raw_socket(iface, loopback=loopback, own_messages=own_messages) as sock:
+        frame = CAN_FRAME.pack(can_id, 1, bytes([can_id & 0xFF]) + bytes(7))
+        accepted = True
+        try:
+            sock.send(frame[:-1] if invalid else frame)
+        except OSError as error:
+            if not invalid or error.errno not in {errno.EINVAL, errno.EMSGSIZE}:
+                raise
+            accepted = False
+        return accepted, collect_timestamps(sock)
+
+
+def timestamp_capabilities(iface: str) -> EthtoolTsInfo:
+    info = EthtoolTsInfo(cmd=ETHTOOL_GET_TS_INFO)
+    request = Ifreq(name=iface.encode("ascii"), data=ctypes.addressof(info))
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        result = ctypes.CDLL(None, use_errno=True).ioctl(
+            sock.fileno(), SIOCETHTOOL, ctypes.byref(request)
+        )
+    if result < 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return info
+
+
+def arm(debugfs: str, fault: str) -> None:
+    with open(os.path.join(debugfs, "inject"), "w", encoding="ascii") as stream:
+        stream.write(f"{fault}\n")
+
+
+def check(name: str, condition: bool) -> bool:
+    print(f"{'PASS' if condition else 'FAIL'}  {name}")
+    return condition
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} IFACE DEBUGFS", file=sys.stderr)
+        return 2
+    iface, debugfs = sys.argv[1:]
+    if os.geteuid() != 0 or not os.path.isdir(debugfs):
+        print("NOT_EXECUTED  privileged wbcan timestamp probe requires root and debugfs")
+        return 77
+
+    vcan = f"wbtstamp{os.getpid() % 100000}"
+    results: list[bool] = []
+    try:
+        run("modprobe", "vcan")
+        run("ip", "link", "add", vcan, "type", "vcan")
+        run("ip", "link", "set", vcan, "up")
+
+        accepted, count = send_and_count(vcan, 0x740)
+        results.append(check("vcan reference emits one software TX timestamp", accepted and count == 1))
+
+        info = timestamp_capabilities(iface)
+        software = (
+            SOF_TIMESTAMPING_TX_SOFTWARE
+            | SOF_TIMESTAMPING_RX_SOFTWARE
+            | SOF_TIMESTAMPING_SOFTWARE
+        )
+        hardware = (
+            SOF_TIMESTAMPING_TX_HARDWARE
+            | SOF_TIMESTAMPING_RX_HARDWARE
+            | SOF_TIMESTAMPING_RAW_HARDWARE
+        )
+        results.append(
+            check(
+                "wbcan advertises software-only timestamp capabilities",
+                info.so_timestamping & software == software
+                and info.so_timestamping & hardware == 0
+                and info.phc_index == -1
+                and info.tx_types == 0
+                and info.rx_filters == 0,
+            )
+        )
+
+        cases = [
+            ("normal loopback", "none 0", {}, 0x741),
+            ("own-message enabled", "none 0", {"own_messages": True}, 0x742),
+            ("loopback disabled", "none 0", {"loopback": False}, 0x743),
+            ("accepted drop-tx", "drop-tx 1", {}, 0x744),
+            ("accepted drop-rx", "drop-rx 1", {}, 0x745),
+            ("accepted arb-lost error", "arb-lost 1", {}, 0x746),
+            ("tx-full successful retry", "tx-full 1", {}, 0x747),
+        ]
+        for name, fault, options, can_id in cases:
+            arm(debugfs, fault)
+            accepted, count = send_and_count(iface, can_id, **options)
+            results.append(check(f"{name} emits exactly one timestamp", accepted and count == 1))
+
+        arm(debugfs, "none 0")
+        accepted, count = send_and_count(iface, 0x748, invalid=True)
+        results.append(check("invalid frame emits no timestamp", not accepted and count == 0))
+    finally:
+        try:
+            arm(debugfs, "none 0")
+        except OSError:
+            pass
+        subprocess.run(
+            ("ip", "link", "del", vcan),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kernel/wbcan/test_tx_timestamp.py
+++ b/kernel/wbcan/test_tx_timestamp.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import time
 
-
 SO_TIMESTAMPING = 37
 SOF_TIMESTAMPING_TX_HARDWARE = 1 << 0
 SOF_TIMESTAMPING_TX_SOFTWARE = 1 << 1

--- a/kernel/wbcan/test_tx_timestamp.py
+++ b/kernel/wbcan/test_tx_timestamp.py
@@ -53,10 +53,7 @@ def raw_socket(iface: str, *, loopback: bool = True, own_messages: bool = False)
     sock.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_LOOPBACK, int(loopback))
     sock.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_RECV_OWN_MSGS, int(own_messages))
     flags = (
-        SOF_TIMESTAMPING_TX_SOFTWARE
-        | SOF_TIMESTAMPING_SOFTWARE
-        | SOF_TIMESTAMPING_OPT_ID
-        | SOF_TIMESTAMPING_OPT_TSONLY
+        SOF_TIMESTAMPING_TX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE | SOF_TIMESTAMPING_OPT_ID | SOF_TIMESTAMPING_OPT_TSONLY
     )
     sock.setsockopt(socket.SOL_SOCKET, SO_TIMESTAMPING, flags)
     sock.bind((iface,))
@@ -105,9 +102,7 @@ def timestamp_capabilities(iface: str) -> EthtoolTsInfo:
     info = EthtoolTsInfo(cmd=ETHTOOL_GET_TS_INFO)
     request = Ifreq(name=iface.encode("ascii"), data=ctypes.addressof(info))
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        result = ctypes.CDLL(None, use_errno=True).ioctl(
-            sock.fileno(), SIOCETHTOOL, ctypes.byref(request)
-        )
+        result = ctypes.CDLL(None, use_errno=True).ioctl(sock.fileno(), SIOCETHTOOL, ctypes.byref(request))
     if result < 0:
         error = ctypes.get_errno()
         raise OSError(error, os.strerror(error))
@@ -144,16 +139,8 @@ def main() -> int:
         results.append(check("vcan reference emits one software TX timestamp", accepted and count == 1))
 
         info = timestamp_capabilities(iface)
-        software = (
-            SOF_TIMESTAMPING_TX_SOFTWARE
-            | SOF_TIMESTAMPING_RX_SOFTWARE
-            | SOF_TIMESTAMPING_SOFTWARE
-        )
-        hardware = (
-            SOF_TIMESTAMPING_TX_HARDWARE
-            | SOF_TIMESTAMPING_RX_HARDWARE
-            | SOF_TIMESTAMPING_RAW_HARDWARE
-        )
+        software = SOF_TIMESTAMPING_TX_SOFTWARE | SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE
+        hardware = SOF_TIMESTAMPING_TX_HARDWARE | SOF_TIMESTAMPING_RX_HARDWARE | SOF_TIMESTAMPING_RAW_HARDWARE
         results.append(
             check(
                 "wbcan advertises software-only timestamp capabilities",

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -511,7 +511,20 @@ check "concurrent arm uses one complete configuration" "0" "$mixed"
 clear_fault
 restart_if_bus_off
 
-# --- 15. state, queue, and fault-plane concurrency stays bounded -----------
+# --- 15. standard software TX timestamp semantics --------------------------
+if python3 "$(dirname "$0")/test_tx_timestamp.py" "$IFACE" "$DBG"
+then
+	green "PASS  software TX timestamp paths match SocketCAN semantics"
+	PASS=$((PASS + 1))
+else
+	red "FAIL  software TX timestamp probe"
+	FAIL=$((FAIL + 1))
+fi
+
+clear_fault
+restart_if_bus_off
+
+# --- 16. state, queue, and fault-plane concurrency stays bounded -----------
 if python3 "$(dirname "$0")/test_state_concurrency.py" "$IFACE" "$DBG"
 then
 	green "PASS  concurrent state and queue transitions stay bounded"
@@ -552,4 +565,5 @@ fi
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 echo "Fault-mode coverage: drop-tx drop-rx bit-flip bus-off tx-full arb-lost stuff-err"
+echo "Timestamp evidence: host software enqueue timing only; no wire, MCU, actuator, or hard-real-time claim"
 [ "$FAIL" -eq 0 ]

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -25,6 +25,7 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/ethtool.h>
 #include <linux/module.h>
 #include <linux/init.h>
 #include <linux/netdevice.h>
@@ -365,6 +366,15 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		netif_wake_queue(dev);
 		return NETDEV_TX_BUSY;
 
+	default:
+		break;
+	}
+
+	/* The frame is now accepted and will not be retried by the stack. */
+	skb_tx_timestamp(skb);
+
+	switch (fault) {
+
 	case WBCAN_FAULT_BUS_OFF:
 	case WBCAN_FAULT_ARB_LOST:
 	case WBCAN_FAULT_STUFF_ERR:
@@ -519,6 +529,10 @@ static const struct net_device_ops wbcan_netdev_ops = {
 	.ndo_stop	= wbcan_stop,
 	.ndo_start_xmit	= wbcan_start_xmit,
 	.ndo_change_mtu	= wbcan_change_mtu,
+};
+
+static const struct ethtool_ops wbcan_ethtool_ops = {
+	.get_ts_info	= ethtool_op_get_ts_info,
 };
 
 /* --------------------------------------------------------------- debugfs ABI
@@ -779,6 +793,7 @@ static int __init wbcan_init(void)
 	priv->match_any = true;
 
 	wbcan_dev->netdev_ops = &wbcan_netdev_ops;
+	wbcan_dev->ethtool_ops = &wbcan_ethtool_ops;
 	wbcan_dev->flags |= IFF_ECHO;
 	strscpy(wbcan_dev->name, "wbcan0", IFNAMSIZ);
 

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -374,7 +374,6 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	skb_tx_timestamp(skb);
 
 	switch (fault) {
-
 	case WBCAN_FAULT_BUS_OFF:
 	case WBCAN_FAULT_ARB_LOST:
 	case WBCAN_FAULT_STUFF_ERR:


### PR DESCRIPTION
## Issue

Refs #184.

## Summary

- request exactly one standard `skb_tx_timestamp()` for every wbcan frame accepted by the driver;
- leave invalid frames and `NETDEV_TX_BUSY` retries un-timestamped until acceptance;
- advertise software-only timestamp support through `ethtool`;
- add a privileged `CAN_RAW` `SO_TIMESTAMPING`/`MSG_ERRQUEUE` probe with a temporary `vcan` reference;
- cover normal, loopback-disabled, own-message, drop, injected error, TX-full retry, and invalid-frame paths.

## Scope

This PR is stacked on #228 (`fix/153-wbcan-state-serialization`) and changes only `kernel/wbcan` plus its Task Packet. It does not claim wire, MCU, actuator, hardware-clock, or hard-real-time timing.

## Evidence

- `python -m py_compile kernel/wbcan/test_tx_timestamp.py`: passed
- `python tools/scripts/check_task_packet.py docs/task_packets/linux-wbcan-software-tx-timestamps.json --base origin/fix/153-wbcan-state-serialization`: passed
- `git diff --check`: passed
- Linux kernel build, checkpatch, module load, and privileged SocketCAN probe: GitHub Actions required evidence

## Owner review

Linux / Hardware I/O Owner: @TH3478

Please review the timestamp ownership boundary and the privileged evidence. Merge only after #228 is merged or this branch is rebased onto the resulting `main` commit.