### PR TITLE
security(ci): add CodeQL coverage for C and C++

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,40 @@ jobs:
         with:
           category: /language:python
 
+  codeql-c-cpp:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Install C and C++ build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            "linux-headers-$(uname -r)" \
+            linux-headers-generic \
+            gcc-riscv64-unknown-elf
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        with:
+          languages: c-cpp
+          build-mode: manual
+      - name: Build kernel and freestanding MCU targets
+        shell: bash
+        run: |
+          set -euo pipefail
+          kernel_headers="$(find /usr/src -maxdepth 1 -type d -name 'linux-headers-*-generic' | sort | head -n1)"
+          test -n "$kernel_headers"
+          make -C kernel/wbcan clean KDIR="$kernel_headers"
+          make -C kernel/wbcan KDIR="$kernel_headers"
+          make -C firmware/mcu clean
+          make -C firmware/mcu host
+          make -C firmware/mcu qemu
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        with:
+          category: /language:c-cpp
+
   dependency-review:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04

--- a/docs/task_packets/issue-225-codeql-c-cpp.json
+++ b/docs/task_packets/issue-225-codeql-c-cpp.json
@@ -1,0 +1,49 @@
+{
+  "issue": 225,
+  "human_owner": "TH3478",
+  "objective": "Add required static analysis coverage for the kernel wbcan driver and freestanding MCU C code without replacing runtime safety evidence.",
+  "allowed_paths": [
+    ".github/workflows/security.yml",
+    "tests/unit/test_security_baseline.py",
+    "docs/task_packets/issue-225-codeql-c-cpp.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "kernel/wbcan/**",
+    "firmware/mcu/**",
+    ".github/workflows/ci.yml"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "robot/control/**",
+    "hardware/safety/**"
+  ],
+  "acceptance": [
+    "a pinned CodeQL C/C++ job analyzes kernel/wbcan and firmware/mcu",
+    "the C/C++ job uses manual build mode and records both kernel and freestanding MCU compiler invocations",
+    "CodeQL upload permissions are limited to the C/C++ and Python analysis jobs",
+    "the C/C++ analysis job cannot silently skip its build or be marked successful with continue-on-error",
+    "the existing wbcan fault suite and MCU QEMU checks remain separate runtime evidence",
+    "a deterministic security workflow regression test protects the C/C++ job configuration"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-225-codeql-c-cpp.json",
+    "python3 -m pytest tests/unit/test_security_baseline.py -q",
+    "make check",
+    "python3 -m mkdocs build --strict",
+    "git diff --check"
+  ],
+  "evidence": [
+    "security workflow regression test output",
+    "Task Packet validation output",
+    "full repository check output",
+    "strict documentation build output",
+    "CodeQL C/C++ and Python analysis results"
+  ],
+  "stop_conditions": [
+    "a compiler database cannot be captured for either the kernel or freestanding MCU target",
+    "a firmware, interface, robot-control, or physical safety change is required",
+    "the analyzer is allowed to skip a build, suppress findings broadly, or replace runtime evidence",
+    "a repository branch-protection setting must be changed outside the code review"
+  ]
+}

--- a/tests/unit/test_security_baseline.py
+++ b/tests/unit/test_security_baseline.py
@@ -23,9 +23,20 @@ def test_security_workflow_is_pinned_and_least_privileged() -> None:
     assert action_lines
     assert all(re.search(r"@[0-9a-f]{40}\s+# v[0-9]", line) for line in action_lines)
 
-    codeql = _job_block(workflow, "codeql-python", "dependency-review")
+    codeql = _job_block(workflow, "codeql-python", "codeql-c-cpp")
     assert "security-events: write" in codeql
     assert "build-mode: none" in codeql
+
+    codeql_c_cpp = _job_block(workflow, "codeql-c-cpp", "dependency-review")
+    assert "security-events: write" in codeql_c_cpp
+    assert "packages: read" not in codeql_c_cpp
+    assert "languages: c-cpp" in codeql_c_cpp
+    assert "build-mode: manual" in codeql_c_cpp
+    assert 'make -C kernel/wbcan KDIR="$kernel_headers"' in codeql_c_cpp
+    assert "make -C firmware/mcu host" in codeql_c_cpp
+    assert "make -C firmware/mcu qemu" in codeql_c_cpp
+    assert "category: /language:c-cpp" in codeql_c_cpp
+    assert "continue-on-error: true" not in codeql_c_cpp
 
     dependency_review = _job_block(workflow, "dependency-review")
     assert "if: github.event_name == 'pull_request'" in dependency_review


### PR DESCRIPTION
## Summary

- Add a pinned CodeQL C/C++ analysis job for the safety-critical C code.
- Cover both the `kernel/wbcan` driver and the freestanding `firmware/mcu` targets.
- Keep static analysis additive to the existing runtime kernel fault suite and MCU QEMU checks.

## Changes

- Add a dedicated `codeql-c-cpp` job using CodeQL manual build mode.
- Install Linux kernel headers and the RISC-V cross-compiler required by the targets.
- Build `kernel/wbcan`, MCU host tests, and the freestanding MCU QEMU target before analysis.
- Grant only `contents: read` and `security-events: write` to analysis jobs.
- Add regression coverage preventing the C/C++ analysis job from being silently skipped or marked successful with `continue-on-error`.
- Add the Issue #225 Task Packet defining the scope and evidence requirements.
- Add the required `Signed-off-by` line to the commit.

## Validation

- All GitHub CI checks pass, including `codeql-c-cpp`.
- Security workflow regression tests pass.
- Task Packet validation passes.
- Full repository tests, contract checks, and strict documentation build pass.

## Scope and limitations

- No changes were made to `kernel/wbcan`, `firmware/mcu`, `interfaces/`, or runtime safety logic.
- No CodeQL suppressions were added.
- Configuring `codeql-c-cpp` as a required branch-protection check remains a repository administration task.
- An independent Integration review is still required.

This PR partially addresses #225.