### PR TITLE
fix(world-model): bind evidence to current location

### DIFF
--- a/docs/task_packets/issue-244-location-relation-evidence.json
+++ b/docs/task_packets/issue-244-location-relation-evidence.json
@@ -1,0 +1,42 @@
+{
+  "issue": 244,
+  "human_owner": "Quchaosheng",
+  "objective": "Bind entity evidence to the current location transition so stale or unrelated evidence cannot confirm a location claim.",
+  "allowed_paths": [
+    "services/world_model/workbench_world_model/reducer.py",
+    "services/world_model/workbench_world_model/verifier.py",
+    "tests/unit/test_world_model.py",
+    "docs/task_packets/issue-244-location-relation-evidence.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**"
+  ],
+  "forbidden": [
+    "robot/**",
+    "firmware/**",
+    "hardware/safety/**"
+  ],
+  "acceptance": [
+    "a location change replaces evidence from the previous location",
+    "an evidence-free location change cannot reuse run-wide or unrelated entity evidence",
+    "same-location observations retain unique evidence in event order",
+    "object verification returns only evidence for the current object location"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_world_model.py -v",
+    "make check",
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-244-location-relation-evidence.json --base origin/main",
+    "git diff --check"
+  ],
+  "evidence": [
+    "world-model reducer and verifier regression output",
+    "full repository check output",
+    "Task Packet boundary output"
+  ],
+  "stop_conditions": [
+    "a public schema or contract change is required",
+    "physical or robot-control evidence is requested",
+    "the fix requires writes outside the allowed paths"
+  ]
+}

--- a/services/world_model/workbench_world_model/reducer.py
+++ b/services/world_model/workbench_world_model/reducer.py
@@ -19,6 +19,15 @@ def _append_entity_evidence(state: WorldState, entity_id: str, evidence_refs: li
     entity_evidence.extend(reference for reference in evidence_refs if reference not in entity_evidence)
 
 
+def _update_location(state: WorldState, entity_id: str, location: object, evidence_refs: list[str]) -> None:
+    normalized_location = str(location)
+    if state.entity_locations.get(entity_id) != normalized_location:
+        state.entity_evidence_refs[entity_id] = list(dict.fromkeys(evidence_refs))
+    else:
+        _append_entity_evidence(state, entity_id, evidence_refs)
+    state.entity_locations[entity_id] = normalized_location
+
+
 def apply_event(state: WorldState, event: WorldEvent) -> WorldState:
     """Apply one ordered event. Re-applying an event is idempotent."""
     if event.event_id in state.applied_event_ids:
@@ -34,14 +43,15 @@ def apply_event(state: WorldState, event: WorldEvent) -> WorldState:
         if entity_id:
             normalized_entity_id = str(entity_id)
             if location:
-                next_state.entity_locations[normalized_entity_id] = str(location)
+                _update_location(next_state, normalized_entity_id, location, event.evidence_refs)
             next_state.entity_confidence[normalized_entity_id] = float(event.payload.get("confidence", 0.0))
             attributes = event.payload.get("attributes")
             if isinstance(attributes, dict):
                 next_state.entity_attributes[normalized_entity_id] = {
                     str(key): str(value) for key, value in attributes.items()
                 }
-            _append_entity_evidence(next_state, normalized_entity_id, event.evidence_refs)
+            if not location:
+                _append_entity_evidence(next_state, normalized_entity_id, event.evidence_refs)
 
     elif event.event_type is WorldEventType.ACTION_RESULT and event.payload.get("outcome") == "completed":
         entity_id = event.payload.get("entity_id")
@@ -49,8 +59,9 @@ def apply_event(state: WorldState, event: WorldEvent) -> WorldState:
         if entity_id:
             normalized_entity_id = str(entity_id)
             if location:
-                next_state.entity_locations[normalized_entity_id] = str(location)
-            _append_entity_evidence(next_state, normalized_entity_id, event.evidence_refs)
+                _update_location(next_state, normalized_entity_id, location, event.evidence_refs)
+            else:
+                _append_entity_evidence(next_state, normalized_entity_id, event.evidence_refs)
 
     return next_state
 

--- a/services/world_model/workbench_world_model/verifier.py
+++ b/services/world_model/workbench_world_model/verifier.py
@@ -105,7 +105,9 @@ def _result(
     reason_code: ReasonCode,
     recovery_hint: RecoveryHint,
     rule_version: str,
+    evidence_refs: list[str] | None = None,
 ) -> VerificationResult:
+    selected_evidence = _unique_evidence(state) if evidence_refs is None else list(dict.fromkeys(evidence_refs))
     return VerificationResult(
         verification_id=f"ver-{uuid.uuid4().hex[:12]}",
         run_id=state.run_id,
@@ -113,7 +115,7 @@ def _result(
         claim=claim,
         status=status,
         reason_code=reason_code,
-        evidence_refs=_unique_evidence(state) or [NO_EVIDENCE_REF],
+        evidence_refs=selected_evidence or [NO_EVIDENCE_REF],
         recovery_hint=recovery_hint,
         verified_at="1970-01-01T00:00:00Z",
         rule_version=rule_version,
@@ -125,7 +127,7 @@ def verify_object_in_tray(state: WorldState, task_id: str, object_id: str, tray_
         raise ValueError("object_id and tray_id must be non-empty")
     expected_location = f"in:{tray_id}"
     actual_location = state.entity_locations.get(object_id)
-    evidence = _unique_evidence(state)
+    evidence = state.entity_evidence_refs.get(object_id, [])
     if actual_location is None:
         status = VerificationStatus.INSUFFICIENT_EVIDENCE
         reason_code = ReasonCode.TARGET_NOT_OBSERVED
@@ -146,7 +148,7 @@ def verify_object_in_tray(state: WorldState, task_id: str, object_id: str, tray_
         reason_code = ReasonCode.GOAL_NOT_SATISFIED
         recovery_hint = RecoveryHint.RETRY_ACTION
         claim = f"{object_id} inside {tray_id}: found at {actual_location}"
-    return _result(state, task_id, claim, status, reason_code, recovery_hint, "tray-membership-v1")
+    return _result(state, task_id, claim, status, reason_code, recovery_hint, "tray-membership-v1", evidence)
 
 
 def verify_kit_contents(

--- a/tests/unit/test_world_model.py
+++ b/tests/unit/test_world_model.py
@@ -223,6 +223,39 @@ class WorldModelTests(unittest.TestCase):
         self.assertEqual(result.reason_code, ReasonCode.EVIDENCE_MISSING)
         self.assertIn("no evidence", result.claim)
 
+    def test_location_change_cannot_reuse_stale_or_unrelated_evidence(self) -> None:
+        move_without_evidence = placed_event().model_copy(update={"sequence_no": 3, "evidence_refs": []})
+        state = reduce_events(
+            "run-001",
+            [
+                observation_event("evt-table", 1),
+                observation_event("evt-unrelated", 2, entity_id="blue_block", location="in:tray"),
+                move_without_evidence,
+            ],
+        )
+
+        result = verify_object_in_tray(state, "task-001", "red_block", "tray")
+
+        self.assertEqual(state.entity_evidence_refs["red_block"], [])
+        self.assertEqual(result.status, VerificationStatus.INSUFFICIENT_EVIDENCE)
+        self.assertEqual(result.reason_code, ReasonCode.EVIDENCE_MISSING)
+        self.assertEqual(result.evidence_refs, ["system://world-state/no-evidence"])
+
+    def test_same_location_evidence_accumulates_until_location_changes(self) -> None:
+        table_events = [observation_event("evt-table-1", 1), observation_event("evt-table-2", 2)]
+        same_location = reduce_events("run-001", table_events)
+        state = reduce_events("run-001", [*table_events, observation_event("evt-tray", 3, location="in:tray")])
+
+        self.assertEqual(
+            same_location.entity_evidence_refs["red_block"],
+            ["frame://evt-table-1", "frame://evt-table-2"],
+        )
+        self.assertEqual(state.entity_evidence_refs["red_block"], ["frame://evt-tray"])
+        self.assertEqual(
+            verify_object_in_tray(state, "task-001", "red_block", "tray").evidence_refs,
+            ["frame://evt-tray"],
+        )
+
     def test_kitting_verifier_checks_all_parts_extras_confidence_and_evidence(self) -> None:
         state = WorldState(
             run_id="kit-run",


### PR DESCRIPTION
## Summary

- replace entity evidence when its location changes
- retain deterministic evidence for repeated observations of the same location
- scope object-location verification to the claimed entity current relation
- reject stale, run-wide, and unrelated entity evidence as location support

## Validation

- `tests/unit/test_world_model.py`: 19 passed
- `make check`: 499 passed plus contract/scenario/golden/context/demo gates
- Task Packet boundary passed
- Ruff and formatting checks passed with the repository-pinned Ruff 0.16.3

## Scope

No public schema, contract, robot-control, firmware, or physical-evidence change. This is the relation-level follow-up identified while reviewing #239.

Closes #244