### PR TITLE
perf(kernel): make wbcan stats race-safe

### DIFF
--- a/docs/task_packets/linux-wbcan-saturation-stats.json
+++ b/docs/task_packets/linux-wbcan-saturation-stats.json
@@ -1,0 +1,47 @@
+{
+  "issue": 157,
+  "human_owner": "TH3478",
+  "objective": "Make wbcan netdev statistics race-safe and account for RX backlog drops under bounded saturation.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/test_state_concurrency.py",
+    "docs/task_packets/linux-wbcan-saturation-stats.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    ".github/workflows/ci.yml"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**"
+  ],
+  "acceptance": [
+    "all netdev statistic writers are serialized by one IRQ-safe writer lock around u64_stats_sync updates",
+    "netdev statistics are exposed through ndo_get_stats64 with reader retry semantics",
+    "RX backlog rejection increments rx_dropped instead of claiming rx_packets",
+    "intentional drop-rx and allocation-failure paths remain observable in netdev statistics",
+    "concurrent TX and stats sampling never observes a counter regression",
+    "the existing seven fault modes and state lifecycle behavior remain unchanged",
+    "no physical CAN, MCU, actuator, or hard-real-time evidence is claimed"
+  ],
+  "commands": [
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test",
+    "python tools/scripts/check_task_packet.py docs/task_packets/linux-wbcan-saturation-stats.json",
+    "git diff --check origin/main...HEAD"
+  ],
+  "evidence": [
+    "kernel build and checkpatch output",
+    "privileged wbcan fault suite output",
+    "concurrent netdev statistics sampling output",
+    "marker-delimited dmesg without kernel warnings"
+  ],
+  "stop_conditions": [
+    "the target kernel lacks u64_stats_sync or ndo_get_stats64",
+    "a CAN core API change is required",
+    "physical hardware evidence is required"
+  ]
+}

--- a/kernel/wbcan/test_state_concurrency.py
+++ b/kernel/wbcan/test_state_concurrency.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable
+from itertools import pairwise
 from pathlib import Path
 
 FRAME = struct.Struct("=IB3x8s")
@@ -67,6 +68,11 @@ class Probe:
         if value is None:
             raise AssertionError(f"missing status counter: {name}")
         return int(value)
+
+    def netdev_stats(self) -> dict[str, int]:
+        root = Path("/sys/class/net") / self.interface / "statistics"
+        names = ("tx_packets", "tx_bytes", "tx_dropped", "rx_packets", "rx_bytes", "rx_dropped")
+        return {name: int((root / name).read_text(encoding="ascii")) for name in names}
 
     def wait_for_state(self, expected: str, timeout: float = 1.0) -> None:
         deadline = time.monotonic() + timeout
@@ -380,6 +386,36 @@ class Probe:
             sender.close()
             peer.close()
 
+    def exercise_stats_sampling(self) -> None:
+        self.arm("none 0")
+        stop = threading.Event()
+        samples: list[dict[str, int]] = []
+
+        def sample() -> None:
+            while not stop.is_set():
+                samples.append(self.netdev_stats())
+                time.sleep(0.0005)
+
+        sampler = threading.Thread(target=sample, name="stats-sampler", daemon=True)
+        sender = threading.Thread(
+            target=self.capture,
+            args=(self.send_frames, 600, 0x739),
+            name="stats-tx",
+            daemon=True,
+        )
+        sampler.start()
+        sender.start()
+        sender.join(timeout=3)
+        stop.set()
+        sampler.join(timeout=1)
+        self.finish_threads(sender, sampler)
+        if len(samples) < 2:
+            raise AssertionError("statistics sampler collected too few snapshots")
+        for previous, current in pairwise(samples):
+            for name in current:
+                if current[name] < previous[name]:
+                    raise AssertionError(f"netdev statistic regressed: {name}")
+
 
 def main() -> int:
     if len(sys.argv) != 3:
@@ -394,6 +430,7 @@ def main() -> int:
         probe.exercise_restart_cancellation()
         probe.exercise_restart_stop_race()
         probe.verify_queue_recovery()
+        probe.exercise_stats_sampling()
     except Exception as exc:  # noqa: BLE001 - preserve the probe failure through cleanup.
         failure = exc
     finally:

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -36,6 +36,7 @@
 #include <linux/slab.h>
 #include <linux/spinlock.h>
 #include <linux/string.h>
+#include <linux/u64_stats_sync.h>
 #include <linux/can.h>
 #include <linux/can/dev.h>
 #include <linux/can/error.h>
@@ -87,6 +88,7 @@ struct wbcan_priv {
 	struct dentry		*dbg_dir;
 
 	spinlock_t		lock;	/* guards fault configuration and stats */
+	struct u64_stats_sync	stats_sync;	/* protects netdev stat snapshots */
 
 	enum wbcan_fault	fault;
 	u32			fault_count;	/* frames left to affect; 0 = off */
@@ -107,6 +109,44 @@ struct wbcan_priv {
 	u64			stat_restart_attempts;
 	u64			stat_stop_attempts;
 };
+
+static void wbcan_stats_add(struct wbcan_priv *priv, u64 tx_packets,
+			    u64 tx_bytes, u64 tx_errors, u64 tx_dropped,
+			    u64 rx_packets, u64 rx_bytes, u64 rx_dropped)
+{
+	struct net_device_stats *stats = &priv->dev->stats;
+	unsigned long flags;
+
+	spin_lock_irqsave(&priv->lock, flags);
+	u64_stats_update_begin(&priv->stats_sync);
+	stats->tx_packets += tx_packets;
+	stats->tx_bytes += tx_bytes;
+	stats->tx_errors += tx_errors;
+	stats->tx_dropped += tx_dropped;
+	stats->rx_packets += rx_packets;
+	stats->rx_bytes += rx_bytes;
+	stats->rx_dropped += rx_dropped;
+	u64_stats_update_end(&priv->stats_sync);
+	spin_unlock_irqrestore(&priv->lock, flags);
+}
+
+static void wbcan_get_stats64(struct net_device *dev,
+			      struct rtnl_link_stats64 *stats)
+{
+	struct wbcan_priv *priv = netdev_priv(dev);
+	unsigned int start;
+
+	do {
+		start = u64_stats_fetch_begin(&priv->stats_sync);
+		stats->tx_packets = dev->stats.tx_packets;
+		stats->tx_bytes = dev->stats.tx_bytes;
+		stats->tx_errors = dev->stats.tx_errors;
+		stats->tx_dropped = dev->stats.tx_dropped;
+		stats->rx_packets = dev->stats.rx_packets;
+		stats->rx_bytes = dev->stats.rx_bytes;
+		stats->rx_dropped = dev->stats.rx_dropped;
+	} while (u64_stats_fetch_retry(&priv->stats_sync, start));
+}
 
 struct wbcan_status_snapshot {
 	enum can_state		state;
@@ -261,8 +301,8 @@ static void wbcan_emit_error(struct net_device *dev, enum wbcan_fault fault)
 		break;
 	}
 
-	if (skb)
-		netif_rx(skb);
+	if (skb && netif_rx(skb) != NET_RX_SUCCESS)
+		wbcan_stats_add(priv, 0, 0, 0, 0, 0, 0, 1);
 }
 
 /* --------------------------------------------------------------- netdev ops */
@@ -340,7 +380,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		 * rather than accepting traffic in a terminal controller state.
 		 */
 		netif_stop_queue(dev);
-		dev->stats.tx_dropped++;
+		wbcan_stats_add(priv, 0, 0, 0, 1, 0, 0, 0);
 		kfree_skb(skb);
 		return NETDEV_TX_OK;
 	}
@@ -381,7 +421,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		priv->stat_tx++;
 		spin_unlock_irqrestore(&priv->lock, flags);
 		wbcan_emit_error(dev, fault);
-		dev->stats.tx_errors++;
+		wbcan_stats_add(priv, 0, 0, 1, 0, 0, 0, 0);
 		kfree_skb(skb);
 		return NETDEV_TX_OK;
 
@@ -393,8 +433,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		spin_lock_irqsave(&priv->lock, flags);
 		priv->stat_tx++;
 		spin_unlock_irqrestore(&priv->lock, flags);
-		dev->stats.tx_packets++;
-		dev->stats.tx_bytes += len;
+		wbcan_stats_add(priv, 1, len, 0, 0, 0, 0, 0);
 		kfree_skb(skb);
 		return NETDEV_TX_OK;
 
@@ -411,8 +450,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		can_change_state(dev, NULL, CAN_STATE_ERROR_ACTIVE,
 				 CAN_STATE_ERROR_ACTIVE);
 
-	dev->stats.tx_packets++;
-	dev->stats.tx_bytes += len;
+	wbcan_stats_add(priv, 1, len, 0, 0, 0, 0, 0);
 	loop = skb->pkt_type == PACKET_LOOPBACK;
 	if (!loop) {
 		consume_skb(skb);
@@ -433,7 +471,7 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		rx_skb = can_create_echo_skb(skb);
 	}
 	if (!rx_skb) {
-		dev->stats.rx_dropped++;
+		wbcan_stats_add(priv, 0, 0, 0, 0, 0, 0, 1);
 		return NETDEV_TX_OK;
 	}
 
@@ -449,18 +487,20 @@ static netdev_tx_t wbcan_start_xmit(struct sk_buff *skb, struct net_device *dev)
 
 	if (fault == WBCAN_FAULT_DROP_RX) {
 		kfree_skb(rx_skb);
+		wbcan_stats_add(priv, 0, 0, 0, 0, 0, 0, 1);
 	} else {
 		rx_skb->dev = dev;
 		rx_skb->ip_summed = CHECKSUM_UNNECESSARY;
 		rx_skb->pkt_type = PACKET_BROADCAST;
-		dev->stats.rx_packets++;
-		dev->stats.rx_bytes += len;
+		if (netif_rx(rx_skb) == NET_RX_SUCCESS) {
+			wbcan_stats_add(priv, 0, 0, 0, 0, 1, len, 0);
 
-		spin_lock_irqsave(&priv->lock, flags);
-		priv->stat_rx++;
-		spin_unlock_irqrestore(&priv->lock, flags);
-
-		netif_rx(rx_skb);
+			spin_lock_irqsave(&priv->lock, flags);
+			priv->stat_rx++;
+			spin_unlock_irqrestore(&priv->lock, flags);
+		} else {
+			wbcan_stats_add(priv, 0, 0, 0, 0, 0, 0, 1);
+		}
 	}
 
 	return NETDEV_TX_OK;
@@ -528,6 +568,7 @@ static const struct net_device_ops wbcan_netdev_ops = {
 	.ndo_stop	= wbcan_stop,
 	.ndo_start_xmit	= wbcan_start_xmit,
 	.ndo_change_mtu	= wbcan_change_mtu,
+	.ndo_get_stats64	= wbcan_get_stats64,
 };
 
 static const struct ethtool_ops wbcan_ethtool_ops = {
@@ -788,6 +829,7 @@ static int __init wbcan_init(void)
 	priv = netdev_priv(wbcan_dev);
 	priv->dev = wbcan_dev;
 	spin_lock_init(&priv->lock);
+	u64_stats_init(&priv->stats_sync);
 	priv->fault = WBCAN_FAULT_NONE;
 	priv->match_any = true;
 


### PR DESCRIPTION
## Issue

Refs #157.

## Changes

- protect netdev statistics updates with `u64_stats_sync`;
- expose coherent counters through `ndo_get_stats64`;
- account for `netif_rx()` backlog drops and intentional RX drops instead of counting them as delivered;
- add concurrent TX/statistics sampling to the privileged state probe.

## Scope

Stacked on #228. No CAN core, firmware, interface, physical bus, MCU, or hard-real-time claims.

## Validation

- ruff check and format: passed
- py_compile: passed
- Task Packet validation: passed
- git diff --check: passed
- Linux build/checkpatch and privileged runtime: required CI evidence

Merge only after #228 lands and Linux owner approval is present.