### PR TITLE
fix(ci): validate Task Packets against the pull request head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - run: make context-check
       - run: python tools/scripts/check_task_packet.py --all
       - if: github.event_name == 'pull_request'
-        run: python tools/scripts/check_task_packet.py --all --base "${{ github.event.pull_request.base.sha }}"
+        run: python tools/scripts/check_task_packet.py --all --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}"
       - run: make docs
       - run: make demo-scripted
       - run: make demo-offline

--- a/docs/task_packets/issue-255-task-packet-head-validation.json
+++ b/docs/task_packets/issue-255-task-packet-head-validation.json
@@ -1,0 +1,49 @@
+{
+  "issue": 255,
+  "human_owner": "TH3478",
+  "objective": "Make CI Task Packet changed-path validation compare the pull request head instead of a synthetic merge commit.",
+  "allowed_paths": [
+    ".github/workflows/ci.yml",
+    "docs/task_packets/issue-255-task-packet-head-validation.json",
+    "tests/unit/test_task_packet.py",
+    "tools/scripts/check_task_packet.py"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "docs/architecture/mcu-protocol-v1.md",
+    "tools/schemas/task-packet-v1.schema.json"
+  ],
+  "forbidden": [
+    "hardware/**",
+    "interfaces/**",
+    "robot/control/**",
+    "services/**"
+  ],
+  "acceptance": [
+    "CI keeps foundation tests on the pull request merge result",
+    "Task Packet boundary validation can compare the base revision with an explicit pull request head",
+    "main-only changes present in a synthetic merge commit are excluded from the pull request changed-path set",
+    "the explicit-head path remains commit-only and does not include local untracked files",
+    "the packet authorizes no MCU, protocol, hardware, or runtime source changes"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py --all",
+    "python -m pytest tests/unit -k task_packet -v",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "explicit-head changed-path regression output",
+    "Task Packet validation output",
+    "repository test and contract output",
+    "clean diff check"
+  ],
+  "stop_conditions": [
+    "the fix requires changing protocol schemas or MCU safety behavior",
+    "a workflow outside .github/workflows/ci.yml must change",
+    "the PR head revision cannot be resolved in the CI checkout"
+  ]
+}

--- a/tests/unit/test_task_packet.py
+++ b/tests/unit/test_task_packet.py
@@ -317,6 +317,38 @@ def test_changed_paths_tracks_final_git_visible_state(tmp_path: Path, monkeypatc
     }
 
 
+def test_changed_paths_can_target_pr_head_from_merge_checkout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def git(*arguments: str) -> str:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    git("init", "-q")
+    git("config", "user.name", "Task Packet Test")
+    git("config", "user.email", "task-packet@example.invalid")
+    (tmp_path / "base.txt").write_text("base\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-qm", "base")
+    base = git("rev-parse", "HEAD")
+
+    (tmp_path / "main.txt").write_text("main\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-qm", "main update")
+    git("checkout", "-qb", "pr", base)
+    (tmp_path / "pr.txt").write_text("pr\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-qm", "pr update")
+    head = git("rev-parse", "HEAD")
+
+    monkeypatch.setattr(task_packet, "ROOT", tmp_path)
+    assert task_packet._changed_paths(base, head) == {"pr.txt"}
+
+
 def test_write_boundary_checks_every_changed_path(valid_packet: dict[str, object]) -> None:
     task_packet._validate_write_boundary(
         {"tools/scripts/check_task_packet.py", "tests/unit/test_task_packet.py"},

--- a/tools/scripts/check_task_packet.py
+++ b/tools/scripts/check_task_packet.py
@@ -263,14 +263,25 @@ def _parse_name_status(output: bytes) -> set[str]:
     return paths
 
 
-def _changed_paths(base: str) -> set[str]:
-    if base.startswith("-") or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", base):
-        raise TaskPacketError(f"invalid base revision: {base!r}")
-    _git_output(["rev-parse", "--verify", f"{base}^{{commit}}"])
-    merge_base = _git_output(["merge-base", base, "HEAD"]).decode("ascii").strip()
+def _validate_revision(revision: str, *, field: str) -> None:
+    if revision.startswith("-") or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", revision):
+        raise TaskPacketError(f"invalid {field} revision: {revision!r}")
+    _git_output(["rev-parse", "--verify", f"{revision}^{{commit}}"])
+
+
+def _changed_paths(base: str, head: str | None = None) -> set[str]:
+    _validate_revision(base, field="base")
+    if head is not None:
+        _validate_revision(head, field="head")
+        merge_base = _git_output(["merge-base", base, head]).decode("ascii").strip()
+    else:
+        merge_base = _git_output(["merge-base", base, "HEAD"]).decode("ascii").strip()
     if not re.fullmatch(r"[0-9a-fA-F]{40,64}", merge_base):
         raise TaskPacketError("git returned an invalid merge-base revision")
     diff_args = ["diff", "--find-renames", "--name-status", "-z"]
+    if head is not None:
+        return _parse_name_status(_git_output([*diff_args, merge_base, head, "--"]))
+
     paths = _parse_name_status(_git_output([*diff_args, merge_base, "--"]))
     paths.update(_parse_name_status(_git_output([*diff_args, "--cached", merge_base, "--"])))
     untracked = _git_output(["ls-files", "--others", "--exclude-standard", "-z", "--"])
@@ -318,8 +329,8 @@ def _validate_write_boundary(changed_paths: set[str], packets: list[dict[str, An
     raise TaskPacketError(f"no single active Task Packet authorizes every changed path; rejected: {closest}")
 
 
-def _validate_diff(base: str, selected_packets: list[Path] | None = None) -> None:
-    changed_paths = _changed_paths(base)
+def _validate_diff(base: str, head: str | None = None, selected_packets: list[Path] | None = None) -> None:
+    changed_paths = _changed_paths(base, head)
     packet_paths = selected_packets or [ROOT / path for path in sorted(changed_paths) if _is_packet_path(path)]
     packet_paths = [path for path in packet_paths if path.is_file() or path.is_symlink()]
     if changed_paths and not packet_paths:
@@ -348,6 +359,10 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     selection.add_argument("packet", nargs="?", type=Path, help="one Task Packet JSON file")
     selection.add_argument("--all", action="store_true", help="validate every committed packet in docs/task_packets")
     parser.add_argument("--base", help="also enforce Git-visible changed paths relative to this revision")
+    parser.add_argument(
+        "--head",
+        help="when used with --base, compare against this committed head instead of the checked-out HEAD",
+    )
     return parser.parse_args(argv)
 
 
@@ -370,8 +385,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Task Packet validation passed: {packet_path}")
     if failures:
         raise TaskPacketError("Task Packet validation failed:\n" + "\n".join(failures))
+    if args.head and not args.base:
+        raise TaskPacketError("--head requires --base")
     if args.base:
-        _validate_diff(args.base, None if args.all else packet_paths)
+        _validate_diff(args.base, args.head, None if args.all else packet_paths)
     return 0
 
 


### PR DESCRIPTION
## Summary

- validate pull-request Task Packet paths against the committed PR head instead of the synthetic merge commit;
- preserve the existing local worktree, staged, and untracked-file behavior when no explicit head is supplied;
- add a merge-checkout regression test;
- add a dedicated Issue #255 Task Packet limited to the CI workflow, validator, regression test, and its own packet.

## Scope boundary

This PR is independent of firmware, MCU protocol, watchdog, safety-state, hardware, and runtime changes. It does not modify the MCU implementation from PR #217.

## Validation

- `python -m pytest tests/unit/test_task_packet.py -v` — 58 passed
- `python tools/scripts/check_task_packet.py --all` — passed
- `python tools/scripts/check_task_packet.py --all --base origin/main` — passed
- `make test` — 498 passed
- `make contract` — passed
- `make scenario-check` — passed
- `make context-check` — passed
- `make docs` — passed
- `git diff --check` — passed

Closes #255