### PR TITLE
feat(motion): add deterministic trajectory preflight

### DIFF
--- a/docs/task_packets/motion-057-trajectory-preflight.json
+++ b/docs/task_packets/motion-057-trajectory-preflight.json
@@ -1,0 +1,77 @@
+{
+  "issue": 57,
+  "human_owner": "cyathea152-bit",
+  "objective": "On top of merged PR #149, implement the ROS-free, fail-closed and deterministic trajectory preflight required by #57 while preserving the Phase-2 validator and evidence compatibility.",
+  "allowed_paths": [
+    "robot/control/ISSUE57.md",
+    "robot/control/README.md",
+    "robot/control/workbench_motion/config/trajectory_preflight.yaml",
+    "robot/control/workbench_motion/workbench_motion/joint_limits.py",
+    "robot/control/workbench_motion/workbench_motion/phase2_probe.py",
+    "robot/control/workbench_motion/test/test_joint_limits.py",
+    "robot/control/workbench_motion/test/test_trajectory_preflight.py",
+    "robot/control/workbench_motion/test/test_phase2_probe.py",
+    "docs/task_packets/motion-057-trajectory-preflight.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/**",
+    "firmware/**",
+    "AGENTS.md",
+    "docs/context/**",
+    "docs/project-management/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/**",
+    "firmware/**",
+    "MoveIt/controller execution",
+    "ROS dispatch, ActionResult or EvidenceSink",
+    "physical or Gazebo execution claims"
+  ],
+  "acceptance": [
+    "The implementation is based on current origin/main commit 1044c843, which contains merged PR #149 commit d283bb9; the old da7c97c/#117 worktree is not used as the implementation base.",
+    "preflight_trajectory(traj, current_joint_positions, *, context) is the single validator implementation and returns immutable AcceptedTrajectory on success or Violation on failure; it imports no ROS, has no dispatcher/callback, does not mutate, clamp, reorder, repair, emit events or execute.",
+    "check_trajectory keeps the PR #149 signature and positional/keyword behavior, remains a thin Violation-or-None wrapper, preserves the six dataclass/asdict fields kind/message/joint/value/bound/point_index, and retains its supplied limits and limit_epsilon precedence rules.",
+    "build_preflight_context accepts keyword-only optional policy, expected_joint_names, hard_limits and override_limits; None loads controlled files and an explicit value wholly replaces that source. Expected joints and effective limits must match exactly and all stored mappings are converted to immutable tuples.",
+    "The policy file robot/control/workbench_motion/config/trajectory_preflight.yaml freezes version=1, limit_epsilon=0.000001, max_duration_s=30.0 and max_start_state_delta_rad=0.05. Epsilon is inward-only; duration and start delta are positive finite values; malformed policy fails closed with invalid_policy.",
+    "The stable trajectory ReasonCode set contains legacy codes joint_names/current_state/points/array_length/non_finite/time/current_position/position/velocity/effort/initial_position/segment_velocity plus joint_order_mismatch/timestamp_malformed/duration_exceeded/start_state_discontinuity. Codes are machine values, may only be added, and message text is non-contractual. Configuration errors are invalid_policy or invalid_limits and are not trajectory Violations.",
+    "The expected joint tuple is sourced from robot/control/workbench_motion/config/arm.yaml. Empty, duplicate, missing, unknown and partial names return joint_names; a same-set permutation returns joint_order_mismatch; no automatic sorting or repair is allowed.",
+    "Time parsing is nanosecond-exact: mapping/object durations require integer non-bool sec and nanosec with -2147483648 <= sec <= 2147483647 and 0 <= nanosec < 1000000000; scalar seconds reject bool, non-finite and sub-nanosecond values; -0.0 normalizes to 0 ns; malformed shape is timestamp_malformed and representable negative/non-increasing time keeps legacy time.",
+    "Validation rejects malformed arrays, NaN/Infinity, negative/non-increasing time, duration greater than 30.0 seconds, position/velocity/effort values outside inward epsilon limits, start-state delta greater than 0.05 rad, and mean segment velocity violations in the fixed validation order documented by ISSUE57.md.",
+    "A first point at t=0 is accepted only as a current-state anchor within limit_epsilon and is not treated as a motion segment; no point insertion, deletion, shifting or timestamp repair occurs.",
+    "AcceptedTrajectory has no public construction path, contains a deeply immutable normalized snapshot, canonical UTF-8 compact JSON bytes, trajectory_sha256='sha256:' plus lowercase SHA-256, policy_version, effective_limits_sha256 and context_sha256. Canonicalization uses exact joint order, integer nanoseconds, [] for absent optional arrays and finite float.hex() strings.",
+    "Equivalent mapping and ROS-like inputs produce byte-identical canonical output; changing any joint value, point, timestamp or optional array changes trajectory_sha256; changing policy, expected joints or effective limits changes the corresponding context evidence without changing the meaning of trajectory_sha256.",
+    "phase2_probe explicitly serializes exactly the legacy six validator_violation keys and tests assert their key set and string values; no new top-level code field is added to that evidence schema.",
+    "Tests cover every configured joint around position/velocity boundaries, every non-identity joint permutation, all timestamp representations and edges, duration/start-delta boundaries, configuration failures, input immutability, post-validation mutation isolation, canonicalization determinism and hash mutation sensitivity without ROS/Gazebo/network dependencies.",
+    "README and robot/control/ISSUE57.md state that #52 must accept only AcceptedTrajectory, while runtime state/scene TOCTOU recheck, controller materialization, zero-dispatch proof, #59 failed-dispatch mapping and C3b sampled collision gating remain downstream and are not claimed by #57.",
+    "Task Packet validation, Motion tests and root make test, make contract, make scenario-check, make context-check and make demo-scripted pass with no forbidden-path changes."
+  ],
+  "commands": [
+    "make task-check PACKET=docs/task_packets/motion-057-trajectory-preflight.json",
+    "uv run --directory robot/control pytest -q",
+    "uv run --directory robot/control pytest -q workbench_motion/test/test_joint_limits.py workbench_motion/test/test_trajectory_preflight.py workbench_motion/test/test_phase2_probe.py",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "make demo-scripted"
+  ],
+  "evidence": [
+    "Task Packet validation output and independent branch base commit 1044c843",
+    "Motion unit-test output covering legacy compatibility, frozen ReasonCode/configuration codes, every-joint boundaries, exact timing, immutable AcceptedTrajectory isolation and canonical/context/trajectory hashes",
+    "phase2_probe validator_violation JSON key-set regression output",
+    "root make test, contract, scenario-check, context-check and demo-scripted output",
+    "reviewable trajectory_preflight.yaml values and recorded policy/effective-limits/context hashes"
+  ],
+  "stop_conditions": [
+    "origin/main or PR #149 changes incompatibly before implementation is rebased; re-verify the clean base before continuing",
+    "the task requires any forbidden path, public interface/schema change, ROS/controller dispatch, ActionResult, EvidenceSink, Agent Runtime, WorldState, firmware or physical claim",
+    "expected joints or vendor-derived limits cannot be loaded from arm.yaml and controlled vendor configuration; do not add hard-coded fallback limits",
+    "Motion Owner has not approved the exact policy values, ReasonCode table, canonicalization rules or AcceptedTrajectory/context-hash execution boundary",
+    "a proposed implementation creates a second validator, silently clips/reorders/repairs input, re-reads mutable raw input after acceptance, or permits a raw trajectory to cross the execution boundary",
+    "required checks fail and the failure cannot be explained by an unrelated pre-existing dirty-worktree condition"
+  ]
+}

--- a/robot/control/ISSUE57.md
+++ b/robot/control/ISSUE57.md
@@ -1,0 +1,205 @@
+# Issue #57：确定性轨迹安全预检（Motion 私有实施计划）
+
+> 仅供 Motion Owner 和本地开发使用，不是 GitHub Issue、PR 描述或公开承诺。
+> 本文对应官方 `#57 feat(motion): add deterministic trajectory safety preflight`。
+
+## 1. 状态与开工门
+
+- #57 官方 Issue 仍为 `open`，没有已合入的 #57 实现。
+- PR #149 已合入并关闭 #116；它替代了已关闭、未合入的 PR #117。
+- 本 checkout 已同步远端最新 `main` `1044c843`（包含 PR #149 merge `d283bb9`），并将独立分支 `feat/57-deterministic-preflight` rebase 到该提交。原 `feat/motion-57-trajectory-preflight` worktree 的 `da7c97c` 是旧 #117 内容，不能继续使用。
+- #57 代码只允许写 `robot/control/**`，不修改 `interfaces/**`、`libs/contracts/**`、`services/**` 或 `firmware/**`。实现前须通过 [`docs/task_packets/motion-057-trajectory-preflight.json`](../docs/task_packets/motion-057-trajectory-preflight.json)；阈值、reason code 和 accepted-snapshot 边界已在 Packet 中冻结。
+
+完成定义：ROS-free 预检内核、稳定拒绝码、不可变通过快照、确定性 canonical bytes/SHA-256 和全套纯 Python 测试均完成；不包含任何控制器下发或物理执行声明。
+
+## 2. 目标与非目标
+
+### 目标
+
+对每条待执行关节轨迹执行同一套 fail-closed 检查：
+
+1. 关节集合和顺序必须与 `config/arm.yaml` 完全一致。
+2. 拒绝非有限/非法数组、非法或非单调时间、超过总时长、位置/速度/effort 越限和起始状态跳变。
+3. 返回可冻结的机器 reason code；人类消息不能成为契约。
+4. 通过后复制为不可变 normalized snapshot，并生成跨输入表示一致的 canonical bytes 与 SHA-256。
+5. 记录 policy、effective limits 和 context hash，说明“在哪套规则下通过”。
+
+### 非目标
+
+- 不导入 ROS，不调用 MoveIt、`ros2_control`、action server 或 controller。
+- 不实现 #52 的 SemanticAction/GRASP/PLACE/STOP adapter、EvidenceSink、ActionResult 或执行期监控。
+- 不做 JTC spline 峰值、连续碰撞证明、运行时越限监测、安全停车或真机验证。
+- 不通过排序、补点、裁剪、clamp 或修复来让非法输入通过。
+
+后续边界：#52 必须把 `AcceptedTrajectory` 作为唯一可执行输入；C3b 再做 bounded-resolution sampled collision gate。运行时 fresh-state/scene 的 TOCTOU 重检属于下游执行集成，不伪装成 #57 已完成。
+
+## 3. 以 #149 为基线的缺口清单
+
+同步 #149 后逐项核对，不能把旧 #117 当作权威：
+
+- 已有/应保留：厂商 UR5e hard limits、hardware override 只能收紧、重复/缺失/未知/partial joint 拒绝、NaN/Inf 和数组检查、位置/速度/effort 检查、时间单调性、t=0 当前状态锚点、平均 segment velocity、`Violation | None`、无 mutation/clamp/dispatch。
+- #57 补齐：同集合错序拒绝；最大总时长；独立最大 start-state delta；冻结 `ReasonCode`；immutable accepted snapshot；canonical bytes/SHA-256；policy/effective-limits/context hash；每个关节和时间边界的系统测试。
+- `phase2_probe` 当前用 `asdict(Violation)`；必须保持六字段 evidence 形状：`kind/message/joint/value/bound/point_index`。
+- 不引入 Hypothesis 作为默认依赖；优先使用 pytest 参数化、固定生成器和每关节循环。只有证明现有测试无法覆盖时，才单独评审新依赖。
+
+## 4. 冻结的 API 与数据模型
+
+保留旧接口，新增唯一正式入口：
+
+```python
+def check_trajectory(
+    traj, current_joint_positions, limits=None, *,
+    limit_epsilon=DEFAULT_LIMIT_EPSILON,
+) -> Violation | None
+
+def preflight_trajectory(
+    traj, current_joint_positions, *,
+    context: PreflightContext,
+) -> AcceptedTrajectory | Violation
+```
+
+`preflight_trajectory` 是唯一实现；`check_trajectory` 只是兼容 wrapper。wrapper 必须保留签名、参数位置、`None`/`Violation` 返回约定和 `asdict` 六字段。传入 `limits` 时其 mapping 插入顺序提供旧 API 的 expected order；不传时从 `arm.yaml` 读取。wrapper 的 `limit_epsilon` 继续权威；时长和 start delta 来自已验证 policy。新入口只使用不可变 `PreflightContext`。
+
+建议的 frozen 类型：
+
+```python
+class ReasonCode(StrEnum): ...
+
+
+@dataclass(frozen=True)
+class PreflightPolicy:
+    version: str
+    limit_epsilon: float
+    max_duration_s: float
+    max_start_state_delta_rad: float
+
+
+@dataclass(frozen=True)
+class PreflightContext:
+    expected_joint_names: tuple[str, ...]
+    effective_limits: tuple[tuple[str, JointLimit], ...]
+    policy: PreflightPolicy
+    effective_limits_sha256: str
+    context_sha256: str
+
+
+@dataclass(frozen=True)
+class Violation:  # kind 仍是真实字段
+    kind: ReasonCode
+    message: str
+    joint: str | None = None
+    value: float | None = None
+    bound: float | None = None
+    point_index: int | None = None
+```
+
+`NormalizedPoint`、`NormalizedTrajectory`、`AcceptedTrajectory` 也必须深度不可变（tuple 和标量，不把 dict 藏在 frozen dataclass 里）。`AcceptedTrajectory` 用 `init=False`，只由模块私有 factory 创建，包含 snapshot、canonical bytes、`trajectory_sha256`、`policy_version`、`effective_limits_sha256`、`context_sha256`。新代码可有只读 `Violation.code` alias，但不得新增顶层 dataclass 字段，避免破坏 `phase2_probe` schema。
+
+## 5. Policy、limits 与 context
+
+新增 `config/trajectory_preflight.yaml`，初始值先作为 Motion Owner 决策冻结：
+
+```yaml
+trajectory_preflight:
+  version: "1"
+  limit_epsilon: 1.0e-6
+  max_duration_s: 30.0
+  max_start_state_delta_rad: 0.05
+```
+
+- epsilon 只向内收紧 hard limit；duration/start delta 不留代码魔数。
+- policy 缺字段、未知字段、bool、NaN/Inf、非正 duration/delta 或负 epsilon，均在 readiness/context 构建时 fail closed。
+- `build_preflight_context(...)` 可显式注入 policy、expected joints、hard limits、override limits；显式参数完整替换对应文件来源，不跨来源偷偷补值。
+- expected joints 与 effective limits 集合必须完全相等；effective limits 按 expected tuple 排序后存储。
+- 配置失败抛 `PreflightConfigurationError`，只允许 `invalid_policy`/`invalid_limits`，不伪装成普通轨迹 `Violation`。
+- `effective_limits_sha256` 对关节顺序、min/max position、max velocity、max effort 做 canonical hash；`context_sha256` 覆盖 schema version、policy、expected tuple 和 limits hash。context 在一次 readiness 生命周期内不可变。
+
+## 6. Reason code 与固定校验顺序
+
+以下旧码含义不能改名或复用：`joint_names`、`current_state`、`points`、`array_length`、`non_finite`、`time`、`current_position`、`position`、`velocity`、`effort`、`initial_position`、`segment_velocity`。
+
+新增码：`joint_order_mismatch`、`timestamp_malformed`、`duration_exceeded`、`start_state_discontinuity`。配置错误码 `invalid_policy`、`invalid_limits` 独立存在。
+
+已构建合法 context 后，首个错误顺序固定为：
+
+1. joint names：空、重复、集合不符、同集合错序。
+2. current state：集合、可解析/有限性、当前位置限位。
+3. points 和所有数组长度。
+4. 数值有限性；时间形态解析。
+5. 整数纳秒时间：负值、严格递增、总时长上限。
+6. 每点 position/velocity/effort 限位。
+7. start-state discontinuity。
+8. current→first 与 point→point 平均速度。
+9. canonicalization/hash。
+
+同一输入多次运行必须得到相同 code 和结构字段；message 可读但不参与机器判定。
+
+## 7. 时间、起点与 canonicalization 规则
+
+- ROS-like/mapping duration 必须有整数且非 bool 的 `sec`、`nanosec`；`-2^31 <= sec <= 2^31-1`、`0 <= nanosec < 1e9`。
+- scalar 秒数接受非 bool int/float；有限且用 `Decimal(str(value))` 转整数纳秒，亚纳秒值返回 `timestamp_malformed`；`-0.0` 归一化为 0 ns。
+- 缺失/形态错误为 `timestamp_malformed`；可表示但负或非递增仍使用兼容码 `time`。
+- 所有比较、snapshot 和 hash 只用整数纳秒；末点超过 policy 上限返回 `duration_exceeded`。
+- 首点 t=0 仅作 current-state anchor，位置必须在 epsilon 内相等，不计零时长运动段；首点 t>0 仍检查 start delta 和平均速度。
+- 通过后输出 UTF-8 紧凑、排序键 JSON；时间为整数 ns；可选空数组统一为 `[]`；有限浮点统一用 `float.hex()` 字符串。`trajectory_sha256` 为 `sha256:<lowercase-hex>`。
+- plain mapping 与 ROS-like 等价对象必须逐字节同 hash；任意关节、点、时间或可选数组变化必须改变 hash。policy/context hash 单独记录，不混入 trajectory hash。
+
+## 8. 文件与测试计划
+
+预计只改 `robot/control/**`（实现前以 Task Packet 冻结）：
+
+| 文件 | 计划 |
+|---|---|
+| `workbench_motion/joint_limits.py` | context/policy、reason codes、统一 preflight、精确时间、duration/start delta、snapshot/canonical hash；保留 wrapper |
+| `workbench_motion/config/trajectory_preflight.yaml` | 版本化 policy（安装路径需验证） |
+| `workbench_motion/phase2_probe.py` | 显式序列化六个旧字段 |
+| `workbench_motion/test/test_joint_limits.py` | #149 回归和兼容性 |
+| `workbench_motion/test/test_trajectory_preflight.py` | #57 边界、属性、hash、immutability |
+| `README.md` | 纯逻辑 gate 与下游边界 |
+
+测试必须覆盖：
+
+- `arm.yaml` 每个关节的 position/velocity 上下界、epsilon 内外边界；任意非 identity permutation。
+- duration 等于/超过上限；重复、逆序、负、亚纳秒、sec/nanosec 越界、bool、NaN/Inf。
+- start delta 等于/超过阈值；t=0 anchor；平均 segment velocity。
+- 输入成功/失败均不变；accepted 后修改原输入不影响 snapshot/bytes/hash；snapshot tuple/frozen 不可写。
+- mapping/ROS-like canonicalization 一致；重复运行字节一致；任一内容变化 hash 改变。
+- `asdict(Violation)` 和 `validator_violation` JSON 精确六键，legacy kind 字符串不漂移。
+- policy/limits 错误为稳定 configuration error，不产生 trajectory violation。
+
+不依赖 ROS、Gazebo、网络或新增 property-testing 插件。
+
+## 9. 实施顺序、证据与命令
+
+1. 在干净分支同步 #149，运行现有 Motion 测试并记录 commit。
+2. 建/审核 Task Packet，冻结 policy、reason code、context/accepted 边界。
+3. 先实现 context/policy 和 normalized parser，再迁移现有 validator 为单一内核。
+4. 加入 duration/start delta、canonicalizer/hash 和 probe schema 兼容。
+5. 先跑 Motion 单测，再跑根仓库 required checks；失败即修复或停止，不以文档替代结果。
+
+建议证据命令：
+
+```bash
+make task-check PACKET=docs/task_packets/motion-057-trajectory-preflight.json
+uv run --directory robot/control pytest -q
+make test
+make contract
+make scenario-check
+make context-check
+```
+
+证据至少包含：Task Packet 校验输出、测试摘要、reason-code/边界/hash 结果、policy 文件和有效 limits/context hash、commit 与 `git_dirty`。本 Issue 不启动 ROS/Gazebo，也不提交物理成功证据。
+
+## 10. 下游交接与停止条件
+
+交给 #52 的接口要求：执行 port 只接受 `AcceptedTrajectory`；发送前从其 snapshot materialize，并校验 trajectory/context hash 与当前 readiness context。原始可变轨迹不得越过该边界。#52 负责 runtime state/scene TOCTOU 重检、零下发和 ActionResult；#59 负责拒绝到 failed dispatch 的编排证明；C3b 负责 sampled collision gate。上述不算 #57 完成项。
+
+立即停止并重新评审的情况：
+
+- #149 基线发生不兼容变化，或发现必须并存第二套 validator/limit/tolerance/hash 语义。
+- 需要修改 interfaces、contracts、services、firmware，或接入 ROS/controller/dispatcher。
+- 无法从 `arm.yaml` 和受控 vendor 配置得到关节/limits；不得写硬编码备用值。
+- Motion Owner 尚未批准阈值、reason code 或 accepted-snapshot 执行边界。
+- 任何实现尝试重排、补点、clamp、repair、重新读取可变原输入或产生执行副作用。
+
+只有上述门和命令证据全部满足，才可把 #57 标为实现完成；在此之前状态仍是 plan/implementation in progress。

--- a/robot/control/README.md
+++ b/robot/control/README.md
@@ -212,3 +212,36 @@ publishing a new artifact.
 An arm swap must additionally update the joint list and names in
 `config/controllers.yaml`, review `config/joint_limits.hw_override.yaml`, and
 rerun this probe. Vendor hard limits remain dynamic; never copy them here.
+
+## Issue 57: deterministic trajectory preflight
+
+`workbench_motion.joint_limits.preflight_trajectory` is the single ROS-free
+trajectory gate. It takes an immutable `PreflightContext`, rejects malformed or
+unsafe input with a stable `ReasonCode`, and returns an `AcceptedTrajectory`
+containing a deep-frozen normalized snapshot, canonical bytes, and SHA-256
+evidence. `check_trajectory` remains the Phase-2-compatible
+`Violation | None` wrapper around that same implementation.
+
+The versioned thresholds live in `config/trajectory_preflight.yaml`. Expected
+joint order comes from `config/arm.yaml`; effective limits remain the
+intersection of controlled vendor limits and the hardware override. Missing or
+invalid policy/limit sources fail readiness with `invalid_policy` or
+`invalid_limits` and are not reported as ordinary trajectory violations.
+
+Run the pure gate tests without ROS, Gazebo, or network access:
+
+```bash
+uv run --directory robot/control pytest -q \
+  workbench_motion/test/test_joint_limits.py \
+  workbench_motion/test/test_trajectory_preflight.py \
+  workbench_motion/test/test_phase2_probe.py
+```
+
+Downstream Issue #52 must expose only `AcceptedTrajectory` to its execution
+port and materialize controller messages from `AcceptedTrajectory.snapshot`.
+It must also compare the accepted trajectory/context evidence with current
+readiness before dispatch. Runtime state/scene TOCTOU rechecks, controller
+materialization, zero-dispatch proof, #59 rejected-dispatch mapping, C3b sampled
+collision gating, execution monitoring, stopping evidence, and physical safety
+remain downstream work; Issue #57 makes no ROS, Gazebo, or physical execution
+claim.

--- a/robot/control/workbench_motion/config/trajectory_preflight.yaml
+++ b/robot/control/workbench_motion/config/trajectory_preflight.yaml
@@ -1,0 +1,6 @@
+# Versioned, fail-closed policy for the ROS-free trajectory preflight gate.
+trajectory_preflight:
+  version: "1"
+  limit_epsilon: 0.000001
+  max_duration_s: 30.0
+  max_start_state_delta_rad: 0.05

--- a/robot/control/workbench_motion/test/test_joint_limits.py
+++ b/robot/control/workbench_motion/test/test_joint_limits.py
@@ -132,7 +132,7 @@ def test_malformed_or_unsafe_trajectory_fails_closed(traj, current, kind):
         (trajectory(point(1.0, velocities=(1.0, 0.0))), "velocity", "j1"),
         (trajectory(point(1.0, effort=(10.0, 0.0))), "effort", "j1"),
         (trajectory(point(0.0, positions=(0.01, 0.0))), "initial_position", "j1"),
-        (trajectory(point(0.1, positions=(0.2, 0.0))), "segment_velocity", "j1"),
+        (trajectory(point(0.01, positions=(0.02, 0.0))), "segment_velocity", "j1"),
         (trajectory(point(0.0), point(0.1, positions=(0.2, 0.0))), "segment_velocity", "j1"),
     ],
 )
@@ -163,7 +163,7 @@ class Duration:
 
 
 class Point:
-    positions: ClassVar[list[float]] = [0.5, 1.0]
+    positions: ClassVar[list[float]] = [0.05, 0.05]
     velocities: ClassVar[list[float]] = []
     accelerations: ClassVar[list[float]] = []
     effort: ClassVar[list[float]] = []

--- a/robot/control/workbench_motion/test/test_phase2_probe.py
+++ b/robot/control/workbench_motion/test/test_phase2_probe.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 from workbench_motion.arm_config import load_arm_config
-from workbench_motion.joint_limits import JointLimit
+from workbench_motion.joint_limits import JointLimit, ReasonCode, Violation
 from workbench_motion.phase2_probe import (
     FAIL_BEHAVIORS,
     FOLLOWERS,
@@ -18,6 +18,7 @@ from workbench_motion.phase2_probe import (
     ActionObservation,
     JointSnapshot,
     RosProbeIO,
+    _violation_dict,
     atomic_write_report,
     behavior_gate,
     classify_over_limit,
@@ -244,6 +245,28 @@ def valid_report():
         "validator_violation": {"kind": "position"},
         "all_passed": True,
     }
+
+
+def test_validator_violation_evidence_keeps_exact_legacy_shape():
+    payload = _violation_dict(
+        Violation(
+            kind=ReasonCode.POSITION,
+            message="outside",
+            joint="j1",
+            value=2.0,
+            bound=1.0,
+            point_index=3,
+        )
+    )
+    assert payload == {
+        "kind": "position",
+        "message": "outside",
+        "joint": "j1",
+        "value": 2.0,
+        "bound": 1.0,
+        "point_index": 3,
+    }
+    assert _violation_dict(None) is None
 
 
 def test_atomic_report_schema_and_replace(tmp_path):

--- a/robot/control/workbench_motion/test/test_trajectory_preflight.py
+++ b/robot/control/workbench_motion/test/test_trajectory_preflight.py
@@ -1,0 +1,627 @@
+"""Boundary and determinism tests for Issue #57 trajectory preflight."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+from dataclasses import FrozenInstanceError, asdict, replace
+from itertools import permutations
+from types import SimpleNamespace
+
+import pytest
+import workbench_motion.joint_limits as joint_limits_module
+from workbench_motion.arm_config import load_arm_config
+from workbench_motion.joint_limits import (
+    AcceptedTrajectory,
+    ConfigurationCode,
+    JointLimit,
+    PreflightConfigurationError,
+    PreflightPolicy,
+    ReasonCode,
+    Violation,
+    build_preflight_context,
+    check_trajectory,
+    load_preflight_policy,
+    preflight_trajectory,
+)
+
+NAMES = ("j1", "j2")
+LIMITS = {
+    "j1": JointLimit(-1.0, 1.0, 100.0, 20.0),
+    "j2": JointLimit(-2.0, 2.0, 100.0, 30.0),
+}
+POLICY = PreflightPolicy("test-1", 1e-6, 30.0, 0.05)
+CURRENT = {"j1": 0.0, "j2": 0.0}
+
+
+def context(*, names=NAMES, limits=None, policy=POLICY):
+    hard = dict(LIMITS if limits is None else limits)
+    return build_preflight_context(
+        policy=policy,
+        expected_joint_names=names,
+        hard_limits=hard,
+        override_limits={},
+    )
+
+
+def point(t, positions=(0.0, 0.0), velocities=(), accelerations=(), effort=()):
+    return {
+        "positions": list(positions),
+        "velocities": list(velocities),
+        "accelerations": list(accelerations),
+        "effort": list(effort),
+        "time_from_start": t,
+    }
+
+
+def trajectory(*points, names=NAMES):
+    return {"joint_names": list(names), "points": list(points)}
+
+
+def run(candidate, *, current=CURRENT, ctx=None):
+    return preflight_trajectory(candidate, current, context=context() if ctx is None else ctx)
+
+
+def accepted(candidate, *, current=CURRENT, ctx=None):
+    result = run(candidate, current=current, ctx=ctx)
+    assert isinstance(result, AcceptedTrajectory), result
+    return result
+
+
+def rejected(candidate, code, *, current=CURRENT, ctx=None):
+    result = run(candidate, current=current, ctx=ctx)
+    assert isinstance(result, Violation)
+    assert result.kind == code
+    return result
+
+
+def test_reason_code_values_are_frozen_and_append_only():
+    assert {code.value for code in ReasonCode} == {
+        "joint_names",
+        "current_state",
+        "points",
+        "array_length",
+        "non_finite",
+        "time",
+        "current_position",
+        "position",
+        "velocity",
+        "effort",
+        "initial_position",
+        "segment_velocity",
+        "joint_order_mismatch",
+        "timestamp_malformed",
+        "duration_exceeded",
+        "start_state_discontinuity",
+    }
+
+
+def test_joint_identity_and_every_non_identity_arm_permutation_are_rejected():
+    arm_names = tuple(load_arm_config().joints)
+    arm_limits = {name: JointLimit(-1.0, 1.0, 10.0, 10.0) for name in arm_names}
+    ctx = context(names=arm_names, limits=arm_limits)
+    current = dict.fromkeys(arm_names, 0.0)
+    base_point = point(0.0, positions=(0.0,) * len(arm_names))
+    for order in permutations(arm_names):
+        result = preflight_trajectory(trajectory(base_point, names=order), current, context=ctx)
+        if order == arm_names:
+            assert isinstance(result, AcceptedTrajectory)
+        else:
+            assert isinstance(result, Violation)
+            assert result.kind == ReasonCode.JOINT_ORDER_MISMATCH
+
+
+@pytest.mark.parametrize(
+    "names,code",
+    [
+        ((), ReasonCode.JOINT_NAMES),
+        (("j1", "j1"), ReasonCode.JOINT_NAMES),
+        (("j1", "other"), ReasonCode.JOINT_NAMES),
+        (("j2", "j1"), ReasonCode.JOINT_ORDER_MISMATCH),
+    ],
+)
+def test_joint_name_failures(names, code):
+    rejected(trajectory(point(0.0), names=names), code)
+
+
+def test_every_configured_joint_position_velocity_and_effort_boundary():
+    arm_names = tuple(load_arm_config().joints)
+    limits = {name: JointLimit(-1.0, 1.0, 10.0, 20.0) for name in arm_names}
+    ctx = context(names=arm_names, limits=limits)
+    current = dict.fromkeys(arm_names, 0.0)
+    zeros = [0.0] * len(arm_names)
+    epsilon = POLICY.limit_epsilon
+
+    for offset, joint in enumerate(arm_names):
+        for value in (-1.0 + epsilon, 1.0 - epsilon):
+            positions = zeros.copy()
+            positions[offset] = value
+            candidate = trajectory(point(0.0, positions=zeros), point(1.0, positions=positions), names=arm_names)
+            accepted(candidate, current=current, ctx=ctx)
+        for value in (-1.0 + epsilon - 1e-9, 1.0 - epsilon + 1e-9):
+            positions = zeros.copy()
+            positions[offset] = value
+            violation = rejected(
+                trajectory(point(0.0, positions=zeros), point(1.0, positions=positions), names=arm_names),
+                ReasonCode.POSITION,
+                current=current,
+                ctx=ctx,
+            )
+            assert violation.joint == joint
+
+        for sign in (-1.0, 1.0):
+            for magnitude in (10.0 - epsilon, 10.0 - epsilon - 1e-9):
+                velocities = zeros.copy()
+                velocities[offset] = sign * magnitude
+                candidate = trajectory(point(0.0, positions=zeros, velocities=velocities), names=arm_names)
+                accepted(candidate, current=current, ctx=ctx)
+            velocities = zeros.copy()
+            velocities[offset] = sign * (10.0 - epsilon + 1e-9)
+            assert (
+                rejected(
+                    trajectory(point(0.0, positions=zeros, velocities=velocities), names=arm_names),
+                    ReasonCode.VELOCITY,
+                    current=current,
+                    ctx=ctx,
+                ).joint
+                == joint
+            )
+
+        efforts = zeros.copy()
+        efforts[offset] = -(20.0 - epsilon)
+        accepted(trajectory(point(0.0, positions=zeros, effort=efforts), names=arm_names), current=current, ctx=ctx)
+        efforts[offset] -= 1e-9
+        assert (
+            rejected(
+                trajectory(point(0.0, positions=zeros, effort=efforts), names=arm_names),
+                ReasonCode.EFFORT,
+                current=current,
+                ctx=ctx,
+            ).joint
+            == joint
+        )
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        True,
+        "1.0",
+        1e-10,
+        {},
+        {"sec": 0},
+        {"nanosec": 0},
+        {"sec": True, "nanosec": 0},
+        {"sec": 0, "nanosec": False},
+        {"sec": 0.0, "nanosec": 0},
+        {"sec": -(2**31) - 1, "nanosec": 0},
+        {"sec": 2**31, "nanosec": 0},
+        {"sec": 0, "nanosec": -1},
+        {"sec": 0, "nanosec": 1_000_000_000},
+        SimpleNamespace(sec=0),
+    ],
+)
+def test_malformed_timestamp_shapes_fail(timestamp):
+    rejected(trajectory(point(timestamp)), ReasonCode.TIMESTAMP_MALFORMED)
+
+
+@pytest.mark.parametrize("timestamp", [math.nan, math.inf, -math.inf])
+def test_non_finite_scalar_timestamps_keep_legacy_code(timestamp):
+    rejected(trajectory(point(timestamp)), ReasonCode.NON_FINITE)
+
+
+def test_integer_nanosecond_time_edges_and_negative_zero_normalization():
+    assert accepted(trajectory(point(-0.0))).snapshot.points[0].time_from_start_ns == 0
+    assert accepted(trajectory(point(0.000000001))).snapshot.points[0].time_from_start_ns == 1
+    rejected(
+        trajectory(point({"sec": 2**31 - 1, "nanosec": 0})),
+        ReasonCode.DURATION_EXCEEDED,
+    )
+    rejected(trajectory(point({"sec": -1, "nanosec": 999_999_999})), ReasonCode.TIME)
+
+
+@pytest.mark.parametrize("timestamp", [2**31, 2**31 + 0.5, 10**400])
+def test_scalar_seconds_above_structured_int32_range_parse_before_duration_check(timestamp):
+    rejected(trajectory(point(timestamp)), ReasonCode.DURATION_EXCEEDED)
+
+
+@pytest.mark.parametrize("timestamp", [-(2**31) - 1, -(10**400)])
+def test_negative_scalar_seconds_below_structured_int32_range_parse_before_time_check(timestamp):
+    rejected(trajectory(point(timestamp)), ReasonCode.TIME)
+
+
+@pytest.mark.parametrize(
+    "duration",
+    [
+        pytest.param(lambda sec, nanosec: {"sec": sec, "nanosec": nanosec}, id="mapping"),
+        pytest.param(lambda sec, nanosec: SimpleNamespace(sec=sec, nanosec=nanosec), id="object"),
+    ],
+)
+def test_structured_timestamp_int32_sec_and_nanosec_boundaries(duration):
+    rejected(trajectory(point(duration(-(2**31), 0))), ReasonCode.TIME)
+    rejected(trajectory(point(duration(-(2**31), 999_999_999))), ReasonCode.TIME)
+    rejected(trajectory(point(duration(2**31 - 1, 0))), ReasonCode.DURATION_EXCEEDED)
+    rejected(trajectory(point(duration(2**31 - 1, 999_999_999))), ReasonCode.DURATION_EXCEEDED)
+    accepted(trajectory(point(duration(0, 0))))
+    accepted(trajectory(point(duration(0, 999_999_999))))
+    rejected(trajectory(point(duration(0, -1))), ReasonCode.TIMESTAMP_MALFORMED)
+    rejected(trajectory(point(duration(0, 1_000_000_000))), ReasonCode.TIMESTAMP_MALFORMED)
+
+
+def test_time_must_be_strictly_increasing():
+    rejected(trajectory(point(0.0), point(0.0)), ReasonCode.TIME)
+    rejected(trajectory(point(1.0), point(0.5)), ReasonCode.TIME)
+
+
+def test_duration_boundary_is_inclusive_and_one_nanosecond_over_fails():
+    accepted(trajectory(point(30.0)))
+    violation = rejected(trajectory(point(30.000000001)), ReasonCode.DURATION_EXCEEDED)
+    assert (violation.value, violation.bound) == (30.000000001, 30.0)
+
+
+def test_non_increasing_time_precedes_duration_and_reports_later_point():
+    violation = rejected(trajectory(point(31.0), point(30.0)), ReasonCode.TIME)
+    assert violation.point_index == 1
+
+
+def test_total_duration_uses_only_the_final_point():
+    violation = rejected(trajectory(point(31.0), point(32.0)), ReasonCode.DURATION_EXCEEDED)
+    assert (violation.point_index, violation.value) == (1, 32.0)
+
+
+def test_start_state_delta_and_t0_anchor_boundaries():
+    accepted(trajectory(point(1.0, positions=(0.05, -0.05))))
+    violation = rejected(trajectory(point(1.0, positions=(0.050000001, 0.0))), ReasonCode.START_STATE_DISCONTINUITY)
+    assert violation.joint == "j1"
+    accepted(trajectory(point(0.0, positions=(1e-6, -1e-6))))
+    rejected(trajectory(point(0.0, positions=(1.0000001e-6, 0.0))), ReasonCode.INITIAL_POSITION)
+
+
+def test_mean_segment_velocity_is_checked_after_start_delta():
+    slow_limits = {name: replace(limit, max_velocity=1.0) for name, limit in LIMITS.items()}
+    ctx = context(limits=slow_limits)
+    violation = rejected(trajectory(point(0.01, positions=(0.02, 0.0))), ReasonCode.SEGMENT_VELOCITY, ctx=ctx)
+    assert violation.joint == "j1"
+
+
+def test_array_lengths_are_checked_globally_before_numeric_values():
+    candidate = trajectory(
+        point(0.0, positions=(math.nan, 0.0)),
+        {"positions": [0.0], "time_from_start": 1.0},
+    )
+    violation = rejected(candidate, ReasonCode.ARRAY_LENGTH)
+    assert violation.point_index == 1
+
+
+def test_all_point_numeric_finiteness_precedes_all_timestamp_shape_checks():
+    candidate = trajectory(
+        point(True),
+        point(1.0, positions=(math.nan, 0.0)),
+    )
+    violation = rejected(candidate, ReasonCode.NON_FINITE)
+    assert violation.point_index == 1
+
+
+def test_all_timestamp_scalar_finiteness_precedes_timestamp_shape_checks():
+    candidate = trajectory(
+        point(True),
+        point(math.nan),
+    )
+    violation = rejected(candidate, ReasonCode.NON_FINITE)
+    assert violation.point_index == 1
+
+
+def test_all_current_state_finiteness_precedes_current_position_limits():
+    violation = rejected(
+        trajectory(point(0.0)),
+        ReasonCode.NON_FINITE,
+        current={"j1": 2.0, "j2": math.nan},
+    )
+    assert violation.joint == "j2"
+
+
+@pytest.mark.parametrize("field", ["positions", "velocities", "accelerations", "effort"])
+def test_bool_and_non_finite_arrays_fail_without_mutation(field):
+    candidate = point(0.0)
+    candidate[field] = [True, 0.0]
+    traj = trajectory(candidate)
+    before = copy.deepcopy(traj)
+    rejected(traj, ReasonCode.NON_FINITE)
+    assert traj == before
+
+
+def test_mapping_and_ros_like_inputs_have_identical_canonical_bytes():
+    mapping = trajectory(
+        point(
+            {"sec": 1, "nanosec": 250_000_000},
+            positions=(0.01, -0.02),
+            velocities=(0.1, -0.1),
+            accelerations=(0.2, -0.2),
+            effort=(1.0, -1.0),
+        )
+    )
+    ros_like = SimpleNamespace(
+        joint_names=list(NAMES),
+        points=[
+            SimpleNamespace(
+                positions=(0.01, -0.02),
+                velocities=(0.1, -0.1),
+                accelerations=(0.2, -0.2),
+                effort=(1.0, -1.0),
+                time_from_start=SimpleNamespace(sec=1, nanosec=250_000_000),
+            )
+        ],
+    )
+    left = accepted(mapping)
+    right = accepted(ros_like)
+    scalar = copy.deepcopy(mapping)
+    scalar["points"][0]["time_from_start"] = 1.25
+    scalar_result = accepted(scalar)
+    assert left.canonical_bytes == right.canonical_bytes
+    assert left.canonical_bytes == scalar_result.canonical_bytes
+    assert left.trajectory_sha256 == right.trajectory_sha256 == scalar_result.trajectory_sha256
+    payload = json.loads(left.canonical_bytes)
+    assert payload["points"][0]["time_from_start_ns"] == 1_250_000_000
+    assert payload["points"][0]["positions"][0] == (0.01).hex()
+
+
+def test_absent_optional_arrays_normalize_to_empty_lists():
+    result = accepted({"joint_names": list(NAMES), "points": [{"positions": [0.0, 0.0], "time_from_start": 0}]})
+    payload = json.loads(result.canonical_bytes)
+    assert payload["points"][0]["velocities"] == []
+    assert payload["points"][0]["accelerations"] == []
+    assert payload["points"][0]["effort"] == []
+
+
+def test_accepted_snapshot_is_isolated_and_deeply_immutable():
+    candidate = trajectory(point(0.0), point(1.0, positions=(0.01, 0.02)))
+    result = accepted(candidate)
+    original_bytes = result.canonical_bytes
+    candidate["joint_names"][0] = "mutated"
+    candidate["points"][1]["positions"][0] = 0.5
+    assert result.snapshot.joint_names == NAMES
+    assert result.snapshot.points[1].positions == (0.01, 0.02)
+    assert result.canonical_bytes == original_bytes
+    with pytest.raises(FrozenInstanceError):
+        result.snapshot.points[0].time_from_start_ns = 5
+    with pytest.raises(TypeError):
+        result.snapshot.points[0].positions[0] = 1.0
+    with pytest.raises(TypeError, match="only be created"):
+        AcceptedTrajectory()
+
+
+def test_canonical_bytes_repeat_and_each_content_mutation_changes_hash():
+    base = trajectory(point(0.0), point(1.0, positions=(0.01, 0.02)))
+    baseline = accepted(base)
+    assert accepted(copy.deepcopy(base)).canonical_bytes == baseline.canonical_bytes
+    mutations = []
+    changed_position = copy.deepcopy(base)
+    changed_position["points"][1]["positions"][0] = 0.011
+    mutations.append(changed_position)
+    changed_time = copy.deepcopy(base)
+    changed_time["points"][1]["time_from_start"] = 1.1
+    mutations.append(changed_time)
+    for field in ("velocities", "accelerations", "effort"):
+        changed_array = copy.deepcopy(base)
+        changed_array["points"][1][field] = [0.01, 0.0]
+        mutations.append(changed_array)
+    added_point = copy.deepcopy(base)
+    added_point["points"].append(point(2.0, positions=(0.02, 0.03)))
+    mutations.append(added_point)
+    assert all(accepted(candidate).trajectory_sha256 != baseline.trajectory_sha256 for candidate in mutations)
+
+
+def test_mutating_each_configured_joint_changes_trajectory_hash():
+    arm_names = tuple(load_arm_config().joints)
+    limits = {name: JointLimit(-1.0, 1.0, 10.0, 10.0) for name in arm_names}
+    ctx = context(names=arm_names, limits=limits)
+    current = dict.fromkeys(arm_names, 0.0)
+    zeros = [0.0] * len(arm_names)
+    base = trajectory(point(0.0, positions=zeros), point(1.0, positions=zeros), names=arm_names)
+    baseline = accepted(base, current=current, ctx=ctx)
+    for offset, _joint in enumerate(arm_names):
+        candidate = copy.deepcopy(base)
+        candidate["points"][1]["positions"][offset] = 0.001
+        result = accepted(candidate, current=current, ctx=ctx)
+        assert result.trajectory_sha256 != baseline.trajectory_sha256
+
+
+def test_trajectory_hash_excludes_policy_and_limit_context():
+    candidate = trajectory(point(0.0), point(1.0, positions=(0.01, 0.02)))
+    baseline = accepted(candidate)
+    policy_context = context(policy=replace(POLICY, version="test-2", max_duration_s=31.0))
+    policy_result = accepted(candidate, ctx=policy_context)
+    changed_limits = dict(LIMITS)
+    changed_limits["j1"] = replace(changed_limits["j1"], max_effort=19.0)
+    limits_result = accepted(candidate, ctx=context(limits=changed_limits))
+    assert baseline.trajectory_sha256 == policy_result.trajectory_sha256 == limits_result.trajectory_sha256
+    assert baseline.context_sha256 != policy_result.context_sha256
+    assert baseline.effective_limits_sha256 == policy_result.effective_limits_sha256
+    assert baseline.effective_limits_sha256 != limits_result.effective_limits_sha256
+
+
+def test_expected_joint_tuple_order_changes_context_evidence():
+    baseline = context()
+    reordered = context(names=tuple(reversed(NAMES)))
+    assert reordered.expected_joint_names != baseline.expected_joint_names
+    assert reordered.effective_limits_sha256 != baseline.effective_limits_sha256
+    assert reordered.context_sha256 != baseline.context_sha256
+
+
+def test_violation_asdict_and_json_keep_exact_legacy_six_fields():
+    violation = rejected(trajectory(point(1.0, positions=(1.0, 0.0))), ReasonCode.POSITION)
+    payload = asdict(violation)
+    assert tuple(payload) == ("kind", "message", "joint", "value", "bound", "point_index")
+    assert json.loads(json.dumps(payload))["kind"] == "position"
+    assert violation.code is ReasonCode.POSITION
+
+
+def test_legacy_wrapper_uses_supplied_mapping_order_and_return_contract():
+    reverse_limits = {"j2": LIMITS["j2"], "j1": LIMITS["j1"]}
+    reverse = trajectory(point(0.0), names=("j2", "j1"))
+    assert check_trajectory(reverse, CURRENT, reverse_limits) is None
+    violation = check_trajectory(trajectory(point(0.0)), CURRENT, reverse_limits)
+    assert isinstance(violation, Violation)
+    assert violation.kind == ReasonCode.JOINT_ORDER_MISMATCH
+
+
+def test_shipped_policy_values_are_frozen():
+    assert load_preflight_policy() == PreflightPolicy("1", 0.000001, 30.0, 0.05)
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {"version": "1", "limit_epsilon": 1e-6, "max_duration_s": 30.0},
+        {
+            "version": "1",
+            "limit_epsilon": 1e-6,
+            "max_duration_s": 30.0,
+            "max_start_state_delta_rad": 0.05,
+            "unknown": 1,
+        },
+        {"version": "1", "limit_epsilon": True, "max_duration_s": 30.0, "max_start_state_delta_rad": 0.05},
+        {"version": "1", "limit_epsilon": -1.0, "max_duration_s": 30.0, "max_start_state_delta_rad": 0.05},
+        {"version": "1", "limit_epsilon": 1e-6, "max_duration_s": math.inf, "max_start_state_delta_rad": 0.05},
+        {"version": "1", "limit_epsilon": 1e-6, "max_duration_s": 1e-10, "max_start_state_delta_rad": 0.05},
+        {"version": "1", "limit_epsilon": 1e-6, "max_duration_s": 30.0, "max_start_state_delta_rad": 0.0},
+    ],
+)
+def test_invalid_explicit_policy_fails_as_configuration(policy):
+    with pytest.raises(PreflightConfigurationError) as caught:
+        context(policy=policy)
+    assert caught.value.code == ConfigurationCode.INVALID_POLICY
+
+
+def test_extreme_integer_policy_fails_with_stable_configuration_code():
+    extreme = replace(POLICY, max_duration_s=10**400)
+    with pytest.raises(PreflightConfigurationError) as caught:
+        context(policy=extreme)
+    assert caught.value.code == ConfigurationCode.INVALID_POLICY
+
+
+def test_policy_file_missing_unknown_and_bool_fields_fail_closed(tmp_path):
+    malformed = tmp_path / "policy.yaml"
+    malformed.write_text(
+        "trajectory_preflight:\n"
+        "  version: '1'\n"
+        "  limit_epsilon: true\n"
+        "  max_duration_s: 30.0\n"
+        "  max_start_state_delta_rad: 0.05\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(PreflightConfigurationError) as caught:
+        load_preflight_policy(malformed)
+    assert caught.value.code == ConfigurationCode.INVALID_POLICY
+
+
+@pytest.mark.parametrize(
+    "names,limits,policy",
+    [
+        (("j1",), LIMITS, POLICY),
+        (NAMES, {"j1": LIMITS["j1"]}, POLICY),
+        (NAMES, {"j1": JointLimit(math.nan, 1.0, 1.0, 1.0), "j2": LIMITS["j2"]}, POLICY),
+        (NAMES, {"j1": JointLimit(1.0, -1.0, 1.0, 1.0), "j2": LIMITS["j2"]}, POLICY),
+        (NAMES, LIMITS, replace(POLICY, limit_epsilon=2.0)),
+    ],
+)
+def test_invalid_limits_fail_as_configuration(names, limits, policy):
+    with pytest.raises(PreflightConfigurationError) as caught:
+        context(names=names, limits=limits, policy=policy)
+    assert caught.value.code == ConfigurationCode.INVALID_LIMITS
+
+
+def test_extreme_integer_hard_limit_fails_with_stable_configuration_code():
+    hard = dict(LIMITS)
+    hard["j1"] = replace(hard["j1"], max_effort=10**400)
+    with pytest.raises(PreflightConfigurationError) as caught:
+        context(limits=hard)
+    assert caught.value.code == ConfigurationCode.INVALID_LIMITS
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"j1": JointLimit(-2.0, 2.0, 200.0, 40.0)},
+        {"j1": JointLimit(-2.0, 1.0, 100.0, 20.0)},
+        {"j1": JointLimit(-1.0, 2.0, 100.0, 20.0)},
+        {"j1": JointLimit(-1.0, 1.0, 101.0, 20.0)},
+        {"j1": JointLimit(-1.0, 1.0, 100.0, 21.0)},
+    ],
+)
+def test_explicit_override_cannot_be_looser_than_hard_limits(override):
+    with pytest.raises(PreflightConfigurationError) as caught:
+        build_preflight_context(
+            policy=POLICY,
+            expected_joint_names=NAMES,
+            hard_limits=LIMITS,
+            override_limits=override,
+        )
+    assert caught.value.code == ConfigurationCode.INVALID_LIMITS
+    assert "looser" in str(caught.value)
+
+
+def test_extreme_integer_override_fails_with_stable_configuration_code():
+    with pytest.raises(PreflightConfigurationError) as caught:
+        build_preflight_context(
+            policy=POLICY,
+            expected_joint_names=NAMES,
+            hard_limits=LIMITS,
+            override_limits={"j1": replace(LIMITS["j1"], max_effort=10**400)},
+        )
+    assert caught.value.code == ConfigurationCode.INVALID_LIMITS
+
+
+def test_context_content_hash_mismatch_fails_closed():
+    ctx = replace(context(), context_sha256="sha256:" + "0" * 64)
+    with pytest.raises(PreflightConfigurationError) as caught:
+        preflight_trajectory(trajectory(point(0.0)), CURRENT, context=ctx)
+    assert caught.value.code == ConfigurationCode.INVALID_LIMITS
+
+
+def test_explicit_integer_limits_are_normalized_for_context_hashing():
+    integer_limits = {
+        "j1": JointLimit(-1, 1, 100, 20),
+        "j2": JointLimit(-2, 2, 100, 30),
+    }
+    assert isinstance(accepted(trajectory(point(0)), ctx=context(limits=integer_limits)), AcceptedTrajectory)
+
+
+def test_explicit_sources_replace_file_sources_and_limit_order_is_canonical(monkeypatch):
+    baseline = context()
+
+    def unexpected_file_load(*args, **kwargs):
+        raise AssertionError("an explicit source must not consult controlled files")
+
+    monkeypatch.setattr(joint_limits_module, "load_arm_config", unexpected_file_load)
+    monkeypatch.setattr(joint_limits_module, "load_preflight_policy", unexpected_file_load)
+    monkeypatch.setattr(joint_limits_module, "load_hard_limits", unexpected_file_load)
+    monkeypatch.setattr(joint_limits_module, "load_hw_override", unexpected_file_load)
+    reverse_limits = {"j2": LIMITS["j2"], "j1": LIMITS["j1"]}
+    explicit = build_preflight_context(
+        policy=POLICY,
+        expected_joint_names=NAMES,
+        hard_limits=reverse_limits,
+        override_limits={},
+    )
+    assert explicit.effective_limits == tuple(LIMITS.items())
+    assert explicit.effective_limits_sha256 == baseline.effective_limits_sha256
+    assert explicit.context_sha256 == baseline.context_sha256
+
+
+def test_forged_context_with_invalid_policy_fails_as_policy_configuration():
+    forged = replace(context(), policy=replace(POLICY, max_duration_s=math.nan))
+    with pytest.raises(PreflightConfigurationError) as caught:
+        preflight_trajectory(trajectory(point(0.0)), CURRENT, context=forged)
+    assert caught.value.code == ConfigurationCode.INVALID_POLICY
+
+
+def test_fixed_first_error_order_is_deterministic():
+    candidate = trajectory({"positions": [math.nan, 0.0], "time_from_start": True}, names=("j2", "j1"))
+    assert rejected(candidate, ReasonCode.JOINT_ORDER_MISMATCH).point_index is None
+    candidate = trajectory({"positions": [math.nan, 0.0], "time_from_start": True})
+    rejected(candidate, ReasonCode.NON_FINITE)
+    first = rejected(trajectory(point(31.0, positions=(2.0, 0.0))), ReasonCode.DURATION_EXCEEDED)
+    second = rejected(trajectory(point(31.0, positions=(2.0, 0.0))), ReasonCode.DURATION_EXCEEDED)
+    assert asdict(first) == asdict(second)

--- a/robot/control/workbench_motion/test/test_trajectory_preflight.py
+++ b/robot/control/workbench_motion/test/test_trajectory_preflight.py
@@ -540,6 +540,20 @@ def test_extreme_integer_hard_limit_fails_with_stable_configuration_code():
     assert caught.value.code == ConfigurationCode.INVALID_LIMITS
 
 
+@pytest.mark.parametrize("field", ["min_position", "max_position", "max_velocity", "max_effort"])
+def test_extreme_integer_hard_limit_cannot_be_masked_by_normal_override(field):
+    hard = dict(LIMITS)
+    hard["j1"] = replace(hard["j1"], **{field: 10**400})
+    with pytest.raises(PreflightConfigurationError) as caught:
+        build_preflight_context(
+            policy=POLICY,
+            expected_joint_names=NAMES,
+            hard_limits=hard,
+            override_limits={"j1": LIMITS["j1"]},
+        )
+    assert caught.value.code == ConfigurationCode.INVALID_LIMITS
+
+
 @pytest.mark.parametrize(
     "override",
     [

--- a/robot/control/workbench_motion/test/test_trajectory_preflight.py
+++ b/robot/control/workbench_motion/test/test_trajectory_preflight.py
@@ -226,6 +226,15 @@ def test_scalar_seconds_above_structured_int32_range_parse_before_duration_check
     rejected(trajectory(point(timestamp)), ReasonCode.DURATION_EXCEEDED)
 
 
+def test_adjacent_large_integer_timestamps_remain_exact():
+    timestamp = 123456789012345678901234567890
+    violation = rejected(
+        trajectory(point(timestamp), point(timestamp + 1)),
+        ReasonCode.DURATION_EXCEEDED,
+    )
+    assert violation.point_index == 1
+
+
 @pytest.mark.parametrize("timestamp", [-(2**31) - 1, -(10**400)])
 def test_negative_scalar_seconds_below_structured_int32_range_parse_before_time_check(timestamp):
     rejected(trajectory(point(timestamp)), ReasonCode.TIME)

--- a/robot/control/workbench_motion/workbench_motion/joint_limits.py
+++ b/robot/control/workbench_motion/workbench_motion/joint_limits.py
@@ -1,15 +1,19 @@
-"""ROS-free hard-limit loading and conservative trajectory validation.
+"""ROS-free, fail-closed trajectory preflight and hard-limit loading.
 
-The validator deliberately checks only vendor hard limits intersected with the
-optional hardware override. MoveIt's planning limits and scaling remain in the
-planning layer. This module judges; it never clamps, dispatches, or emits events.
+The module owns one validator implementation: :func:`preflight_trajectory`.
+The Phase-2 :func:`check_trajectory` API is retained as a compatibility wrapper.
+Nothing here clamps, repairs, dispatches, imports ROS, or emits events.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +23,44 @@ from workbench_motion.arm_config import load_arm_config
 
 DEFAULT_LIMIT_EPSILON = 1e-6
 _SOURCE_CONFIG = Path(__file__).resolve().parent.parent / "config"
+_MISSING = object()
+_NANOSECONDS_PER_SECOND = 1_000_000_000
+_MIN_DURATION_SEC = -(2**31)
+_MAX_DURATION_SEC = 2**31 - 1
+
+
+class ReasonCode(StrEnum):
+    """Stable machine codes for trajectory rejection; values are append-only."""
+
+    JOINT_NAMES = "joint_names"
+    CURRENT_STATE = "current_state"
+    POINTS = "points"
+    ARRAY_LENGTH = "array_length"
+    NON_FINITE = "non_finite"
+    TIME = "time"
+    CURRENT_POSITION = "current_position"
+    POSITION = "position"
+    VELOCITY = "velocity"
+    EFFORT = "effort"
+    INITIAL_POSITION = "initial_position"
+    SEGMENT_VELOCITY = "segment_velocity"
+    JOINT_ORDER_MISMATCH = "joint_order_mismatch"
+    TIMESTAMP_MALFORMED = "timestamp_malformed"
+    DURATION_EXCEEDED = "duration_exceeded"
+    START_STATE_DISCONTINUITY = "start_state_discontinuity"
+
+
+class ConfigurationCode(StrEnum):
+    INVALID_POLICY = "invalid_policy"
+    INVALID_LIMITS = "invalid_limits"
+
+
+class PreflightConfigurationError(ValueError):
+    """A readiness/configuration failure, distinct from a trajectory violation."""
+
+    def __init__(self, code: ConfigurationCode, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code.value}: {message}")
 
 
 @dataclass(frozen=True)
@@ -29,14 +71,67 @@ class JointLimit:
     max_effort: float
 
 
+@dataclass(frozen=True, slots=True)
+class PreflightPolicy:
+    version: str
+    limit_epsilon: float
+    max_duration_s: float
+    max_start_state_delta_rad: float
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightContext:
+    expected_joint_names: tuple[str, ...]
+    effective_limits: tuple[tuple[str, JointLimit], ...]
+    policy: PreflightPolicy
+    effective_limits_sha256: str
+    context_sha256: str
+
+
 @dataclass(frozen=True)
 class Violation:
-    kind: str
+    # ``kind`` remains a real field so dataclasses.asdict retains the six-field
+    # Phase-2 evidence shape. StrEnum remains JSON-serializable as a string.
+    kind: ReasonCode
     message: str
     joint: str | None = None
     value: float | None = None
     bound: float | None = None
     point_index: int | None = None
+
+    @property
+    def code(self) -> ReasonCode:
+        return self.kind
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedPoint:
+    positions: tuple[float, ...]
+    velocities: tuple[float, ...]
+    accelerations: tuple[float, ...]
+    effort: tuple[float, ...]
+    time_from_start_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedTrajectory:
+    joint_names: tuple[str, ...]
+    points: tuple[NormalizedPoint, ...]
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class AcceptedTrajectory:
+    """Deeply immutable accepted snapshot, constructible only by this module."""
+
+    snapshot: NormalizedTrajectory
+    canonical_bytes: bytes
+    trajectory_sha256: str
+    policy_version: str
+    effective_limits_sha256: str
+    context_sha256: str
+
+    def __new__(cls):  # pragma: no cover - the public rejection is tested
+        raise TypeError("AcceptedTrajectory can only be created by preflight_trajectory")
 
 
 class _LimitsLoader(yaml.SafeLoader):
@@ -44,7 +139,10 @@ class _LimitsLoader(yaml.SafeLoader):
 
 
 def _degrees(loader: yaml.SafeLoader, node: yaml.Node) -> float:
-    return math.radians(float(loader.construct_scalar(node)))
+    try:
+        return math.radians(float(loader.construct_scalar(node)))
+    except OverflowError as exc:
+        raise ValueError("degree value must be a finite number") from exc
 
 
 _LimitsLoader.add_constructor("!degrees", _degrees)
@@ -65,7 +163,10 @@ def _package_share(package: str) -> Path:
 def _number(value: Any, label: str) -> float:
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise ValueError(f"{label} must be a finite number")
-    result = float(value)
+    try:
+        result = float(value)
+    except OverflowError as exc:
+        raise ValueError(f"{label} must be a finite number") from exc
     if not math.isfinite(result):
         raise ValueError(f"{label} must be a finite number")
     return result
@@ -114,18 +215,23 @@ def _default_override_path() -> Path:
     return _SOURCE_CONFIG / "joint_limits.hw_override.yaml"
 
 
+def _default_policy_path() -> Path:
+    try:
+        installed = _package_share("workbench_motion") / "config" / "trajectory_preflight.yaml"
+        if installed.is_file():
+            return installed
+    except FileNotFoundError:
+        pass
+    return _SOURCE_CONFIG / "trajectory_preflight.yaml"
+
+
 def load_hw_override(
     path: Path | str | None = None,
     *,
     hard_limits: Mapping[str, JointLimit] | None = None,
 ) -> dict[str, JointLimit]:
-    """Load real-hardware overrides and reject anything not strictly within hard limits.
-
-    An empty file or absent ``joint_limits`` mapping means no override. Missing
-    joints are allowed; unknown joints, malformed values, and looser bounds are
-    rejected fail-closed.
-    """
-    hard = dict(hard_limits or _default_hard_limits())
+    """Load hardware overrides and reject anything outside vendor hard limits."""
+    hard = dict(_default_hard_limits() if hard_limits is None else hard_limits)
     override_path = Path(path) if path is not None else _default_override_path()
     if not override_path.is_file():
         raise FileNotFoundError(f"hardware override not found: {override_path}")
@@ -175,11 +281,38 @@ def load_hw_override(
 load_override = load_hw_override
 
 
-def effective_limits(hard: Mapping[str, JointLimit], override: Mapping[str, JointLimit]) -> dict[str, JointLimit]:
-    """Intersect hard and override limits, independently taking the tighter bound."""
+def _validate_override_within_hard(hard: Mapping[str, JointLimit], override: Mapping[str, JointLimit]) -> None:
     unknown = set(override) - set(hard)
     if unknown:
         raise ValueError(f"override contains unknown joints: {sorted(unknown)}")
+    for joint, candidate in override.items():
+        if not isinstance(candidate, JointLimit):
+            raise ValueError(f"override limit for {joint} must be JointLimit")
+        values = (
+            candidate.min_position,
+            candidate.max_position,
+            candidate.max_velocity,
+            candidate.max_effort,
+        )
+        for value in values:
+            _number(value, f"override limit for {joint}")
+        if candidate.min_position > candidate.max_position:
+            raise ValueError(f"override limit for {joint} has min_position > max_position")
+        if candidate.max_velocity < 0 or candidate.max_effort < 0:
+            raise ValueError(f"override limit for {joint} has a negative magnitude")
+        base = hard[joint]
+        if (
+            candidate.min_position < base.min_position
+            or candidate.max_position > base.max_position
+            or candidate.max_velocity > base.max_velocity
+            or candidate.max_effort > base.max_effort
+        ):
+            raise ValueError(f"override limit for {joint} is looser than the hard limit")
+
+
+def effective_limits(hard: Mapping[str, JointLimit], override: Mapping[str, JointLimit]) -> dict[str, JointLimit]:
+    """Intersect hard and override limits, independently taking tighter bounds."""
+    _validate_override_within_hard(hard, override)
     return {
         joint: JointLimit(
             min_position=max(base.min_position, override.get(joint, base).min_position),
@@ -191,22 +324,539 @@ def effective_limits(hard: Mapping[str, JointLimit], override: Mapping[str, Join
     }
 
 
+def _policy_from_mapping(raw: Mapping[str, Any]) -> PreflightPolicy:
+    expected = {"version", "limit_epsilon", "max_duration_s", "max_start_state_delta_rad"}
+    if set(raw) != expected:
+        missing = sorted(expected - set(raw))
+        unknown = sorted(set(raw) - expected)
+        raise ValueError(f"policy fields mismatch; missing={missing}, unknown={unknown}")
+    version = raw["version"]
+    if not isinstance(version, str) or not version:
+        raise ValueError("policy version must be a non-empty string")
+    return PreflightPolicy(
+        version=version,
+        limit_epsilon=_number(raw["limit_epsilon"], "limit_epsilon"),
+        max_duration_s=_number(raw["max_duration_s"], "max_duration_s"),
+        max_start_state_delta_rad=_number(raw["max_start_state_delta_rad"], "max_start_state_delta_rad"),
+    )
+
+
+def _duration_threshold_ns(seconds: float) -> int:
+    try:
+        nanoseconds = Decimal(str(seconds)) * _NANOSECONDS_PER_SECOND
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError("duration must be exactly representable in nanoseconds") from exc
+    if nanoseconds != nanoseconds.to_integral_value():
+        raise ValueError("duration must be exactly representable in nanoseconds")
+    return int(nanoseconds)
+
+
+def _validate_policy(policy: PreflightPolicy) -> PreflightPolicy:
+    if not isinstance(policy, PreflightPolicy):
+        raise ValueError("policy must be PreflightPolicy or a policy mapping")
+    if not isinstance(policy.version, str) or not policy.version:
+        raise ValueError("policy version must be a non-empty string")
+    epsilon = _number(policy.limit_epsilon, "limit_epsilon")
+    duration = _number(policy.max_duration_s, "max_duration_s")
+    start_delta = _number(policy.max_start_state_delta_rad, "max_start_state_delta_rad")
+    if epsilon < 0:
+        raise ValueError("limit_epsilon must be non-negative")
+    if duration <= 0 or start_delta <= 0:
+        raise ValueError("duration and start-state delta must be positive")
+    _duration_threshold_ns(duration)
+    return PreflightPolicy(policy.version, epsilon, duration, start_delta)
+
+
+def load_preflight_policy(path: Path | str | None = None) -> PreflightPolicy:
+    """Load and strictly validate the versioned preflight policy file."""
+    policy_path = Path(path) if path is not None else _default_policy_path()
+    try:
+        data = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+        if not isinstance(data, Mapping) or set(data) != {"trajectory_preflight"}:
+            raise ValueError("policy root must contain only trajectory_preflight")
+        raw = data["trajectory_preflight"]
+        if not isinstance(raw, Mapping):
+            raise ValueError("trajectory_preflight must be a mapping")
+        return _validate_policy(_policy_from_mapping(raw))
+    except PreflightConfigurationError:
+        raise
+    except (OSError, TypeError, ValueError, yaml.YAMLError) as exc:
+        raise PreflightConfigurationError(ConfigurationCode.INVALID_POLICY, str(exc)) from exc
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _limit_payload(expected: tuple[str, ...], limits: Mapping[str, JointLimit]) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "joint_limits": [
+            {
+                "joint": joint,
+                "min_position": float(limits[joint].min_position).hex(),
+                "max_position": float(limits[joint].max_position).hex(),
+                "max_velocity": float(limits[joint].max_velocity).hex(),
+                "max_effort": float(limits[joint].max_effort).hex(),
+            }
+            for joint in expected
+        ],
+    }
+
+
+def _context_hashes(
+    expected: tuple[str, ...], limits: Mapping[str, JointLimit], policy: PreflightPolicy
+) -> tuple[str, str]:
+    limits_hash = _sha256(_canonical_json_bytes(_limit_payload(expected, limits)))
+    context_payload = {
+        "schema_version": "1",
+        "expected_joint_names": list(expected),
+        "effective_limits_sha256": limits_hash,
+        "policy": {
+            "version": policy.version,
+            "limit_epsilon": policy.limit_epsilon.hex(),
+            "max_duration_s": policy.max_duration_s.hex(),
+            "max_start_state_delta_rad": policy.max_start_state_delta_rad.hex(),
+        },
+    }
+    return limits_hash, _sha256(_canonical_json_bytes(context_payload))
+
+
+def _validate_limits(expected: tuple[str, ...], limits: Mapping[str, JointLimit], epsilon: float) -> None:
+    if not expected or any(not isinstance(joint, str) or not joint for joint in expected):
+        raise ValueError("expected joint names must be non-empty strings")
+    if len(set(expected)) != len(expected):
+        raise ValueError("expected joint names contain duplicates")
+    if set(limits) != set(expected):
+        raise ValueError("effective limits must contain exactly the expected joints")
+    for joint in expected:
+        limit = limits[joint]
+        if not isinstance(limit, JointLimit):
+            raise ValueError(f"limit for {joint} must be JointLimit")
+        values = (limit.min_position, limit.max_position, limit.max_velocity, limit.max_effort)
+        for value in values:
+            _number(value, f"limit for {joint}")
+        if limit.min_position > limit.max_position or limit.max_velocity < 0 or limit.max_effort < 0:
+            raise ValueError(f"limit for {joint} has invalid bounds")
+        if limit.min_position + epsilon > limit.max_position - epsilon:
+            raise ValueError(f"limit epsilon collapses the position range for {joint}")
+
+
+def build_preflight_context(
+    *,
+    policy: PreflightPolicy | Mapping[str, Any] | None = None,
+    expected_joint_names: Sequence[str] | None = None,
+    hard_limits: Mapping[str, JointLimit] | None = None,
+    override_limits: Mapping[str, JointLimit] | None = None,
+) -> PreflightContext:
+    """Build an immutable readiness snapshot from controlled or explicit inputs."""
+    try:
+        if policy is None:
+            validated_policy = load_preflight_policy()
+        else:
+            candidate = _policy_from_mapping(policy) if isinstance(policy, Mapping) else policy
+            validated_policy = _validate_policy(candidate)
+    except PreflightConfigurationError:
+        raise
+    except (TypeError, ValueError) as exc:
+        raise PreflightConfigurationError(ConfigurationCode.INVALID_POLICY, str(exc)) from exc
+
+    try:
+        arm = None
+        if expected_joint_names is None or hard_limits is None:
+            arm = load_arm_config()
+        expected = tuple(arm.joints if expected_joint_names is None else expected_joint_names)
+        hard = load_hard_limits(arm.vendor_description_pkg, arm.ur_type) if hard_limits is None else dict(hard_limits)
+        override = load_hw_override(hard_limits=hard) if override_limits is None else dict(override_limits)
+        combined = effective_limits(hard, override)
+        _validate_limits(expected, combined, validated_policy.limit_epsilon)
+        ordered = {joint: combined[joint] for joint in expected}
+        limits_hash, context_hash = _context_hashes(expected, ordered, validated_policy)
+        return PreflightContext(
+            expected_joint_names=expected,
+            effective_limits=tuple(ordered.items()),
+            policy=validated_policy,
+            effective_limits_sha256=limits_hash,
+            context_sha256=context_hash,
+        )
+    except PreflightConfigurationError:
+        raise
+    except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+        raise PreflightConfigurationError(ConfigurationCode.INVALID_LIMITS, str(exc)) from exc
+
+
+def _validated_context(context: PreflightContext) -> tuple[tuple[str, ...], dict[str, JointLimit], PreflightPolicy]:
+    if not isinstance(context, PreflightContext):
+        raise PreflightConfigurationError(ConfigurationCode.INVALID_LIMITS, "context must be a PreflightContext")
+    try:
+        policy = _validate_policy(context.policy)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise PreflightConfigurationError(ConfigurationCode.INVALID_POLICY, str(exc)) from exc
+    try:
+        expected = tuple(context.expected_joint_names)
+        limits = dict(context.effective_limits)
+        if len(limits) != len(context.effective_limits):
+            raise ValueError("effective limits contain duplicate joints")
+        _validate_limits(expected, limits, policy.limit_epsilon)
+        limits_hash, context_hash = _context_hashes(expected, limits, policy)
+        if limits_hash != context.effective_limits_sha256 or context_hash != context.context_sha256:
+            raise ValueError("context hashes do not match context contents")
+        return expected, limits, policy
+    except (TypeError, ValueError) as exc:
+        raise PreflightConfigurationError(ConfigurationCode.INVALID_LIMITS, str(exc)) from exc
+
+
 def _field(obj: Any, name: str, default: Any = None) -> Any:
-    if isinstance(obj, Mapping):
-        return obj.get(name, default)
-    return getattr(obj, name, default)
+    try:
+        if isinstance(obj, Mapping):
+            return obj.get(name, default)
+        return getattr(obj, name, default)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return default
 
 
-def _seconds(value: Any) -> float:
-    if isinstance(value, int | float) and not isinstance(value, bool):
-        return float(value)
-    if isinstance(value, Mapping):
-        return float(value.get("sec", 0)) + float(value.get("nanosec", 0)) / 1e9
-    return float(getattr(value, "sec", 0)) + float(getattr(value, "nanosec", 0)) / 1e9
+def _array(value: Any) -> tuple[Any, ...] | None:
+    if value is None:
+        return ()
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        try:
+            return tuple(value)
+        except (TypeError, ValueError):
+            return None
+    return None
 
 
-def _bad(kind: str, message: str, **kwargs: Any) -> Violation:
+def _bad(kind: ReasonCode, message: str, **kwargs: Any) -> Violation:
     return Violation(kind=kind, message=message, **kwargs)
+
+
+def _numeric_array(values: tuple[Any, ...], index: int) -> tuple[float, ...] | Violation:
+    result: list[float] = []
+    for raw in values:
+        if isinstance(raw, bool):
+            return _bad(ReasonCode.NON_FINITE, "trajectory contains a non-numeric value", point_index=index)
+        try:
+            value = float(raw)
+        except (OverflowError, TypeError, ValueError):
+            return _bad(ReasonCode.NON_FINITE, "trajectory contains a non-numeric value", point_index=index)
+        if not math.isfinite(value):
+            return _bad(ReasonCode.NON_FINITE, "trajectory contains NaN or infinity", point_index=index)
+        result.append(value)
+    return tuple(result)
+
+
+def _structured_time_ns(sec: Any, nanosec: Any, index: int) -> int | Violation:
+    if (
+        isinstance(sec, bool)
+        or isinstance(nanosec, bool)
+        or not isinstance(sec, int)
+        or not isinstance(nanosec, int)
+        or not (_MIN_DURATION_SEC <= sec <= _MAX_DURATION_SEC)
+        or not (0 <= nanosec < _NANOSECONDS_PER_SECOND)
+    ):
+        return _bad(ReasonCode.TIMESTAMP_MALFORMED, "duration sec/nanosec fields are malformed", point_index=index)
+    return sec * _NANOSECONDS_PER_SECOND + nanosec
+
+
+def _time_ns(raw: Any, index: int) -> int | Violation:
+    if raw is _MISSING or isinstance(raw, bool):
+        return _bad(ReasonCode.TIMESTAMP_MALFORMED, "time_from_start is missing or malformed", point_index=index)
+    if isinstance(raw, int | float):
+        if isinstance(raw, float) and not math.isfinite(raw):
+            return _bad(ReasonCode.NON_FINITE, "trajectory contains NaN or infinity", point_index=index)
+        try:
+            nanoseconds = Decimal(str(raw)) * _NANOSECONDS_PER_SECOND
+        except (InvalidOperation, ValueError):
+            return _bad(ReasonCode.TIMESTAMP_MALFORMED, "time is not representable in nanoseconds", point_index=index)
+        if nanoseconds != nanoseconds.to_integral_value():
+            return _bad(ReasonCode.TIMESTAMP_MALFORMED, "time is not representable in nanoseconds", point_index=index)
+        return int(nanoseconds)
+    if isinstance(raw, Mapping):
+        if "sec" not in raw or "nanosec" not in raw:
+            return _bad(ReasonCode.TIMESTAMP_MALFORMED, "duration requires sec and nanosec", point_index=index)
+        return _structured_time_ns(raw["sec"], raw["nanosec"], index)
+    sec = getattr(raw, "sec", _MISSING)
+    nanosec = getattr(raw, "nanosec", _MISSING)
+    if sec is _MISSING or nanosec is _MISSING:
+        return _bad(ReasonCode.TIMESTAMP_MALFORMED, "duration requires sec and nanosec", point_index=index)
+    return _structured_time_ns(sec, nanosec, index)
+
+
+def _seconds_for_violation(timestamp_ns: int) -> float | None:
+    try:
+        return timestamp_ns / _NANOSECONDS_PER_SECOND
+    except OverflowError:
+        return None
+
+
+def _trajectory_bytes(snapshot: NormalizedTrajectory) -> bytes:
+    return _canonical_json_bytes(
+        {
+            "schema_version": "1",
+            "joint_names": list(snapshot.joint_names),
+            "points": [
+                {
+                    "positions": [value.hex() for value in point.positions],
+                    "velocities": [value.hex() for value in point.velocities],
+                    "accelerations": [value.hex() for value in point.accelerations],
+                    "effort": [value.hex() for value in point.effort],
+                    "time_from_start_ns": point.time_from_start_ns,
+                }
+                for point in snapshot.points
+            ],
+        }
+    )
+
+
+def _accept(snapshot: NormalizedTrajectory, context: PreflightContext) -> AcceptedTrajectory:
+    canonical = _trajectory_bytes(snapshot)
+    accepted = object.__new__(AcceptedTrajectory)
+    object.__setattr__(accepted, "snapshot", snapshot)
+    object.__setattr__(accepted, "canonical_bytes", canonical)
+    object.__setattr__(accepted, "trajectory_sha256", _sha256(canonical))
+    object.__setattr__(accepted, "policy_version", context.policy.version)
+    object.__setattr__(accepted, "effective_limits_sha256", context.effective_limits_sha256)
+    object.__setattr__(accepted, "context_sha256", context.context_sha256)
+    return accepted
+
+
+def preflight_trajectory(
+    traj: Any,
+    current_joint_positions: Mapping[str, float],
+    *,
+    context: PreflightContext,
+) -> AcceptedTrajectory | Violation:
+    """Return an immutable accepted snapshot or the first stable violation."""
+    expected, limits, policy = _validated_context(context)
+
+    raw_names = _array(_field(traj, "joint_names", _MISSING))
+    if raw_names is None or not raw_names or any(not isinstance(name, str) or not name for name in raw_names):
+        return _bad(ReasonCode.JOINT_NAMES, "joint_names must be non-empty strings")
+    names = tuple(raw_names)
+    if len(names) != len(set(names)):
+        return _bad(ReasonCode.JOINT_NAMES, "joint_names contains duplicates")
+    if set(names) != set(expected):
+        return _bad(ReasonCode.JOINT_NAMES, "joint_names must contain exactly all controlled joints")
+    if names != expected:
+        return _bad(ReasonCode.JOINT_ORDER_MISMATCH, "joint_names order does not match the controlled order")
+
+    if not isinstance(current_joint_positions, Mapping) or set(current_joint_positions) != set(expected):
+        return _bad(ReasonCode.CURRENT_STATE, "current state must contain exactly all controlled joints")
+    current: dict[str, float] = {}
+    epsilon = policy.limit_epsilon
+    for joint in expected:
+        raw = current_joint_positions[joint]
+        if isinstance(raw, bool):
+            return _bad(ReasonCode.NON_FINITE, f"current state for {joint} is not numeric", joint=joint)
+        try:
+            value = float(raw)
+        except (OverflowError, TypeError, ValueError):
+            return _bad(ReasonCode.NON_FINITE, f"current state for {joint} is not numeric", joint=joint)
+        if not math.isfinite(value):
+            return _bad(ReasonCode.NON_FINITE, f"current state for {joint} is not finite", joint=joint, value=value)
+        current[joint] = value
+
+    for joint in expected:
+        value = current[joint]
+        limit = limits[joint]
+        lo, hi = limit.min_position + epsilon, limit.max_position - epsilon
+        if value < lo or value > hi:
+            return _bad(
+                ReasonCode.CURRENT_POSITION,
+                f"current state for {joint} is outside limits",
+                joint=joint,
+                value=value,
+                bound=lo if value < lo else hi,
+            )
+
+    raw_points = _array(_field(traj, "points", _MISSING))
+    if raw_points is None or not raw_points:
+        return _bad(ReasonCode.POINTS, "trajectory points must be non-empty")
+    raw_arrays: list[dict[str, tuple[Any, ...]]] = []
+    size = len(expected)
+    for index, point in enumerate(raw_points):
+        fields: dict[str, tuple[Any, ...]] = {}
+        for field_name in ("positions", "velocities", "accelerations", "effort"):
+            values = _array(_field(point, field_name, _MISSING if field_name == "positions" else ()))
+            valid_lengths = (size,) if field_name == "positions" else (0, size)
+            if values is None or len(values) not in valid_lengths:
+                length_requirement = (
+                    "match joint_names" if field_name == "positions" else "be zero or match joint_names"
+                )
+                return _bad(
+                    ReasonCode.ARRAY_LENGTH,
+                    f"{field_name} length must {length_requirement}",
+                    point_index=index,
+                )
+            fields[field_name] = values
+        raw_arrays.append(fields)
+
+    parsed_arrays: list[dict[str, tuple[float, ...]]] = []
+    for index, fields in enumerate(raw_arrays):
+        parsed: dict[str, tuple[float, ...]] = {}
+        for field_name, values in fields.items():
+            numeric = _numeric_array(values, index)
+            if isinstance(numeric, Violation):
+                return numeric
+            parsed[field_name] = numeric
+        parsed_arrays.append(parsed)
+
+    for index, point in enumerate(raw_points):
+        raw_time = _field(point, "time_from_start", _MISSING)
+        if isinstance(raw_time, float) and not math.isfinite(raw_time):
+            return _bad(ReasonCode.NON_FINITE, "trajectory contains NaN or infinity", point_index=index)
+
+    normalized_points: list[NormalizedPoint] = []
+    for index, (point, parsed) in enumerate(zip(raw_points, parsed_arrays, strict=True)):
+        timestamp = _time_ns(_field(point, "time_from_start", _MISSING), index)
+        if isinstance(timestamp, Violation):
+            return timestamp
+        normalized_points.append(
+            NormalizedPoint(
+                positions=parsed["positions"],
+                velocities=parsed["velocities"],
+                accelerations=parsed["accelerations"],
+                effort=parsed["effort"],
+                time_from_start_ns=timestamp,
+            )
+        )
+
+    for index, point in enumerate(normalized_points):
+        timestamp = point.time_from_start_ns
+        if timestamp < 0:
+            return _bad(
+                ReasonCode.TIME,
+                "time_from_start must be non-negative",
+                value=_seconds_for_violation(timestamp),
+                bound=0.0,
+                point_index=index,
+            )
+
+    previous_ns = normalized_points[0].time_from_start_ns
+    for index, point in enumerate(normalized_points[1:], start=1):
+        timestamp = point.time_from_start_ns
+        if timestamp <= previous_ns:
+            return _bad(
+                ReasonCode.TIME,
+                "time_from_start must be strictly increasing",
+                value=_seconds_for_violation(timestamp),
+                bound=_seconds_for_violation(previous_ns),
+                point_index=index,
+            )
+        previous_ns = timestamp
+
+    max_duration_ns = _duration_threshold_ns(policy.max_duration_s)
+    final_index = len(normalized_points) - 1
+    final_timestamp = normalized_points[final_index].time_from_start_ns
+    if final_timestamp > max_duration_ns:
+        return _bad(
+            ReasonCode.DURATION_EXCEEDED,
+            "trajectory duration exceeds policy",
+            value=_seconds_for_violation(final_timestamp),
+            bound=policy.max_duration_s,
+            point_index=final_index,
+        )
+
+    for index, point in enumerate(normalized_points):
+        for offset, joint in enumerate(expected):
+            limit = limits[joint]
+            position = point.positions[offset]
+            lo = limit.min_position + epsilon
+            hi = limit.max_position - epsilon
+            vmax = max(0.0, limit.max_velocity - epsilon)
+            emax = max(0.0, limit.max_effort - epsilon)
+            if position < lo or position > hi:
+                return _bad(
+                    ReasonCode.POSITION,
+                    f"{joint} position is outside limits",
+                    joint=joint,
+                    value=position,
+                    bound=lo if position < lo else hi,
+                    point_index=index,
+                )
+            if point.velocities and abs(point.velocities[offset]) > vmax:
+                return _bad(
+                    ReasonCode.VELOCITY,
+                    f"{joint} velocity exceeds limit",
+                    joint=joint,
+                    value=point.velocities[offset],
+                    bound=vmax,
+                    point_index=index,
+                )
+            if point.effort and abs(point.effort[offset]) > emax:
+                return _bad(
+                    ReasonCode.EFFORT,
+                    f"{joint} effort exceeds limit",
+                    joint=joint,
+                    value=point.effort[offset],
+                    bound=emax,
+                    point_index=index,
+                )
+
+    first = normalized_points[0]
+    for offset, joint in enumerate(expected):
+        delta = abs(first.positions[offset] - current[joint])
+        if first.time_from_start_ns == 0:
+            if delta > epsilon:
+                return _bad(
+                    ReasonCode.INITIAL_POSITION,
+                    f"{joint} first point at t=0 differs from current state",
+                    joint=joint,
+                    value=first.positions[offset],
+                    bound=current[joint],
+                    point_index=0,
+                )
+        elif delta > policy.max_start_state_delta_rad:
+            return _bad(
+                ReasonCode.START_STATE_DISCONTINUITY,
+                f"{joint} first point is too far from current state",
+                joint=joint,
+                value=delta,
+                bound=policy.max_start_state_delta_rad,
+                point_index=0,
+            )
+
+    previous_positions: tuple[float, ...] | None = None
+    previous_time_ns: int | None = None
+    for index, point in enumerate(normalized_points):
+        for offset, joint in enumerate(expected):
+            if previous_positions is None:
+                if point.time_from_start_ns == 0:
+                    continue
+                start = current[joint]
+                delta = abs(point.positions[offset] - start)
+                dt_ns = point.time_from_start_ns
+                message = f"{joint} current-to-first mean velocity exceeds limit"
+            else:
+                delta = abs(point.positions[offset] - previous_positions[offset])
+                dt_ns = point.time_from_start_ns - previous_time_ns
+                message = f"{joint} segment mean velocity exceeds limit"
+            mean_velocity = delta * _NANOSECONDS_PER_SECOND / dt_ns
+            vmax = max(0.0, limits[joint].max_velocity - epsilon)
+            if mean_velocity > vmax:
+                return _bad(
+                    ReasonCode.SEGMENT_VELOCITY,
+                    message,
+                    joint=joint,
+                    value=mean_velocity,
+                    bound=vmax,
+                    point_index=index,
+                )
+        previous_positions = point.positions
+        previous_time_ns = point.time_from_start_ns
+
+    snapshot = NormalizedTrajectory(joint_names=expected, points=tuple(normalized_points))
+    return _accept(snapshot, context)
 
 
 def check_trajectory(
@@ -216,160 +866,23 @@ def check_trajectory(
     *,
     limit_epsilon: float = DEFAULT_LIMIT_EPSILON,
 ) -> Violation | None:
-    """Return the first fail-closed violation, or ``None``; never mutate ``traj``.
-
-    ``traj`` may be a ROS-like object or a plain mapping with ``joint_names`` and
-    ``points``. Explicit limits make tests and later adapters deterministic; when
-    omitted, the shipped vendor hard limits and hardware override are loaded.
-    """
-    if not math.isfinite(limit_epsilon) or limit_epsilon < 0:
+    """Compatibility wrapper returning ``Violation | None`` without mutation."""
+    try:
+        epsilon = _number(limit_epsilon, "limit_epsilon")
+    except ValueError as exc:
+        raise ValueError("limit_epsilon must be finite and non-negative") from exc
+    if epsilon < 0:
         raise ValueError("limit_epsilon must be finite and non-negative")
+    policy = replace(load_preflight_policy(), limit_epsilon=epsilon)
     if limits is None:
-        hard = _default_hard_limits()
-        limits = effective_limits(hard, load_hw_override(hard_limits=hard))
-    limits = dict(limits)
-    names = list(_field(traj, "joint_names", []) or [])
-    if not names:
-        return _bad("joint_names", "joint_names must be non-empty")
-    if len(names) != len(set(names)):
-        return _bad("joint_names", "joint_names contains duplicates")
-    unknown = set(names) - set(limits)
-    if unknown:
-        return _bad("joint_names", f"unknown joints: {sorted(unknown)}")
-    if set(names) != set(limits):
-        return _bad("joint_names", "partial joint goals are not allowed")
-    if set(current_joint_positions) != set(limits):
-        return _bad("current_state", "current state must contain exactly all controlled joints")
-    current: dict[str, float] = {}
-    for joint, raw in current_joint_positions.items():
-        try:
-            value = float(raw)
-        except (TypeError, ValueError):
-            return _bad("non_finite", f"current state for {joint} is not numeric", joint=joint)
-        if not math.isfinite(value):
-            return _bad("non_finite", f"current state for {joint} is not finite", joint=joint, value=value)
-        lim = limits[joint]
-        lo, hi = lim.min_position + limit_epsilon, lim.max_position - limit_epsilon
-        if value < lo or value > hi:
-            return _bad(
-                "current_position",
-                f"current state for {joint} is outside limits",
-                joint=joint,
-                value=value,
-                bound=lo if value < lo else hi,
-            )
-        current[joint] = value
-
-    points = list(_field(traj, "points", []) or [])
-    if not points:
-        return _bad("points", "trajectory points must be non-empty")
-    previous_time: float | None = None
-    previous_positions: Sequence[float] | None = None
-    n = len(names)
-    for index, point in enumerate(points):
-        positions = list(_field(point, "positions", []) or [])
-        if len(positions) != n:
-            return _bad("array_length", "positions length must match joint_names", point_index=index)
-        arrays = {
-            "velocities": list(_field(point, "velocities", []) or []),
-            "accelerations": list(_field(point, "accelerations", []) or []),
-            "effort": list(_field(point, "effort", []) or []),
-        }
-        for field_name, values in arrays.items():
-            if len(values) not in (0, n):
-                return _bad("array_length", f"{field_name} length must be zero or match joint_names", point_index=index)
-        try:
-            time_from_start = _seconds(_field(point, "time_from_start", 0.0))
-            numeric_positions = [float(v) for v in positions]
-            numeric_arrays = {key: [float(v) for v in values] for key, values in arrays.items()}
-        except (TypeError, ValueError):
-            return _bad("non_finite", "trajectory contains a non-numeric value", point_index=index)
-        all_values = [time_from_start, *numeric_positions]
-        for values in numeric_arrays.values():
-            all_values.extend(values)
-        if not all(math.isfinite(v) for v in all_values):
-            return _bad("non_finite", "trajectory contains NaN or infinity", point_index=index)
-        if time_from_start < 0:
-            return _bad(
-                "time", "time_from_start must be non-negative", value=time_from_start, bound=0.0, point_index=index
-            )
-        if previous_time is not None and time_from_start <= previous_time:
-            return _bad(
-                "time",
-                "time_from_start must be strictly increasing",
-                value=time_from_start,
-                bound=previous_time,
-                point_index=index,
-            )
-
-        for offset, joint in enumerate(names):
-            lim = limits[joint]
-            pos = numeric_positions[offset]
-            lo = lim.min_position + limit_epsilon
-            hi = lim.max_position - limit_epsilon
-            vmax = max(0.0, lim.max_velocity - limit_epsilon)
-            emax = max(0.0, lim.max_effort - limit_epsilon)
-            if pos < lo or pos > hi:
-                return _bad(
-                    "position",
-                    f"{joint} position is outside limits",
-                    joint=joint,
-                    value=pos,
-                    bound=lo if pos < lo else hi,
-                    point_index=index,
-                )
-            if numeric_arrays["velocities"] and abs(numeric_arrays["velocities"][offset]) > vmax:
-                return _bad(
-                    "velocity",
-                    f"{joint} velocity exceeds limit",
-                    joint=joint,
-                    value=numeric_arrays["velocities"][offset],
-                    bound=vmax,
-                    point_index=index,
-                )
-            if numeric_arrays["effort"] and abs(numeric_arrays["effort"][offset]) > emax:
-                return _bad(
-                    "effort",
-                    f"{joint} effort exceeds limit",
-                    joint=joint,
-                    value=numeric_arrays["effort"][offset],
-                    bound=emax,
-                    point_index=index,
-                )
-            if previous_positions is None:
-                start = current[joint]
-                dt = time_from_start
-                if dt == 0.0:
-                    if abs(pos - start) > limit_epsilon:
-                        return _bad(
-                            "initial_position",
-                            f"{joint} first point at t=0 differs from current state",
-                            joint=joint,
-                            value=pos,
-                            bound=start,
-                            point_index=index,
-                        )
-                elif abs(pos - start) / dt > vmax:
-                    return _bad(
-                        "segment_velocity",
-                        f"{joint} current-to-first mean velocity exceeds limit",
-                        joint=joint,
-                        value=abs(pos - start) / dt,
-                        bound=vmax,
-                        point_index=index,
-                    )
-            else:
-                dt = time_from_start - previous_time  # positive by the check above
-                mean_velocity = abs(pos - previous_positions[offset]) / dt
-                if mean_velocity > vmax:
-                    return _bad(
-                        "segment_velocity",
-                        f"{joint} segment mean velocity exceeds limit",
-                        joint=joint,
-                        value=mean_velocity,
-                        bound=vmax,
-                        point_index=index,
-                    )
-        previous_time = time_from_start
-        previous_positions = numeric_positions
-    return None
+        context = build_preflight_context(policy=policy)
+    else:
+        supplied_limits = dict(limits)
+        context = build_preflight_context(
+            policy=policy,
+            expected_joint_names=tuple(supplied_limits),
+            hard_limits=supplied_limits,
+            override_limits={},
+        )
+    result = preflight_trajectory(traj, current_joint_positions, context=context)
+    return result if isinstance(result, Violation) else None

--- a/robot/control/workbench_motion/workbench_motion/joint_limits.py
+++ b/robot/control/workbench_motion/workbench_motion/joint_limits.py
@@ -570,6 +570,8 @@ def _time_ns(raw: Any, index: int) -> int | Violation:
     if raw is _MISSING or isinstance(raw, bool):
         return _bad(ReasonCode.TIMESTAMP_MALFORMED, "time_from_start is missing or malformed", point_index=index)
     if isinstance(raw, int | float):
+        if isinstance(raw, int):
+            return raw * _NANOSECONDS_PER_SECOND
         if isinstance(raw, float) and not math.isfinite(raw):
             return _bad(ReasonCode.NON_FINITE, "trajectory contains NaN or infinity", point_index=index)
         try:

--- a/robot/control/workbench_motion/workbench_motion/joint_limits.py
+++ b/robot/control/workbench_motion/workbench_motion/joint_limits.py
@@ -139,10 +139,7 @@ class _LimitsLoader(yaml.SafeLoader):
 
 
 def _degrees(loader: yaml.SafeLoader, node: yaml.Node) -> float:
-    try:
-        return math.radians(float(loader.construct_scalar(node)))
-    except OverflowError as exc:
-        raise ValueError("degree value must be a finite number") from exc
+    return math.radians(float(loader.construct_scalar(node)))
 
 
 _LimitsLoader.add_constructor("!degrees", _degrees)
@@ -478,6 +475,7 @@ def build_preflight_context(
         expected = tuple(arm.joints if expected_joint_names is None else expected_joint_names)
         hard = load_hard_limits(arm.vendor_description_pkg, arm.ur_type) if hard_limits is None else dict(hard_limits)
         override = load_hw_override(hard_limits=hard) if override_limits is None else dict(override_limits)
+        _validate_limits(expected, hard, validated_policy.limit_epsilon)
         combined = effective_limits(hard, override)
         _validate_limits(expected, combined, validated_policy.limit_epsilon)
         ordered = {joint: combined[joint] for joint in expected}

--- a/robot/control/workbench_motion/workbench_motion/phase2_probe.py
+++ b/robot/control/workbench_motion/workbench_motion/phase2_probe.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 import time
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from itertools import pairwise
 from pathlib import Path
 from typing import Any, Protocol
@@ -358,7 +358,16 @@ def _snapshot_dict(snapshot: JointSnapshot) -> dict[str, Any]:
 
 
 def _violation_dict(violation: Violation | None) -> dict[str, Any] | None:
-    return asdict(violation) if violation is not None else None
+    if violation is None:
+        return None
+    return {
+        "kind": violation.kind.value,
+        "message": violation.message,
+        "joint": violation.joint,
+        "value": violation.value,
+        "bound": violation.bound,
+        "point_index": violation.point_index,
+    }
 
 
 def _requested_limit_excess(


### PR DESCRIPTION
## Related Issue
Closes #57
## What changed
  - 新增无 ROS、fail-closed、确定性的轨迹安全预检器。
  - 保留旧版 `check_trajectory` API 和六字段 `Violation` 证据格式。
  - 新增不可变的 `AcceptedTrajectory` 快照、确定性规范化字节和 SHA-256 证据。
  - 固化关节集合与顺序、有限数值、时间戳、总时长、位置、速度、effort、起始状态和段速度校验。
  - 配置错误统一返回 `invalid_policy` 或 `invalid_limits`。
  - 在应用 hardware override 前先独立校验 hard limits，避免非法 hard limit 被正常 override 掩盖。
  - 恢复原始 `_degrees()` 实现，仅由 `_number()` 负责超大数字的稳定错误归一化。
  - 增加 policy、hard limit、override 极大整数以及 hard limit 被 override 掩盖场景的回归测试。
## Interfaces affected
  - 未修改 `interfaces/`、JSON Schema、`libs/contracts/`、services、firmware、ROS dispatch 或 controller execution。
  - 旧版 `check_trajectory` 签名保持兼容。
  - 旧版六字段 `Violation` 证据格式保持不变。
  - `preflight_trajectory(..., context=...)` 是唯一正式的轨迹校验实现。
  - 下游执行只能接收 `AcceptedTrajectory`。
## Tests and commands
  以下检查均已通过：

  - `make lint`
  - Motion 全量测试：`237 passed`
  - Motion 目标测试：`164 passed`
  - 干净 `git archive` 导出树中的 `make test`：`550 passed`
  - `make contract`
  - `make scenario-check`
  - `make context-check`
  - `make demo-scripted`
  - Task Packet 普通校验
  - Task Packet `--base origin/main` 校验

  额外回归覆盖：

  - 每个配置关节的位置、速度和 effort 边界
  - policy、hard limit、override 的极大整数
  - 非法 hard limit 被正常 override 掩盖
  - scalar 和 structured timestamp 边界
  - 总时长、起始状态和段速度边界
  - 固定首错顺序
  - 输入不可变和 accepted snapshot 隔离
  - trajectory 与 context hash 敏感性
  - legacy 六字段 evidence 兼容性
## Evidence
  - Task Packet：`docs/task_packets/motion-057-trajectory-preflight.json`
  - 基线：`origin/main`，提交 `1044c843`
  - 本 PR 包含以下提交：
    - `d1d00e1 feat(motion): add deterministic trajectory preflight`
    - `e3043cd fix(motion): validate hard limits before overrides`
  - 已在干净 `git archive` 导出树中重复执行根测试，排除了本地 `.venv` 和日志符号链接等环境干扰。
## Risks and rollback
  - 本变更不会下发轨迹，也不会执行真实机器人运动。
  - 运行时 TOCTOU 重检、controller materialization、碰撞 gating 和 failed-dispatch 映射仍属于下游工作。
  - 如需回滚，可依次回滚提交 `e3043cd` 和 `d1d00e1`。
## Checklist

  - [x] I changed only approved paths.
  - [x] Tests and contract checks pass.
  - [x] I covered normal and failure behavior.
  - [x] I updated examples/docs when an interface changed.
  - [x] I did not add secrets, private data or unreviewed assets.
