### PR TITLE
feat(app): add software performance regression gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ PYTHON ?= python3
 
 .PHONY: bootstrap lint fmt test contract scenario-check golden-check evaluation-check evaluation-scripted context-check \
 	dashboard-test dashboard demo demo-scripted demo-offline demo-model model-provision performance-test benchmark-startup \
-	benchmark-resources offline-integration docs task-check check container-smoke sim sim-doctor sim-list sim-run
+	benchmark-resources performance-regression-test offline-integration docs task-check check container-smoke \
+	sim sim-doctor sim-list sim-run
 
 bootstrap:
 	$(PYTHON) -m pip install --upgrade pip
@@ -79,6 +80,9 @@ benchmark-startup:
 
 benchmark-resources:
 	$(PYTHON) tools/scripts/benchmark_resources.py --project workbench-startup-benchmark --output runs/performance/resources.json
+
+performance-regression-test:
+	$(PYTHON) -m pytest tests/unit/test_performance_regression.py -v
 
 dashboard-test:
 	$(PYTHON) -m unittest tests.unit.test_dashboard_backend -v

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -49,3 +49,9 @@ python tools/scripts/analyze_telemetry.py runs/hardware/run-001.jsonl \
 ```
 
 没有哈希匹配的操作员证明，分析器会拒绝 `source=hardware`，因此测试夹具不能被悄悄当作真实硬件证据。
+
+## 软件性能回归
+
+同环境基线比较、绝对预算和失败关闭规则见
+[`software-regression-gate.md`](software-regression-gate.md)。该门禁只适用于开发主机的
+软件性能，不替代目标板或物理机器人测量。

--- a/docs/performance/software-regression-gate.md
+++ b/docs/performance/software-regression-gate.md
@@ -1,0 +1,53 @@
+# 软件性能回归门禁
+
+LINUX-APP11 使用同一环境中的基线报告和当前报告进行比较。门禁同时检查绝对预算
+和相对退化，任何一项超限都返回非零退出码。它只接受本地软件报告，不接受或推断
+真实硬件性能。
+
+## 采集基线和当前报告
+
+在同一主机、Python 版本和 Compose cache 模式下分别采集基线与当前结果：
+
+```bash
+python tools/scripts/benchmark_startup.py --output runs/performance/baseline/startup.json
+python tools/scripts/benchmark_resources.py \
+  --project workbench-startup-benchmark \
+  --output runs/performance/baseline/resources.json
+python tools/scripts/demo_scripted.py \
+  --iterations 30 \
+  --telemetry runs/performance/baseline/simulation.jsonl
+python tools/scripts/analyze_telemetry.py \
+  runs/performance/baseline/simulation.jsonl \
+  --output runs/performance/baseline/telemetry.json
+```
+
+在代码变更后用相同命令写入 `runs/performance/current/`。资源和 telemetry 报告
+至少需要 5 个样本；正式比较建议保留现有的 30 次 telemetry 运行。
+
+## 执行门禁
+
+```bash
+python tools/scripts/performance_regression.py \
+  --policy docs/performance/software-regression-policy-v1.json \
+  --baseline-startup runs/performance/baseline/startup.json \
+  --current-startup runs/performance/current/startup.json \
+  --baseline-resources runs/performance/baseline/resources.json \
+  --current-resources runs/performance/current/resources.json \
+  --baseline-telemetry runs/performance/baseline/telemetry.json \
+  --current-telemetry runs/performance/current/telemetry.json \
+  --output runs/performance/regression.json
+```
+
+输出中的每项检查包含基线值、当前值、绝对上限和允许的相对退化上限。以下情况
+会失败关闭：
+
+- 报告缺失、schema 版本错误或包含 `NaN`/`Infinity`；
+- 基线与当前的操作系统、Python 版本或启动 cache 模式不一致；
+- 样本数量不足或 P50/P95/max 顺序错误；
+- telemetry 含有 `hardware` 来源；
+- 当前值超过绝对预算或相对退化上限。
+
+策略中的 2 GiB 和 2 CPU 是任务书的软件容器预算，启动和流水线阈值是开发环境
+门禁。结果始终标记为 `local_software`，并明确保留
+`target_hardware_measurement: NOT_EXECUTED`。目标板、真实 ROS/Gazebo 和物理机器人
+必须重新建立各自的可比基线，不能沿用本门禁作为发布证据。

--- a/docs/performance/software-regression-policy-v1.json
+++ b/docs/performance/software-regression-policy-v1.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "evidence_class": "local_software",
+  "required_reports": ["startup", "resources", "telemetry"],
+  "minimum_samples": 5,
+  "metrics": {
+    "startup.container_start_to_health": {
+      "maximum": 10.0,
+      "max_regression_percent": 25.0,
+      "noise_tolerance": 1.0
+    },
+    "startup.container_start_to_ready": {
+      "maximum": 10.0,
+      "max_regression_percent": 25.0,
+      "noise_tolerance": 1.0
+    },
+    "startup.full_stack_clone_to_ready": {
+      "maximum": 120.0,
+      "max_regression_percent": 25.0,
+      "noise_tolerance": 5.0
+    },
+    "resources.cpu_percent_p95_total": {
+      "maximum": 200.0,
+      "max_regression_percent": 25.0,
+      "noise_tolerance": 5.0
+    },
+    "resources.memory_bytes_p95_total": {
+      "maximum": 2147483648,
+      "max_regression_percent": 25.0,
+      "noise_tolerance": 16777216
+    },
+    "telemetry.end_to_end.p95_ms": {
+      "maximum": 50.0,
+      "max_regression_percent": 25.0,
+      "noise_tolerance": 2.0
+    }
+  }
+}

--- a/docs/task_packets/linux-app11-performance-regression.json
+++ b/docs/task_packets/linux-app11-performance-regression.json
@@ -1,0 +1,64 @@
+{
+  "issue": "LINUX-APP11",
+  "human_owner": "Quchaosheng",
+  "objective": "Add a fail-closed local-software performance regression gate with comparable baselines, absolute budgets and machine-readable evidence.",
+  "allowed_paths": [
+    "tools/scripts/performance_regression.py",
+    "tools/scripts/benchmark_startup.py",
+    "tools/scripts/benchmark_resources.py",
+    "tools/scripts/performance_tools.py",
+    "tests/unit/test_performance_regression.py",
+    "tests/unit/test_performance_tools.py",
+    "docs/performance/README.md",
+    "docs/performance/software-regression-gate.md",
+    "docs/performance/software-regression-policy-v1.json",
+    "docs/task_packets/linux-app11-performance-regression.json",
+    "Makefile"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/**"
+  ],
+  "acceptance": [
+    "startup, aggregate container CPU and memory, and simulation end-to-end P95 are compared against a same-environment baseline",
+    "both absolute budgets and relative regression limits must pass",
+    "missing, malformed, non-finite, negative, unordered or undersampled evidence fails closed",
+    "different platform, Python version, machine architecture or startup cache mode reports are rejected as incomparable",
+    "hardware telemetry is rejected and the output marks target hardware and physical validation NOT_EXECUTED",
+    "the command writes a machine-readable report and exits non-zero when any metric fails"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/linux-app11-performance-regression.json",
+    "python3 -m pytest tests/unit/test_performance_regression.py tests/unit/test_performance_tools.py -v",
+    "python3 -m ruff check tools/scripts/performance_regression.py tests/unit/test_performance_regression.py",
+    "python3 -m ruff format --check tools/scripts/performance_regression.py tests/unit/test_performance_regression.py",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "performance regression unit-test output",
+    "passing and failing machine-readable gate reports",
+    "invalid and incomparable evidence rejection assertions",
+    "repository gate output"
+  ],
+  "stop_conditions": [
+    "a threshold requires target-hardware or physical-robot measurement",
+    "reports were not captured on comparable software environments",
+    "a frozen interface, firmware, robot-control or hardware change is required",
+    "local software measurements would be presented as target-hardware or release evidence"
+  ]
+}

--- a/tests/unit/test_performance_regression.py
+++ b/tests/unit/test_performance_regression.py
@@ -4,11 +4,9 @@ import sys
 from pathlib import Path
 
 import pytest
+from performance_regression import PerformanceGateError, evaluate, load_json
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "tools" / "scripts"))
-
-from performance_regression import PerformanceGateError, evaluate, load_json
 
 
 ENVIRONMENT = {"platform": "test-linux", "python": "3.12.0", "machine": "x86_64"}

--- a/tests/unit/test_performance_regression.py
+++ b/tests/unit/test_performance_regression.py
@@ -1,0 +1,178 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "scripts"))
+
+from performance_regression import PerformanceGateError, evaluate, load_json
+
+
+ENVIRONMENT = {"platform": "test-linux", "python": "3.12.0", "machine": "x86_64"}
+
+
+def startup(ready: float = 1.0, full: float = 8.0) -> dict:
+    return {
+        "schema_version": 1,
+        "cache_mode": "standard",
+        "environment": ENVIRONMENT,
+        "phases_s": {
+            "image_build": 7.0,
+            "container_start_to_health": ready,
+            "container_start_to_ready": ready,
+            "full_stack_clone_to_ready": full,
+        },
+    }
+
+
+def resources(cpu: float = 2.0, memory: float = 16_000_000) -> dict:
+    return {
+        "schema_version": 1,
+        "sample_count": 5,
+        "environment": ENVIRONMENT,
+        "resources": {
+            "dashboard": {
+                "samples": 5,
+                "cpu_percent_p50": cpu / 2,
+                "cpu_percent_p95": cpu,
+                "cpu_percent_max": cpu + 1,
+                "memory_bytes_p50": memory - 1_000_000,
+                "memory_bytes_p95": memory,
+                "memory_bytes_max": memory + 1_000_000,
+            }
+        },
+    }
+
+
+def telemetry(p95: float = 10.0) -> dict:
+    return {
+        "schema_version": 1,
+        "environment": ENVIRONMENT,
+        "sources": {
+            "simulation": {
+                "stages": {
+                    "end_to_end": {
+                        "samples": 30,
+                        "p50_ms": p95 / 2,
+                        "p95_ms": p95,
+                        "max_ms": p95 + 1,
+                    }
+                }
+            }
+        },
+    }
+
+
+def policy() -> dict:
+    path = ROOT / "docs" / "performance" / "software-regression-policy-v1.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def bundle(
+    *,
+    ready: float = 1.0,
+    full: float = 8.0,
+    cpu: float = 2.0,
+    memory: float = 16_000_000,
+    p95: float = 10.0,
+) -> dict:
+    return {
+        "startup": startup(ready, full),
+        "resources": resources(cpu, memory),
+        "telemetry": telemetry(p95),
+    }
+
+
+def test_gate_passes_comparable_reports_within_budgets() -> None:
+    current = bundle(ready=1.1, full=9.0, cpu=2.2, memory=17_000_000, p95=11.0)
+    report = evaluate(bundle(), current, policy())
+
+    assert report["status"] == "PASS"
+    assert all(check["status"] == "PASS" for check in report["checks"])
+    assert report["evidence_class"] == "local_software"
+    assert report["target_hardware_measurement"] == "NOT_EXECUTED"
+
+
+def test_gate_fails_relative_regression_even_below_absolute_budget() -> None:
+    report = evaluate(bundle(), bundle(p95=20.0), policy())
+
+    failed = {check["metric"] for check in report["checks"] if check["status"] == "FAIL"}
+    assert report["status"] == "FAIL"
+    assert failed == {"telemetry.end_to_end.p95_ms"}
+
+
+def test_gate_fails_absolute_budget_even_with_slow_baseline() -> None:
+    report = evaluate(bundle(full=119.0), bundle(full=121.0), policy())
+
+    check = next(item for item in report["checks"] if item["metric"] == "startup.full_stack_clone_to_ready")
+    assert check["status"] == "FAIL"
+    assert check["current"] > check["absolute_limit"]
+
+
+def test_gate_rejects_incomparable_environment_and_cache_mode() -> None:
+    current = bundle()
+    current["startup"]["cache_mode"] = "disabled"
+    with pytest.raises(PerformanceGateError, match="not comparable"):
+        evaluate(bundle(), current, policy())
+
+    current = bundle()
+    current["resources"]["environment"] = {**ENVIRONMENT, "python": "3.13.0"}
+    with pytest.raises(PerformanceGateError, match="not comparable"):
+        evaluate(bundle(), current, policy())
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), -1, True, "slow"])
+def test_gate_rejects_invalid_numeric_evidence(invalid: object) -> None:
+    current = bundle()
+    current["telemetry"]["sources"]["simulation"]["stages"]["end_to_end"]["p95_ms"] = invalid
+    with pytest.raises(PerformanceGateError, match="finite non-negative"):
+        evaluate(bundle(), current, policy())
+
+
+def test_gate_rejects_hardware_telemetry_and_insufficient_samples() -> None:
+    current = bundle()
+    current["telemetry"]["sources"]["hardware"] = current["telemetry"]["sources"]["simulation"]
+    with pytest.raises(PerformanceGateError, match="simulation telemetry only"):
+        evaluate(bundle(), current, policy())
+
+    current = bundle()
+    current["resources"]["sample_count"] = 4
+    with pytest.raises(PerformanceGateError, match="at least 5 samples"):
+        evaluate(bundle(), current, policy())
+
+
+def test_json_loader_rejects_non_finite_constants(tmp_path: Path) -> None:
+    path = tmp_path / "invalid.json"
+    path.write_text('{"value": NaN}', encoding="utf-8")
+    with pytest.raises(PerformanceGateError, match="non-finite"):
+        load_json(path)
+
+
+def test_cli_writes_failed_report_and_exits_nonzero(tmp_path: Path) -> None:
+    paths = {}
+    for prefix, reports in (("baseline", bundle()), ("current", bundle(p95=20.0))):
+        for kind, payload in reports.items():
+            path = tmp_path / f"{prefix}-{kind}.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            paths[f"{prefix}-{kind}"] = path
+    output = tmp_path / "gate.json"
+    command = [
+        sys.executable,
+        str(ROOT / "tools" / "scripts" / "performance_regression.py"),
+        "--policy",
+        str(ROOT / "docs" / "performance" / "software-regression-policy-v1.json"),
+    ]
+    for kind in ("startup", "resources", "telemetry"):
+        command.extend([f"--baseline-{kind}", str(paths[f"baseline-{kind}"])])
+        command.extend([f"--current-{kind}", str(paths[f"current-{kind}"])])
+    command.extend(["--output", str(output)])
+
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert completed.returncode == 1
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["status"] == "FAIL"
+    assert any(check["status"] == "FAIL" for check in report["checks"])

--- a/tests/unit/test_performance_tools.py
+++ b/tests/unit/test_performance_tools.py
@@ -9,6 +9,7 @@ from performance_tools import (
     hardware_log_hashes,
     load_telemetry,
     parse_memory_bytes,
+    software_environment,
     summarize_resource_samples,
     summarize_telemetry,
     validate_hardware_evidence,
@@ -31,6 +32,11 @@ def record(source: str, run_id: str, sequence: int, stage: str, duration_ms: flo
 
 
 class TelemetryTests(unittest.TestCase):
+    def test_software_environment_has_comparison_identity(self) -> None:
+        environment = software_environment()
+        self.assertEqual(set(environment), {"platform", "python", "machine"})
+        self.assertTrue(all(isinstance(value, str) and value for value in environment.values()))
+
     def test_simulation_and_hardware_use_the_same_aggregator(self) -> None:
         simulation = [
             record("simulation", f"sim-{index}", 0, "planning", value) for index, value in enumerate((1, 2, 9))

--- a/tools/scripts/benchmark_resources.py
+++ b/tools/scripts/benchmark_resources.py
@@ -3,14 +3,13 @@
 
 import argparse
 import json
-import platform
 import subprocess
 import time
 import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 
-from performance_tools import summarize_resource_samples
+from performance_tools import software_environment, summarize_resource_samples
 
 
 def docker_stats(containers: list[str]) -> list[dict]:
@@ -68,7 +67,7 @@ def main() -> int:
         "schema_version": 1,
         "started_at": started_at,
         "finished_at": datetime.now(UTC).isoformat(),
-        "environment": {"platform": platform.platform(), "python": platform.python_version()},
+        "environment": software_environment(),
         "containers": containers,
         "sample_count": args.samples,
         "interval_s": args.interval,

--- a/tools/scripts/benchmark_startup.py
+++ b/tools/scripts/benchmark_startup.py
@@ -4,13 +4,14 @@
 import argparse
 import json
 import os
-import platform
 import subprocess
 import time
 import urllib.error
 import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
+
+from performance_tools import software_environment
 
 
 def command(args: list[str], environment: dict[str, str]) -> str:
@@ -74,7 +75,7 @@ def main() -> int:
         "compose_file": str(args.compose_file),
         "project": args.project,
         "cache_mode": "disabled" if args.no_cache else "standard",
-        "environment": {"platform": platform.platform(), "python": platform.python_version()},
+        "environment": software_environment(),
         "target_full_stack_s": 120,
         "phases_s": {
             "image_build": build_s,

--- a/tools/scripts/performance_regression.py
+++ b/tools/scripts/performance_regression.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Compare local-software performance reports against a baseline and budget."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+class PerformanceGateError(ValueError):
+    """A report or policy cannot be used as trustworthy comparison evidence."""
+
+
+def _reject_constant(value: str) -> None:
+    raise PerformanceGateError(f"non-finite JSON constant is not allowed: {value}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"), parse_constant=_reject_constant)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PerformanceGateError(f"cannot read JSON report: {path}") from exc
+    if not isinstance(payload, dict):
+        raise PerformanceGateError(f"report must be a JSON object: {path}")
+    return payload
+
+
+def _number(value: object, label: str) -> float:
+    if type(value) not in (int, float) or not math.isfinite(value) or value < 0:
+        raise PerformanceGateError(f"{label} must be a finite non-negative number")
+    return float(value)
+
+
+def _positive_int(value: object, label: str) -> int:
+    if type(value) is not int or value < 1:
+        raise PerformanceGateError(f"{label} must be a positive integer")
+    return value
+
+
+def _environment(report: dict[str, Any], kind: str) -> dict[str, str]:
+    environment = report.get("environment")
+    if not isinstance(environment, dict):
+        raise PerformanceGateError(f"{kind} report has no environment object")
+    result: dict[str, str] = {}
+    for key in ("platform", "python", "machine"):
+        value = environment.get(key)
+        if not isinstance(value, str) or not value:
+            raise PerformanceGateError(f"{kind} environment.{key} must be a non-empty string")
+        result[key] = value
+    return result
+
+
+def extract_startup(report: dict[str, Any]) -> tuple[dict[str, float], dict[str, str]]:
+    if report.get("schema_version") != 1:
+        raise PerformanceGateError("startup report schema_version must be 1")
+    cache_mode = report.get("cache_mode")
+    if cache_mode not in {"standard", "disabled"}:
+        raise PerformanceGateError("startup cache_mode must be standard or disabled")
+    phases = report.get("phases_s")
+    if not isinstance(phases, dict):
+        raise PerformanceGateError("startup report has no phases_s object")
+    metrics = {
+        f"startup.{name}": _number(value, f"startup.phases_s.{name}")
+        for name, value in phases.items()
+        if value is not None
+    }
+    required = {
+        "startup.container_start_to_health",
+        "startup.container_start_to_ready",
+        "startup.full_stack_clone_to_ready",
+    }
+    if not required.issubset(metrics):
+        raise PerformanceGateError("startup report is missing required phases")
+    environment = _environment(report, "startup")
+    environment["cache_mode"] = cache_mode
+    return metrics, environment
+
+
+def extract_resources(report: dict[str, Any], minimum_samples: int) -> tuple[dict[str, float], dict[str, str]]:
+    if report.get("schema_version") != 1:
+        raise PerformanceGateError("resource report schema_version must be 1")
+    if _positive_int(report.get("sample_count"), "resource sample_count") < minimum_samples:
+        raise PerformanceGateError(f"resource report requires at least {minimum_samples} samples")
+    resources = report.get("resources")
+    if not isinstance(resources, dict) or not resources:
+        raise PerformanceGateError("resource report has no container resources")
+    cpu_total = 0.0
+    memory_total = 0.0
+    for name, values in resources.items():
+        if not isinstance(name, str) or not name or not isinstance(values, dict):
+            raise PerformanceGateError("resource entries must map container names to objects")
+        samples = _positive_int(values.get("samples"), f"resources.{name}.samples")
+        if samples < minimum_samples:
+            raise PerformanceGateError(f"resources.{name} requires at least {minimum_samples} samples")
+        cpu_p50 = _number(values.get("cpu_percent_p50"), f"resources.{name}.cpu_percent_p50")
+        cpu_p95 = _number(values.get("cpu_percent_p95"), f"resources.{name}.cpu_percent_p95")
+        cpu_max = _number(values.get("cpu_percent_max"), f"resources.{name}.cpu_percent_max")
+        memory_p50 = _number(values.get("memory_bytes_p50"), f"resources.{name}.memory_bytes_p50")
+        memory_p95 = _number(values.get("memory_bytes_p95"), f"resources.{name}.memory_bytes_p95")
+        memory_max = _number(values.get("memory_bytes_max"), f"resources.{name}.memory_bytes_max")
+        if not cpu_p50 <= cpu_p95 <= cpu_max:
+            raise PerformanceGateError(f"resources.{name} CPU percentiles are not ordered")
+        if not memory_p50 <= memory_p95 <= memory_max:
+            raise PerformanceGateError(f"resources.{name} memory percentiles are not ordered")
+        cpu_total += cpu_p95
+        memory_total += memory_p95
+    metrics = {
+        "resources.cpu_percent_p95_total": cpu_total,
+        "resources.memory_bytes_p95_total": memory_total,
+    }
+    return metrics, _environment(report, "resource")
+
+
+def extract_telemetry(report: dict[str, Any], minimum_samples: int) -> tuple[dict[str, float], dict[str, str]]:
+    if report.get("schema_version") != 1:
+        raise PerformanceGateError("telemetry report schema_version must be 1")
+    sources = report.get("sources")
+    if not isinstance(sources, dict) or set(sources) != {"simulation"}:
+        raise PerformanceGateError("software regression accepts simulation telemetry only")
+    simulation = sources["simulation"]
+    stages = simulation.get("stages") if isinstance(simulation, dict) else None
+    if not isinstance(stages, dict) or not stages:
+        raise PerformanceGateError("telemetry report has no simulation stages")
+    metrics: dict[str, float] = {}
+    for name, values in stages.items():
+        if not isinstance(name, str) or not name or not isinstance(values, dict):
+            raise PerformanceGateError("telemetry stages must map names to objects")
+        samples = _positive_int(values.get("samples"), f"telemetry.{name}.samples")
+        if samples < minimum_samples:
+            raise PerformanceGateError(f"telemetry.{name} requires at least {minimum_samples} samples")
+        p50 = _number(values.get("p50_ms"), f"telemetry.{name}.p50_ms")
+        p95 = _number(values.get("p95_ms"), f"telemetry.{name}.p95_ms")
+        maximum = _number(values.get("max_ms"), f"telemetry.{name}.max_ms")
+        if not p50 <= p95 <= maximum:
+            raise PerformanceGateError(f"telemetry.{name} percentiles are not ordered")
+        metrics[f"telemetry.{name}.p95_ms"] = p95
+    return metrics, _environment(report, "telemetry")
+
+
+def _check_environment(kind: str, baseline: dict[str, str], current: dict[str, str]) -> None:
+    if baseline != current:
+        raise PerformanceGateError(
+            f"{kind} reports are not comparable: baseline environment {baseline!r} != current {current!r}"
+        )
+
+
+def _required_reports(policy: dict[str, Any]) -> list[str]:
+    required = policy.get("required_reports")
+    supported = {"startup", "resources", "telemetry"}
+    if not isinstance(required, list) or not required or any(kind not in supported for kind in required):
+        raise PerformanceGateError("policy required_reports must list supported report kinds")
+    if len(required) != len(set(required)):
+        raise PerformanceGateError("policy required_reports must be unique")
+    return required
+
+
+def evaluate(
+    baseline_reports: dict[str, dict[str, Any]],
+    current_reports: dict[str, dict[str, Any]],
+    policy: dict[str, Any],
+) -> dict[str, Any]:
+    if policy.get("schema_version") != 1 or policy.get("evidence_class") != "local_software":
+        raise PerformanceGateError("policy must be schema version 1 for local_software evidence")
+    required = _required_reports(policy)
+    if set(baseline_reports) != set(required) or set(current_reports) != set(required):
+        raise PerformanceGateError("baseline and current reports must exactly match required_reports")
+    minimum_samples = _positive_int(policy.get("minimum_samples"), "policy minimum_samples")
+    extractors = {
+        "startup": extract_startup,
+        "resources": lambda report: extract_resources(report, minimum_samples),
+        "telemetry": lambda report: extract_telemetry(report, minimum_samples),
+    }
+    baseline_metrics: dict[str, float] = {}
+    current_metrics: dict[str, float] = {}
+    for kind in required:
+        baseline_values, baseline_environment = extractors[kind](baseline_reports[kind])
+        current_values, current_environment = extractors[kind](current_reports[kind])
+        _check_environment(kind, baseline_environment, current_environment)
+        baseline_metrics.update(baseline_values)
+        current_metrics.update(current_values)
+
+    metric_policy = policy.get("metrics")
+    if not isinstance(metric_policy, dict) or not metric_policy:
+        raise PerformanceGateError("policy metrics must be a non-empty object")
+    checks = []
+    for name, limits in metric_policy.items():
+        if name not in baseline_metrics or name not in current_metrics or not isinstance(limits, dict):
+            raise PerformanceGateError(f"policy metric is unavailable: {name}")
+        maximum = _number(limits.get("maximum"), f"policy.metrics.{name}.maximum")
+        regression_percent = _number(
+            limits.get("max_regression_percent"), f"policy.metrics.{name}.max_regression_percent"
+        )
+        noise_tolerance = _number(limits.get("noise_tolerance"), f"policy.metrics.{name}.noise_tolerance")
+        baseline_value = baseline_metrics[name]
+        current_value = current_metrics[name]
+        relative_limit = baseline_value * (1 + regression_percent / 100) + noise_tolerance
+        passed = current_value <= maximum and current_value <= relative_limit
+        checks.append(
+            {
+                "metric": name,
+                "baseline": baseline_value,
+                "current": current_value,
+                "absolute_limit": maximum,
+                "regression_limit": relative_limit,
+                "status": "PASS" if passed else "FAIL",
+            }
+        )
+
+    passed = all(check["status"] == "PASS" for check in checks)
+    return {
+        "schema_version": 1,
+        "evidence_class": "local_software",
+        "status": "PASS" if passed else "FAIL",
+        "checks": checks,
+        "target_hardware_measurement": "NOT_EXECUTED",
+        "physical_source_validation": "NOT_EXECUTED",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--policy", type=Path, required=True)
+    for kind in ("startup", "resources", "telemetry"):
+        parser.add_argument(f"--baseline-{kind}", type=Path)
+        parser.add_argument(f"--current-{kind}", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        policy = load_json(args.policy)
+        required = _required_reports(policy)
+        baseline = {
+            kind: load_json(getattr(args, f"baseline_{kind}"))
+            for kind in required
+            if getattr(args, f"baseline_{kind}") is not None
+        }
+        current = {
+            kind: load_json(getattr(args, f"current_{kind}"))
+            for kind in required
+            if getattr(args, f"current_{kind}") is not None
+        }
+        report = evaluate(baseline, current, policy)
+    except PerformanceGateError as exc:
+        parser.error(str(exc))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, allow_nan=False))
+    return 0 if report["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/performance_tools.py
+++ b/tools/scripts/performance_tools.py
@@ -33,6 +33,15 @@ MEMORY_UNITS = {
 }
 
 
+def software_environment() -> dict[str, str]:
+    """Return the stable environment identity shared by software reports."""
+    return {
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "machine": platform.machine(),
+    }
+
+
 def percentile(values: list[float], quantile: float) -> float | None:
     if not values:
         return None
@@ -153,11 +162,7 @@ def summarize_telemetry(
     return {
         "schema_version": 1,
         "generated_by": "tools/scripts/analyze_telemetry.py",
-        "environment": {
-            "platform": platform.platform(),
-            "python": platform.python_version(),
-            "machine": platform.machine(),
-        },
+        "environment": software_environment(),
         "record_count": len(records),
         "sources": sources,
         "hardware_evidence": (


### PR DESCRIPTION
## Summary

Add the LINUX-APP11 local-software performance regression gate.

## What Changed

- Compare startup, aggregate container CPU/RAM, and simulation pipeline P95
- Enforce both absolute budgets and relative regression limits
- Reject malformed, non-finite, negative, unordered, or undersampled evidence
- Reject reports captured on incomparable environments
- Reject hardware telemetry from the software-only gate
- Emit a machine-readable PASS/FAIL report and non-zero exit code on regression
- Add a versioned policy, usage documentation, tests, Makefile target, and Task Packet

## Evidence Boundary

This gate measures local software performance only. It does not claim target hardware, ROS/Gazebo, or physical robot performance. Those fields remain NOT_EXECUTED.

## Validation

- 17 focused performance tests passed
- Python syntax checks passed
- JSON syntax checks passed
- context-check passed
- git diff --check passed

Ruff, the official Task Packet validator, and Docker measurements were not run locally because the current environment lacks ruff, jsonschema, and a captured Docker baseline.

## Related Issue

## What changed

## Interfaces affected

## Tests and commands

## Evidence

## Risks and rollback

## Checklist

- [ ] I changed only approved paths.
- [ ] Tests and contract checks pass.
- [ ] I covered normal and failure behavior.
- [ ] I updated examples/docs when an interface changed.
- [ ] I did not add secrets, private data or unreviewed assets.
