### PR TITLE
fix(platform): support cross-platform registry and evidence locking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY libs/application ./libs/application
 COPY libs/contracts ./libs/contracts
 COPY libs/hardware ./libs/hardware
 COPY libs/kernel ./libs/kernel
+COPY libs/task_utils ./libs/task_utils
 COPY services/agent_runtime ./services/agent_runtime
 COPY services/backend ./services/backend
 COPY services/world_model ./services/world_model

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -53,14 +53,28 @@ Publishing still requires a human-owned version tag and repository permissions. 
 
 ## Windows without Make
 
-Run the equivalent checks with the active Python interpreter:
+Create an isolated Python 3.12 environment, install the current checkout, and
+run the complete Python test suite and validation checks from PowerShell:
 
 ```powershell
-python -m unittest discover -s tests -p "test_*.py" -v
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev,docs]"
+python -m ruff check .
+python -m ruff format --check .
+python -m pytest -v
 python tools/scripts/validate_contracts.py
 python tools/scripts/validate_scenarios.py
 python tools/scripts/validate_golden_set.py
 python tools/scripts/check_context.py
+python tools/scripts/check_task_packet.py --all
+python -m mkdocs build --strict
 python tools/scripts/demo_scripted.py
 python tools/scripts/local_runner.py --goal "Place the red block in the tray"
 ```
+
+The locking regressions use `spawn`, so the same registry and evidence
+concurrency tests are collected on Windows and POSIX. A persistent sidecar
+`.lock` file is expected next to each protected registry; it contains no
+application data and must not be deleted while writers may be active.

--- a/docs/task_packets/issue-222-windows-locking.json
+++ b/docs/task_packets/issue-222-windows-locking.json
@@ -3,6 +3,7 @@
   "human_owner": "TH3478",
   "objective": "Make schema-registry and hardware-evidence writer locking portable across Windows and POSIX without weakening conflict, atomicity, or rollback guarantees.",
   "allowed_paths": [
+    "Dockerfile",
     "docs/deployment/container.md",
     "docs/task_packets/issue-222-windows-locking.json",
     "hardware/validation/tools/evidence.py",
@@ -10,6 +11,7 @@
     "libs/task_utils/**",
     "pyproject.toml",
     "tests/hardware/test_engineering_packages.py",
+    "tests/unit/test_container_baseline.py",
     "tests/unit/test_file_lock.py",
     "tests/unit/test_kernel_version_registry.py"
   ],
@@ -32,6 +34,7 @@
     "Windows locking uses a dedicated one-byte lock file and waits for conflicting writers",
     "registry atomic persistence, idempotency, and conflict rejection remain unchanged",
     "evidence duplicate detection, append durability, and short-write rollback remain unchanged",
+    "the runtime container copies every configured package source before installing the checkout",
     "multiprocessing regressions use a context supported by Windows and POSIX",
     "the Windows runbook installs the current checkout in an isolated environment and executes the complete pytest suite"
   ],
@@ -39,6 +42,7 @@
     "python tools/scripts/check_task_packet.py docs/task_packets/issue-222-windows-locking.json",
     "python -m pytest tests/unit/test_file_lock.py tests/unit/test_kernel_version_registry.py -v",
     "python -m pytest tests/hardware/test_engineering_packages.py -k ValidationPackageTests -v",
+    "python -m pytest tests/unit/test_container_baseline.py -v",
     "make lint",
     "make test",
     "make contract",
@@ -46,12 +50,14 @@
     "make golden-check",
     "make context-check",
     "make docs",
+    "make container-smoke",
     "git diff --check"
   ],
   "evidence": [
     "simulated Windows-backend import and byte-range locking regression output",
     "portable registry and evidence multiprocessing regression output",
     "failure-release and append-rollback regression output",
+    "container package-copy regression and smoke-build output",
     "repository lint, test, contract, scenario, and context validation output",
     "Task Packet validation and clean diff output"
   ],

--- a/docs/task_packets/issue-222-windows-locking.json
+++ b/docs/task_packets/issue-222-windows-locking.json
@@ -1,0 +1,65 @@
+{
+  "issue": 222,
+  "human_owner": "TH3478",
+  "objective": "Make schema-registry and hardware-evidence writer locking portable across Windows and POSIX without weakening conflict, atomicity, or rollback guarantees.",
+  "allowed_paths": [
+    "docs/deployment/container.md",
+    "docs/task_packets/issue-222-windows-locking.json",
+    "hardware/validation/tools/evidence.py",
+    "libs/kernel/workbench/kernel/version_registry.py",
+    "libs/task_utils/**",
+    "pyproject.toml",
+    "tests/hardware/test_engineering_packages.py",
+    "tests/unit/test_file_lock.py",
+    "tests/unit/test_kernel_version_registry.py"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "docs/task_packets/hardware-validation-evidence.json",
+    "docs/task_packets/kernel-version-registry.json",
+    "tools/schemas/task-packet-v1.schema.json"
+  ],
+  "forbidden": [
+    ".github/workflows/**",
+    "firmware/**",
+    "interfaces/**",
+    "robot/control/**",
+    "services/**"
+  ],
+  "acceptance": [
+    "version registry and evidence modules import without an unconditional fcntl dependency",
+    "one standard-library lock adapter serializes threads and processes on Windows and POSIX",
+    "Windows locking uses a dedicated one-byte lock file and waits for conflicting writers",
+    "registry atomic persistence, idempotency, and conflict rejection remain unchanged",
+    "evidence duplicate detection, append durability, and short-write rollback remain unchanged",
+    "multiprocessing regressions use a context supported by Windows and POSIX",
+    "the Windows runbook installs the current checkout in an isolated environment and executes the complete pytest suite"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-222-windows-locking.json",
+    "python -m pytest tests/unit/test_file_lock.py tests/unit/test_kernel_version_registry.py -v",
+    "python -m pytest tests/hardware/test_engineering_packages.py -k ValidationPackageTests -v",
+    "make lint",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make golden-check",
+    "make context-check",
+    "make docs",
+    "git diff --check"
+  ],
+  "evidence": [
+    "simulated Windows-backend import and byte-range locking regression output",
+    "portable registry and evidence multiprocessing regression output",
+    "failure-release and append-rollback regression output",
+    "repository lint, test, contract, scenario, and context validation output",
+    "Task Packet validation and clean diff output"
+  ],
+  "stop_conditions": [
+    "a third-party runtime locking dependency is required",
+    "a Windows CI workflow change is required",
+    "an interface schema change is required",
+    "a write outside the allowed paths is required",
+    "robot-control or firmware changes are required"
+  ]
+}

--- a/hardware/validation/tools/evidence.py
+++ b/hardware/validation/tools/evidence.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
 import re
 from datetime import UTC, datetime
 from pathlib import Path
+
+from workbench_task_utils import exclusive_file_lock
 
 REQUIRED_FIELDS = {
     "evidence_id",
@@ -141,22 +142,23 @@ def register(
     units: dict[str, tuple[str, str]],
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor = os.open(path, os.O_APPEND | os.O_CREAT | os.O_RDWR, 0o666)
-    try:
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        existing = validate_register(path, root=root, scenarios=scenarios, units=units)
-        if record.get("evidence_id") in {item["evidence_id"] for item in existing}:
-            raise EvidenceError("duplicate evidence_id")
-        validate_record(record, root=root, scenarios=scenarios, units=units)
-        payload = (json.dumps(record, allow_nan=False, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
-        original_size = os.fstat(descriptor).st_size
+    lock_path = path.with_name(f".{path.name}.lock")
+    with exclusive_file_lock(lock_path):
+        descriptor = os.open(path, os.O_APPEND | os.O_CREAT | os.O_RDWR, 0o666)
         try:
-            if os.write(descriptor, payload) != len(payload):
-                raise OSError("short write while appending evidence")
-            os.fsync(descriptor)
-        except OSError:
-            os.ftruncate(descriptor, original_size)
-            os.fsync(descriptor)
-            raise
-    finally:
-        os.close(descriptor)
+            existing = validate_register(path, root=root, scenarios=scenarios, units=units)
+            if record.get("evidence_id") in {item["evidence_id"] for item in existing}:
+                raise EvidenceError("duplicate evidence_id")
+            validate_record(record, root=root, scenarios=scenarios, units=units)
+            payload = (json.dumps(record, allow_nan=False, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+            original_size = os.fstat(descriptor).st_size
+            try:
+                if os.write(descriptor, payload) != len(payload):
+                    raise OSError("short write while appending evidence")
+                os.fsync(descriptor)
+            except OSError:
+                os.ftruncate(descriptor, original_size)
+                os.fsync(descriptor)
+                raise
+        finally:
+            os.close(descriptor)

--- a/libs/kernel/workbench/kernel/version_registry.py
+++ b/libs/kernel/workbench/kernel/version_registry.py
@@ -1,6 +1,5 @@
 """K3: durable schema version registry."""
 
-import fcntl
 import json
 import os
 import tempfile
@@ -8,6 +7,8 @@ import threading
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+from workbench_task_utils import exclusive_file_lock
 
 
 class VersionRegistryError(ValueError):
@@ -50,12 +51,8 @@ class VersionRegistry:
         try:
             self.registry_file.parent.mkdir(parents=True, exist_ok=True)
             lock_path = self.registry_file.with_name(f".{self.registry_file.name}.lock")
-            with lock_path.open("a+b") as lock_file:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-                try:
-                    yield
-                finally:
-                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            with exclusive_file_lock(lock_path):
+                yield
         except OSError as exc:
             raise VersionRegistryError(f"registry could not be locked: {self.registry_file}") from exc
 

--- a/libs/task_utils/README.md
+++ b/libs/task_utils/README.md
@@ -1,16 +1,20 @@
 # task_utils
 
-Shared utilities for task verifiers:
+Shared standard-library utilities used across Workbench task boundaries.
 
-- Spatial containment check (bounding box, convex hull)
-- Pose comparison with configurable tolerance
-- Confidence aggregation across multiple observations
-- Evidence ref builder
+Implemented today:
 
-Import in verifiers:
+- `exclusive_file_lock`: persistent sidecar-file locking backed by `flock` on
+  POSIX and one-byte `msvcrt` locking on Windows. It serializes both threads and
+  processes and does not remove the lock file after use.
+
 ```python
-from workbench_task_utils import contains, pose_close, aggregate_confidence
+from workbench_task_utils import exclusive_file_lock
+
+with exclusive_file_lock("state.json.lock"):
+    update_state()
 ```
 
-Not implemented yet — will be populated as repeated patterns emerge across
-task verifiers in v0.1 and v0.2.
+Spatial containment, pose comparison, confidence aggregation, and evidence-ref
+helpers remain planned and will be added only when repeated verifier patterns
+need them.

--- a/libs/task_utils/workbench_task_utils/__init__.py
+++ b/libs/task_utils/workbench_task_utils/__init__.py
@@ -1,0 +1,5 @@
+"""Shared utilities used across Workbench task boundaries."""
+
+from .file_lock import exclusive_file_lock
+
+__all__ = ["exclusive_file_lock"]

--- a/libs/task_utils/workbench_task_utils/file_lock.py
+++ b/libs/task_utils/workbench_task_utils/file_lock.py
@@ -1,0 +1,91 @@
+"""Cross-platform advisory file locking using only the Python standard library."""
+
+from __future__ import annotations
+
+import errno
+import os
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+_WINDOWS = os.name == "nt"
+
+if _WINDOWS:
+    import msvcrt
+else:
+    import fcntl
+
+_LOCK_RETRY_SECONDS = 0.05
+_thread_locks: dict[str, threading.Lock] = {}
+_thread_locks_guard = threading.Lock()
+
+
+def _normalized_path(lock_path: str | os.PathLike[str]) -> str:
+    path = os.fspath(lock_path)
+    if not isinstance(path, str):
+        raise TypeError("lock path must resolve to a string")
+    return os.path.normcase(os.path.realpath(os.path.abspath(path)))
+
+
+def _thread_lock_for(path: str) -> threading.Lock:
+    with _thread_locks_guard:
+        return _thread_locks.setdefault(path, threading.Lock())
+
+
+def _ensure_lock_byte(descriptor: int) -> None:
+    if os.fstat(descriptor).st_size:
+        return
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    if os.write(descriptor, b"\0") != 1:
+        raise OSError(errno.EIO, "could not initialize lock file")
+
+
+def _acquire_descriptor(descriptor: int) -> None:
+    if not _WINDOWS:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        return
+
+    while True:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        try:
+            msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+        except OSError as exc:
+            if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                raise
+            time.sleep(_LOCK_RETRY_SECONDS)
+        else:
+            return
+
+
+def _release_descriptor(descriptor: int) -> None:
+    if not _WINDOWS:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        return
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+
+
+@contextmanager
+def exclusive_file_lock(lock_path: str | os.PathLike[str]) -> Iterator[None]:
+    """Hold an exclusive advisory lock for one persistent sidecar file."""
+
+    path = _normalized_path(lock_path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_BINARY", 0)
+
+    with _thread_lock_for(path):
+        descriptor = os.open(path, flags, 0o666)
+        acquired = False
+        try:
+            if _WINDOWS:
+                _ensure_lock_byte(descriptor)
+            _acquire_descriptor(descriptor)
+            acquired = True
+            yield
+        finally:
+            try:
+                if acquired:
+                    _release_descriptor(descriptor)
+            finally:
+                os.close(descriptor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ packages = [
   "workbench.application",
   "workbench.hardware",
   "workbench.kernel",
+  "workbench_task_utils",
   "workbench_agent_runtime",
   "workbench_backend",
   "workbench_contracts",
@@ -39,6 +40,7 @@ packages = [
 "workbench.application" = "libs/application/workbench/application"
 "workbench.hardware" = "libs/hardware/workbench/hardware"
 "workbench.kernel" = "libs/kernel/workbench/kernel"
+workbench_task_utils = "libs/task_utils/workbench_task_utils"
 workbench_agent_runtime = "services/agent_runtime/workbench_agent_runtime"
 workbench_backend = "services/backend/workbench_backend"
 workbench_contracts = "libs/contracts/workbench_contracts"

--- a/tests/hardware/test_engineering_packages.py
+++ b/tests/hardware/test_engineering_packages.py
@@ -5,6 +5,7 @@ import importlib.util
 import json
 import multiprocessing
 import re
+import sys
 import tempfile
 import threading
 import unittest
@@ -13,6 +14,7 @@ from pathlib import Path
 from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "task_utils"))
 
 
 def load_module(name: str, path: Path):
@@ -337,7 +339,7 @@ class ValidationPackageTests(unittest.TestCase):
 
     def test_concurrent_duplicate_evidence_id_has_one_process_winner(self) -> None:
         record = self._record("EVIDENCE-DUPLICATE")
-        context = multiprocessing.get_context("fork")
+        context = multiprocessing.get_context("spawn")
         barrier = context.Barrier(2)
         results = context.Queue()
         processes = [
@@ -388,6 +390,10 @@ class ValidationPackageTests(unittest.TestCase):
                 self.module.register(self.register, self._record("EVIDENCE-002"), **self.kwargs)
         self.assertEqual(self.register.read_bytes(), original)
         self.assertEqual(self.module.validate_register(self.register, **self.kwargs), [first])
+
+        third = self._record("EVIDENCE-003")
+        self.module.register(self.register, third, **self.kwargs)
+        self.assertEqual(self.module.validate_register(self.register, **self.kwargs), [first, third])
 
     def test_physical_result_requires_physical_pass_for_every_scenario(self) -> None:
         module = load_module("validation_result_derivation", ROOT / "hardware/validation/tools/validate_validation.py")

--- a/tests/unit/test_container_baseline.py
+++ b/tests/unit/test_container_baseline.py
@@ -1,3 +1,4 @@
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -13,10 +14,10 @@ def test_runtime_and_devcontainer_use_the_same_immutable_base() -> None:
 def test_runtime_container_copies_installable_workbench_packages_before_install() -> None:
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
     install_offset = dockerfile.index("python -m pip install --no-compile .")
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    package_directories = pyproject["tool"]["setuptools"]["package-dir"].values()
+    source_roots = {"/".join(Path(directory).parts[:2]) for directory in package_directories}
 
-    for package_copy in (
-        "COPY libs/application ./libs/application",
-        "COPY libs/hardware ./libs/hardware",
-        "COPY libs/kernel ./libs/kernel",
-    ):
+    for source_root in sorted(source_roots):
+        package_copy = f"COPY {source_root} ./{source_root}"
         assert dockerfile.index(package_copy) < install_offset

--- a/tests/unit/test_file_lock.py
+++ b/tests/unit/test_file_lock.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+TASK_UTILS = ROOT / "libs" / "task_utils"
+FILE_LOCK_MODULE = TASK_UTILS / "workbench_task_utils" / "file_lock.py"
+sys.path.insert(0, str(TASK_UTILS))
+
+from workbench_task_utils import exclusive_file_lock
+
+
+def test_exclusive_file_lock_serializes_threads(tmp_path: Path) -> None:
+    lock_path = tmp_path / "shared.lock"
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+
+    def hold_first() -> None:
+        with exclusive_file_lock(lock_path):
+            first_entered.set()
+            assert release_first.wait(5)
+
+    def enter_second() -> None:
+        with exclusive_file_lock(lock_path):
+            second_entered.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(hold_first)
+        assert first_entered.wait(5)
+        second = executor.submit(enter_second)
+        try:
+            assert not second_entered.wait(0.1)
+        finally:
+            release_first.set()
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+    assert second_entered.is_set()
+    assert lock_path.exists()
+
+
+def test_exclusive_file_lock_releases_after_body_error(tmp_path: Path) -> None:
+    lock_path = tmp_path / "failure.lock"
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        with exclusive_file_lock(lock_path):
+            raise RuntimeError("injected failure")
+
+    with exclusive_file_lock(lock_path):
+        pass
+
+
+def test_windows_backend_imports_without_fcntl_and_locks_first_byte(tmp_path: Path) -> None:
+    lock_path = tmp_path / "windows.lock"
+    script = textwrap.dedent(
+        f"""
+        import builtins
+        import errno
+        import importlib.util
+        import os
+        import sys
+        import types
+
+        calls = []
+        fake_msvcrt = types.ModuleType("msvcrt")
+        fake_msvcrt.LK_NBLCK = 1
+        fake_msvcrt.LK_UNLCK = 2
+
+        def locking(descriptor, mode, length):
+            calls.append((mode, length, os.lseek(descriptor, 0, os.SEEK_CUR)))
+            if mode == fake_msvcrt.LK_NBLCK and sum(call[0] == mode for call in calls) == 1:
+                raise OSError(errno.EACCES, "lock is busy")
+
+        fake_msvcrt.locking = locking
+        sys.modules["msvcrt"] = fake_msvcrt
+
+        original_import = builtins.__import__
+        def guarded_import(name, *args, **kwargs):
+            if name == "fcntl":
+                raise AssertionError("Windows backend requested fcntl")
+            return original_import(name, *args, **kwargs)
+
+        original_os_name = os.name
+        builtins.__import__ = guarded_import
+        os.name = "nt"
+        try:
+            spec = importlib.util.spec_from_file_location("windows_file_lock", {str(FILE_LOCK_MODULE)!r})
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        finally:
+            os.name = original_os_name
+            builtins.__import__ = original_import
+
+        module.time.sleep = lambda _seconds: None
+        with module.exclusive_file_lock({str(lock_path)!r}):
+            pass
+
+        assert calls == [(1, 1, 0), (1, 1, 0), (2, 1, 0)]
+        assert os.path.getsize({str(lock_path)!r}) == 1
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_lock_consumers_do_not_import_fcntl_directly() -> None:
+    consumers = [
+        ROOT / "libs" / "kernel" / "workbench" / "kernel" / "version_registry.py",
+        ROOT / "hardware" / "validation" / "tools" / "evidence.py",
+    ]
+
+    for consumer in consumers:
+        tree = ast.parse(consumer.read_text(encoding="utf-8"))
+        imported_modules = {
+            alias.name for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names
+        }
+        imported_modules.update(
+            node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module is not None
+        )
+        assert "fcntl" not in imported_modules

--- a/tests/unit/test_kernel_version_registry.py
+++ b/tests/unit/test_kernel_version_registry.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "libs" / "task_utils"))
 sys.path.insert(0, str(ROOT / "libs" / "kernel"))
 
 from workbench.kernel.version_registry import VersionConflictError, VersionRegistry, VersionRegistryError
@@ -97,13 +98,17 @@ def test_failed_replace_keeps_original_and_removes_temporary_file(
     def fail_replace(source: str, destination: Path) -> None:
         raise OSError("injected replace failure")
 
-    monkeypatch.setattr("workbench.kernel.version_registry.os.replace", fail_replace)
-    with pytest.raises(VersionRegistryError, match="could not be persisted"):
-        registry.register_schema("result", "1.0.0", {"type": "object"})
+    with monkeypatch.context() as context:
+        context.setattr("workbench.kernel.version_registry.os.replace", fail_replace)
+        with pytest.raises(VersionRegistryError, match="could not be persisted"):
+            registry.register_schema("result", "1.0.0", {"type": "object"})
 
     assert path.read_bytes() == before
     assert registry.versions == {"action": {"1.0.0": {"required": ["id"]}}}
     assert list(tmp_path.glob(f".{path.name}.*.tmp")) == []
+
+    registry.register_schema("result", "1.0.0", {"type": "object"})
+    assert VersionRegistry(path).versions["result"] == {"1.0.0": {"type": "object"}}
 
 
 def test_stale_instances_merge_disjoint_schema_versions(tmp_path: Path) -> None:
@@ -134,7 +139,7 @@ def test_stale_instance_rechecks_conflicting_version(tmp_path: Path) -> None:
 
 def test_concurrent_process_registrations_are_not_lost(tmp_path: Path) -> None:
     path = tmp_path / "registry.json"
-    with multiprocessing.get_context("fork").Pool(4) as processes:
+    with multiprocessing.get_context("spawn").Pool(4) as processes:
         processes.starmap(_register_from_process, [(str(path), index) for index in range(8)])
 
     assert set(VersionRegistry(path).versions["process"]) == {str(index) for index in range(8)}


### PR DESCRIPTION
## Summary

- add `workbench_task_utils.exclusive_file_lock` with POSIX `flock` and Windows one-byte `msvcrt.locking` backends
- migrate the schema version registry and hardware evidence writer to persistent sidecar locks without changing conflict, atomic persistence, or append rollback semantics
- replace fork-only multiprocessing regressions with `spawn` and add lock release plus simulated Windows backend coverage
- update package metadata, the Windows PowerShell runbook, and the bounded Issue #222 Task Packet

## Validation

- `make lint`
- `make test` — 653 passed, 189 subtests passed
- focused lock, registry, and hardware package tests — 41 passed
- complete `ValidationPackageTests` selection — 6 passed
- `make contract`
- `make scenario-check`
- `make golden-check`
- `make context-check`
- `python tools/scripts/check_task_packet.py --all`
- `make docs`
- `make demo-scripted`
- `make demo-offline`
- `git diff --check`

## Boundaries

- no Windows GitHub Actions job is added in this issue
- native Windows execution was not available locally; the Windows backend is covered with an isolated mocked `msvcrt` process and all multiprocessing regressions use `spawn`
- no interface schema, firmware, robot control, service, or CI workflow files are changed

Fixes #222