### PR TITLE
fix: stabilize post-merge validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,54 @@ fail-closed simulation controls.
 grasp/place adapter, Gazebo-backed task results, and physical hardware evidence.
 Committed fixtures are pipeline tests, not robot or Gazebo evidence.
 
-The same manifest and seed produce the same materialized scene hash. That does
-not imply deterministic Gazebo physics, sensor noise, process timing, or event ordering.
+The reproducibility guarantees are deliberately separate:
+
+1. The same frozen manifest and seed produce the same materialized scene hash.
+2. The same valid, ordered event log reduces to the same replay state.
+3. The scripted fixture generator emits the same ordered events only when its
+   complete input, including versions and configuration, is identical.
+
+A seed alone does not determine event order. None of these guarantees implies
+deterministic Gazebo physics, sensor noise, process timing, or physical behavior.
+
+## Validation and Platform Support
+
+The portable Python runtime is tested on Python 3.12. Native Windows support
+covers contracts, event processing, the read-only backend, monitoring, task
+packet validation, and deterministic fixture workflows. Linux-only features
+remain explicitly separate:
+
+| Boundary | Supported evidence | Not implied |
+| --- | --- | --- |
+| Python runtime | Unit and integration tests on Linux and Windows | Gazebo, ROS 2, or robot motion |
+| Containers | Runtime and devcontainer share one immutable Ubuntu digest | Reproducibility on an unpinned base image |
+| Dashboard backend | Bounded read-only HTTP API; write methods return `405` | Authentication for public deployment or any control authority |
+| `wbcan` | Linux kernel build, virtual SocketCAN fault tests, race-safe counters | Physical CAN timing, MCU behavior, or actuator safety |
+| Scripted scenarios | Deterministic fixture artifacts with checksums | Physical or Gazebo execution |
+
+The complete portable check is `python -m pytest`. Linux CI additionally owns
+container, MCU-QEMU, and privileged kernel-module gates. A merge is not treated
+as validated when any required job fails or is skipped.
 
 ## Quickstart
 
-Ubuntu 24.04 or WSL2, Python 3.12, no GPU required.
+Ubuntu 24.04, WSL2, or Windows 11 with Python 3.12; no GPU is required for the
+portable runtime. Kernel-module, ROS 2, and container checks require Linux.
 
 ```bash
 git clone https://github.com/Quchaosheng/workbench-desk-robot.git
 cd workbench-desk-robot
 make bootstrap
 make demo-scripted
+```
+
+On native Windows, install the editable development package and run the
+portable checks directly:
+
+```powershell
+py -3.12 -m pip install -e ".[dev]"
+py -3.12 -m pytest
+py -3.12 tools/scripts/demo_scripted.py
 ```
 
 Useful commands:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,18 +86,49 @@ metadata 和 checksums。它会明确标记为 `SCRIPTED_FIXTURE`，并保持
 **还没有：**完整 Gazebo 世界、真实相机桥接、MoveIt 抓取放置适配器、Gazebo 实测任务结果
 和真实硬件证据。仓库中的 fixture 是软件链路测试，不是机器人或 Gazebo 证据。
 
-同一 manifest 和 seed 会得到同一物化场景 hash，但这不意味着 Gazebo 物理、传感器噪声、
-进程时序或事件顺序也完全确定。
+仓库提供的确定性保证彼此独立：
+
+1. 同一冻结 manifest 和 seed 会得到同一物化场景 hash。
+2. 同一份合法且顺序一致的事件日志会归约为同一回放状态。
+3. 只有完整输入、版本和配置都一致时，脚本 fixture 生成器才保证输出同一有序事件序列。
+
+seed 本身不能决定事件顺序；这些保证也不代表 Gazebo 物理、传感器噪声、进程时序或真实
+机器人行为完全确定。
+
+## 验证与平台支持
+
+可移植 Python 运行时以 Python 3.12 为基线。原生 Windows 支持覆盖契约、事件处理、只读后端、
+监控、Task Packet 校验和确定性 fixture 流程；Linux 专属能力保持独立边界：
+
+| 边界 | 已支持的证据 | 不代表 |
+| --- | --- | --- |
+| Python runtime | Linux 和 Windows 上的单元、集成测试 | Gazebo、ROS 2 或机器人运动 |
+| 容器 | runtime 与 devcontainer 使用同一个不可变 Ubuntu digest | 未固定基础镜像也可复现 |
+| Dashboard 后端 | 有界只读 HTTP API；写方法返回 `405` | 公网部署认证或任何控制权限 |
+| `wbcan` | Linux 内核构建、虚拟 SocketCAN 故障测试、并发安全计数 | 真实 CAN 时序、MCU 行为或执行器安全 |
+| 脚本场景 | 带 checksum 的确定性 fixture artifact | 真实机器人或 Gazebo 执行 |
+
+完整的可移植检查是 `python -m pytest`。Linux CI 另外负责容器、MCU-QEMU 和特权内核模块
+门禁。任何必需 job 失败或被跳过时，都不能把该次合并视为已经验证。
 
 ## 快速开始
 
-Ubuntu 24.04 或 WSL2，Python 3.12，不需要 GPU。
+Ubuntu 24.04、WSL2 或安装 Python 3.12 的 Windows 11 都可运行可移植 runtime，且不需要
+GPU。内核模块、ROS 2 和容器检查仍要求 Linux。
 
 ```bash
 git clone https://github.com/Quchaosheng/workbench-desk-robot.git
 cd workbench-desk-robot
 make bootstrap
 make demo-scripted
+```
+
+原生 Windows 可直接安装开发依赖并运行可移植检查：
+
+```powershell
+py -3.12 -m pip install -e ".[dev]"
+py -3.12 -m pytest
+py -3.12 tools/scripts/demo_scripted.py
 ```
 
 常用命令：

--- a/docs/task_packets/post-merge-stabilization-2026-08-26.json
+++ b/docs/task_packets/post-merge-stabilization-2026-08-26.json
@@ -1,0 +1,70 @@
+{
+  "issue": "post-merge-stabilization-2026-08-26",
+  "issues": [40, 157, 161, 222, 242, 243],
+  "human_owner": "Quchaosheng",
+  "objective": "Restore post-merge test integrity, Windows portability, wbcan statistics serialization, and truthful platform documentation after the August 26 merge batch.",
+  "allowed_paths": [
+    "README.md",
+    "README.zh-CN.md",
+    "docs/task_packets/post-merge-stabilization-2026-08-26.json",
+    "kernel/wbcan/test_state_concurrency.py",
+    "kernel/wbcan/test_wbcan.sh",
+    "kernel/wbcan/wbcan.c",
+    "libs/kernel/workbench/kernel/event_store.py",
+    "services/backend/workbench_backend/server.py",
+    "tests/integration/test_offline_system.py",
+    "tests/unit/test_container_baseline.py",
+    "tests/unit/test_kernel_event_store.py",
+    "tests/unit/test_monitoring.py",
+    "tests/unit/test_task_packet.py",
+    "tools/scripts/benchmark_monitoring.py"
+  ],
+  "read_only_paths": [
+    ".devcontainer/Dockerfile",
+    ".github/workflows/ci.yml",
+    "AGENTS.md",
+    "Dockerfile",
+    "kernel/wbcan/validate_test_report.py",
+    "tools/schemas/task-packet-v1.schema.json"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "interfaces/**",
+    "robot/control/**"
+  ],
+  "acceptance": [
+    "runtime and development containers use one immutable Ubuntu digest without duplicating that digest in a test constant",
+    "native Windows tests do not require POSIX resource APIs or symbolic-link privileges",
+    "read-only HTTP write rejection drains bounded request bodies before responding",
+    "wbcan netdev counters use a race-safe snapshot boundary and never count rejected RX delivery as received",
+    "JSONL append reuses validated in-process state while detecting and reloading external file changes",
+    "the wbcan machine-readable report is created and every check append fails closed",
+    "English and Chinese READMEs distinguish portable Python validation from privileged Linux and physical evidence",
+    "English and Chinese READMEs state scene materialization, event replay, and scripted fixture determinism as three separate guarantees"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/post-merge-stabilization-2026-08-26.json",
+    "python -m pytest tests/unit/test_container_baseline.py tests/unit/test_monitoring.py tests/unit/test_task_packet.py tests/integration/test_offline_system.py -v",
+    "python -m pytest tests/unit/test_linux_driver_tests.py -v",
+    "python -m pytest -v",
+    "python -m ruff check .",
+    "python -m ruff format --check .",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "focused Windows-compatible Python test output",
+    "full Python test-suite output on the current host",
+    "wbcan report-contract unit-test output",
+    "kernel build and privileged fault-suite output when a supported Linux host is available",
+    "Task Packet validation and clean diff output"
+  ],
+  "stop_conditions": [
+    "a public interface or firmware change is required",
+    "physical CAN or robot evidence would be inferred from software tests",
+    "the kernel fix requires a second controller state machine beside Linux CAN core",
+    "a write outside the approved paths is required"
+  ]
+}

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -17,9 +17,28 @@ TEST_RESTART_DELAY="/sys/module/wbcan/parameters/test_restart_delay_ms"
 TEST_STOP_DELAY="/sys/module/wbcan/parameters/test_stop_delay_ms"
 PASS=0
 FAIL=0
+REPORT_FILE="${WBCAN_TEST_REPORT:-}"
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+if [ -n "$REPORT_FILE" ]; then
+	printf 'result\ttest_id\tname\texpected\tactual\n' > "$REPORT_FILE" || {
+		red "cannot create test report at $REPORT_FILE"
+		exit 1
+	}
+fi
+
+report_check() {
+	local result="$1" name="$2" want="$3" got="$4" slug
+	[ -n "$REPORT_FILE" ] || return 0
+	slug=$(printf '%s' "$name" | tr '[:upper:] ' '[:lower:]_' | tr -cd '[:alnum:]_-')
+	printf '%s\twbcan-%s\t%s\t%s\t%s\n' \
+		"$result" "$slug" "$name" "$want" "$got" >> "$REPORT_FILE" || {
+		red "cannot append to test report at $REPORT_FILE"
+		exit 1
+	}
+}
 
 need() {
 	command -v "$1" >/dev/null 2>&1 || {
@@ -140,9 +159,11 @@ check() {
 	if [ "$want" = "$got" ]; then
 		green "PASS  $name"
 		PASS=$((PASS + 1))
+		report_check PASS "$name" "$want" "$got"
 	else
 		red   "FAIL  $name: want '$want' got '$got'"
 		FAIL=$((FAIL + 1))
+		report_check FAIL "$name" "$want" "$got"
 	fi
 }
 

--- a/libs/kernel/workbench/kernel/event_store.py
+++ b/libs/kernel/workbench/kernel/event_store.py
@@ -57,6 +57,7 @@ class EventStore:
         self.checkpoints: list[int] = []
         self._lock = threading.RLock()
         self._connection: sqlite3.Connection | None = None
+        self._events_signature: tuple[int, int, int] | None = None
         if self.backend == "sqlite":
             self._connection = sqlite3.connect(self.log_file)
             self._connection.execute("PRAGMA foreign_keys = ON")
@@ -98,6 +99,13 @@ class EventStore:
                     "SELECT event_count FROM checkpoints ORDER BY checkpoint_id"
                 ).fetchall()
             ]
+
+    def _jsonl_signature(self) -> tuple[int, int, int] | None:
+        try:
+            stat = self.log_file.stat()
+        except FileNotFoundError:
+            return None
+        return stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns
 
     def _validate_events(self, events: list[dict[str, Any]]) -> None:
         if self.legacy_objects:
@@ -211,7 +219,10 @@ class EventStore:
             raise EventStoreError("event must contain strict JSON values") from exc
         persisted_events = [json.loads(encoded) for encoded in serialized]
         with self._lock:
-            events = self._read_events()
+            if self.backend == "jsonl" and self._events_signature == self._jsonl_signature():
+                events = self.events
+            else:
+                events = self._read_events()
             self._validate_events([*events, *persisted_events])
             if self.backend == "jsonl":
                 try:
@@ -234,6 +245,8 @@ class EventStore:
                     self._connection.rollback()
                     raise EventStoreError(f"event database could not be appended: {self.log_file}") from exc
             self.events = [*events, *persisted_events]
+            if self.backend == "jsonl":
+                self._events_signature = self._jsonl_signature()
 
     def create_checkpoint(self) -> int:
         with self._lock:

--- a/services/backend/workbench_backend/server.py
+++ b/services/backend/workbench_backend/server.py
@@ -26,6 +26,7 @@ DEFAULT_DATA_DIR = DEFAULT_STATIC_DIR / "data"
 OPENAPI_RESOURCE = resources.files("workbench_backend").joinpath("api-openapi-v1.json")
 API_VERSION = "1"
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+MAX_REJECTED_REQUEST_BODY_BYTES = 1024 * 1024
 RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 
@@ -182,6 +183,16 @@ class DashboardHandler(BaseHTTPRequestHandler):
         self._send_file(static_path)
 
     def _reject_write(self) -> None:
+        raw_length = self.headers.get("Content-Length", "0")
+        try:
+            content_length = int(raw_length)
+        except ValueError:
+            content_length = -1
+        if not 0 <= content_length <= MAX_REJECTED_REQUEST_BODY_BYTES:
+            self._send_json({"error": "invalid_request_body"}, HTTPStatus.BAD_REQUEST)
+            return
+        if content_length:
+            self.rfile.read(content_length)
         self._send_json(
             {"error": "read_only", "message": "This service exposes no robot or ROS control operations."},
             HTTPStatus.METHOD_NOT_ALLOWED,

--- a/tests/unit/test_container_baseline.py
+++ b/tests/unit/test_container_baseline.py
@@ -1,14 +1,18 @@
+import re
 import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-UBUNTU_24_04_DIGEST = "sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+IMMUTABLE_UBUNTU_BASE = re.compile(r"^FROM ubuntu@sha256:[0-9a-f]{64}$")
 
 
 def test_runtime_and_devcontainer_use_the_same_immutable_base() -> None:
-    for relative_path in ("Dockerfile", ".devcontainer/Dockerfile"):
-        first_line = (ROOT / relative_path).read_text(encoding="utf-8").splitlines()[0]
-        assert first_line == f"FROM ubuntu@{UBUNTU_24_04_DIGEST}"
+    first_lines = {
+        (ROOT / relative_path).read_text(encoding="utf-8").splitlines()[0]
+        for relative_path in ("Dockerfile", ".devcontainer/Dockerfile")
+    }
+    assert len(first_lines) == 1
+    assert IMMUTABLE_UBUNTU_BASE.fullmatch(first_lines.pop())
 
 
 def test_runtime_container_copies_installable_workbench_packages_before_install() -> None:

--- a/tests/unit/test_kernel_event_store.py
+++ b/tests/unit/test_kernel_event_store.py
@@ -101,6 +101,18 @@ def test_append_rejects_duplicate_identity_and_mixed_run_before_writing(tmp_path
     assert log.read_bytes() == before
 
 
+def test_append_reloads_jsonl_after_external_change(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    store = EventStore(log)
+    store.append(event(0))
+    with log.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(event(1), separators=(",", ":")) + "\n")
+
+    store.append(event(2))
+
+    assert store.replay() == [event(0), event(1), event(2)]
+
+
 def test_integrity_checks_contract_and_strict_json(tmp_path: Path) -> None:
     log = tmp_path / "events.jsonl"
     store = EventStore(log)

--- a/tests/unit/test_task_packet.py
+++ b/tests/unit/test_task_packet.py
@@ -154,7 +154,8 @@ def test_path_validation_allows_future_paths_but_rejects_changed_links(
     monkeypatch.setattr(task_packet, "ROOT", tmp_path)
     assert task_packet._normalize_repo_path("new/path/**", field="allowed_paths") == "new/path/**"
     link = tmp_path / "new"
-    link.symlink_to(tmp_path / "outside")
+    link.mkdir()
+    monkeypatch.setattr(task_packet, "_is_link", lambda path: path == link)
     with pytest.raises(task_packet.TaskPacketError, match="symbolic links"):
         task_packet._validate_write_boundary({"new"}, [{"allowed_paths": ["new/**"]}])
 

--- a/tools/scripts/benchmark_monitoring.py
+++ b/tools/scripts/benchmark_monitoring.py
@@ -105,7 +105,7 @@ def benchmark(iterations: int) -> dict:
     snapshot_json = json.dumps(snapshot.as_dict(), separators=(",", ":"), allow_nan=False).encode()
     prometheus = collector.metrics.export_prometheus().encode()
     max_rss = None
-    if resource is not None:
+    if resource is not None and hasattr(resource, "getrusage") and hasattr(resource, "RUSAGE_SELF"):
         max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         if platform.system() == "Linux":
             max_rss *= 1_024


### PR DESCRIPTION
## Summary
- restore the wbcan machine-readable report contract removed by the state-serialization merge
- keep runtime/devcontainer digest validation synchronized without duplicating a stale digest constant
- make Windows HTTP rejection, monitoring resource probes, Task Packet link tests, and JSONL append performance portable
- document truthful deterministic and platform evidence boundaries in both READMEs

## Verification
- python -m pytest -q: 745 passed
- python -m ruff check .
- python -m ruff format --check .
- contract, scenario, context, Task Packet, and strict MkDocs checks passed

Closes #40