### PR TITLE
test(backend): add split-host allowlist runtime evidence

### DIFF
--- a/docs/task_packets/issue-71-backend-egress-policy-phase-b.json
+++ b/docs/task_packets/issue-71-backend-egress-policy-phase-b.json
@@ -67,12 +67,16 @@
     "Missing, blank, or malformed allow-list configuration cannot make a non-loopback event source ready; existing Phase A fail-closed readiness behavior remains in force.",
     "The deployment documentation defines WORKBENCH_EVENT_SOURCE_ALLOWLIST as a comma-separated list of literal IP addresses or CIDR ranges, shows controller and same-host examples, and does not describe hostnames as allow-list entries.",
     "The rendered controller Compose configuration contains the expected event-source URL and allow-list arguments without granting write, robot-control, or additional filesystem capabilities.",
+    "A real runtime smoke starts separate simulation and controller Compose projects, dynamically discovers the controller bridge gateway, and proves an explicitly allow-listed non-loopback event source makes the controller ready and exposes remote runs.",
+    "The same runtime smoke replaces the allow-list with a non-matching CIDR and proves the controller fails closed with HTTP 503 while the simulation peer remains ready.",
     "Existing URL validation, prohibited-address checks, all-DNS-result validation, DNS pinning, redirect rejection, response limits, timeout limits, read-only API behavior, WorldEvent shape, and OpenAPI behavior remain unchanged.",
     "This Packet does not implement total DNS timeout, multiple safe-IP failover, retries, or partition recovery behavior assigned to Issue #74."
   ],
   "commands": [
     "python -m pytest tests/unit/test_multi_host.py tests/unit/test_multi_host_deployment.py tests/unit/test_dashboard_backend.py -v",
     "docker compose --env-file tests/fixtures/issue-71-controller.env -f deploy/multi-host/compose.controller.yaml config",
+    "docker build --tag workbench-1:issue-71-smoke .",
+    "python -m pytest tests/unit/test_multi_host_deployment.py -k controller_compose_runtime -v -s",
     "make test",
     "make contract",
     "make scenario-check",
@@ -80,17 +84,18 @@
     "make demo-scripted",
     "make check",
     "git diff --check",
-    "python tools/scripts/check_task_packet.py docs/task_packets/issue-71-backend-egress-policy-phase-b.json --base fix/71-backend-egress-policy"
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-71-backend-egress-policy-phase-b.json --base f821f417b1e202f310d5bf208a5136fa408fd789"
   ],
   "evidence": [
     "Verbose CLI tests prove environment fallback and explicit CLI override while executing services/backend/workbench_backend/server.py.",
     "Deployment tests prove both Compose variables are required, both CLI arguments are present, and no permissive allow-list default exists.",
     "Deployment documentation tests prove the IP/CIDR-only operator contract and both deployment examples are present.",
     "docker compose config renders the controller service successfully from the checked-in non-secret test environment fixture and shows the expected URL and allow-list arguments.",
+    "The dedicated Docker runtime smoke prints the dynamically discovered non-loopback gateway and proves allowed_status=200, denied_status=503, and sim_status_after_denial=200 across separate Compose projects.",
     "Existing Phase A security and Dashboard regression tests continue to pass.",
     "make check completes successfully.",
     "git diff --check produces no output.",
-    "Task Packet diff-boundary validation against fix/71-backend-egress-policy confirms every Phase B changed path is allowed."
+    "Task Packet diff-boundary validation against fixed follow-up base f821f417b1e202f310d5bf208a5136fa408fd789 confirms every changed path is allowed."
   ],
   "stop_conditions": [
     "A change to services/backend/workbench_backend/remote_http.py or services/backend/workbench_backend/read_model.py is required.",
@@ -108,6 +113,7 @@
     "Phase B is stacked on Phase A and must not be merged independently before the Phase A policy is present.",
     "Fail closed when a non-loopback deployment omits or supplies an invalid allow-list; do not add a permissive default.",
     "Keep IP/CIDR values non-secret and do not put credentials into Compose arguments or documentation examples.",
+    "The runtime smoke discovers its bridge gateway and host ports dynamically; if the local Docker engine cannot publish ports between separate Compose projects, report the environment limitation instead of weakening the allow-list.",
     "If deployment wiring must be rolled back, disable the non-loopback remote event source rather than restoring unrestricted outbound access."
   ]
 }

--- a/tests/unit/test_multi_host_deployment.py
+++ b/tests/unit/test_multi_host_deployment.py
@@ -2,14 +2,21 @@ import ipaddress
 import json
 import os
 import re
+import socket
 import subprocess
+import time
 import unittest
+import urllib.error
+import urllib.request
+import uuid
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CONTROLLER_COMPOSE = ROOT / "deploy" / "multi-host" / "compose.controller.yaml"
+SIM_COMPOSE = ROOT / "deploy" / "multi-host" / "compose.sim.yaml"
 CONTROLLER_ENV_FIXTURE = ROOT / "tests" / "fixtures" / "issue-71-controller.env"
 DEPLOYMENT_DOC = ROOT / "docs" / "deployment" / "multi-host.md"
+SMOKE_IMAGE = "workbench-1:issue-71-smoke"
 EVENT_SOURCE_ENVIRONMENT = {
     "WORKBENCH_EVENT_SOURCE_URL": "http://10.20.30.40:8090",
     "WORKBENCH_EVENT_SOURCE_ALLOWLIST": "10.20.30.0/24",
@@ -98,6 +105,208 @@ class ControllerComposeDeploymentTests(unittest.TestCase):
         self.assertEqual(controller["tmpfs"], ["/tmp:size=32m"])
         for prohibited_capability in ("cap_add", "devices", "privileged", "volumes"):
             self.assertNotIn(prohibited_capability, controller)
+
+
+class ControllerComposeRuntimeSmokeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            image = subprocess.run(
+                ["docker", "image", "inspect", SMOKE_IMAGE],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            raise unittest.SkipTest(f"Docker is unavailable: {exc}") from exc
+        if image.returncode != 0:
+            raise unittest.SkipTest(f"build {SMOKE_IMAGE!r} before running the split-host runtime smoke")
+
+    def setUp(self) -> None:
+        token = uuid.uuid4().hex[:12]
+        self.sim_project = f"issue71-sim-{token}"
+        self.controller_project = f"issue71-controller-{token}"
+        with (
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sim_socket,
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM) as controller_socket,
+        ):
+            sim_socket.bind(("127.0.0.1", 0))
+            controller_socket.bind(("127.0.0.1", 0))
+            self.sim_port = sim_socket.getsockname()[1]
+            self.controller_port = controller_socket.getsockname()[1]
+        self.sim_environment = os.environ | {
+            "WORKBENCH_IMAGE": SMOKE_IMAGE,
+            "SIM_PORT": str(self.sim_port),
+        }
+        self.controller_environment = os.environ | {
+            "WORKBENCH_IMAGE": SMOKE_IMAGE,
+            "CONTROLLER_PORT": str(self.controller_port),
+            "WORKBENCH_EVENT_SOURCE_URL": "http://127.0.0.1:1",
+            "WORKBENCH_EVENT_SOURCE_ALLOWLIST": "127.0.0.1/32",
+        }
+        self.addCleanup(self._cleanup)
+
+    def _run(
+        self,
+        command: list[str],
+        *,
+        environment: dict[str, str] | None = None,
+        check: bool = True,
+        timeout: float = 90,
+    ) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if check and result.returncode != 0:
+            self.fail(
+                f"command failed ({result.returncode}): {' '.join(command)}\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        return result
+
+    def _compose(
+        self,
+        project: str,
+        compose_file: Path,
+        environment: dict[str, str],
+        *arguments: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return self._run(
+            [
+                "docker",
+                "compose",
+                "-p",
+                project,
+                "-f",
+                str(compose_file.relative_to(ROOT)),
+                *arguments,
+            ],
+            environment=environment,
+            check=check,
+        )
+
+    def _cleanup(self) -> None:
+        self._compose(
+            self.controller_project,
+            CONTROLLER_COMPOSE,
+            self.controller_environment,
+            "down",
+            "--remove-orphans",
+            check=False,
+        )
+        self._compose(
+            self.sim_project,
+            SIM_COMPOSE,
+            self.sim_environment,
+            "down",
+            "--remove-orphans",
+            check=False,
+        )
+
+    def _wait_for_status(self, url: str, expected_status: int) -> dict[str, object]:
+        deadline = time.monotonic() + 30
+        last_status: int | None = None
+        last_body = ""
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(url, timeout=2) as response:
+                    last_status = response.status
+                    last_body = response.read().decode("utf-8")
+            except urllib.error.HTTPError as exc:
+                last_status = exc.code
+                last_body = exc.read().decode("utf-8")
+            except (ConnectionError, TimeoutError, urllib.error.URLError):
+                time.sleep(0.25)
+                continue
+            if last_status == expected_status:
+                payload = json.loads(last_body)
+                self.assertIsInstance(payload, dict)
+                return payload
+            time.sleep(0.25)
+        self.fail(f"{url} returned status={last_status}, body={last_body!r}; expected {expected_status}")
+
+    def test_controller_compose_runtime_enforces_event_source_allowlist(self) -> None:
+        self._compose(self.sim_project, SIM_COMPOSE, self.sim_environment, "up", "-d")
+        sim_payload = self._wait_for_status(f"http://127.0.0.1:{self.sim_port}/readyz", 200)
+        self.assertEqual(sim_payload["status"], "ready")
+
+        self._compose(
+            self.controller_project,
+            CONTROLLER_COMPOSE,
+            self.controller_environment,
+            "up",
+            "-d",
+        )
+        network = self._run(
+            [
+                "docker",
+                "network",
+                "inspect",
+                f"{self.controller_project}_default",
+                "--format",
+                "{{(index .IPAM.Config 0).Gateway}}",
+            ]
+        )
+        gateway = network.stdout.strip()
+        gateway_address = ipaddress.ip_address(gateway)
+        self.assertFalse(gateway_address.is_loopback)
+
+        event_source_url = f"http://{gateway}:{self.sim_port}"
+        self.controller_environment |= {
+            "WORKBENCH_EVENT_SOURCE_URL": event_source_url,
+            "WORKBENCH_EVENT_SOURCE_ALLOWLIST": f"{gateway}/32",
+        }
+        self._compose(
+            self.controller_project,
+            CONTROLLER_COMPOSE,
+            self.controller_environment,
+            "up",
+            "-d",
+            "--force-recreate",
+        )
+        allowed_payload = self._wait_for_status(f"http://127.0.0.1:{self.controller_port}/readyz", 200)
+        self.assertEqual(allowed_payload["status"], "ready")
+        self.assertEqual(allowed_payload["data_source"], "remote-simulation-event-source")
+
+        with urllib.request.urlopen(f"http://127.0.0.1:{self.controller_port}/api/v1/runs", timeout=2) as response:
+            remote_runs = json.loads(response.read())
+        self.assertTrue(remote_runs["runs"])
+
+        self.controller_environment["WORKBENCH_EVENT_SOURCE_ALLOWLIST"] = "203.0.113.1/32"
+        self._compose(
+            self.controller_project,
+            CONTROLLER_COMPOSE,
+            self.controller_environment,
+            "up",
+            "-d",
+            "--force-recreate",
+        )
+        denied_payload = self._wait_for_status(f"http://127.0.0.1:{self.controller_port}/readyz", 503)
+        self.assertEqual(denied_payload["status"], "not_ready")
+        self.assertEqual(denied_payload["data_source"], "remote-simulation-event-source")
+        sim_after_denial = self._wait_for_status(f"http://127.0.0.1:{self.sim_port}/readyz", 200)
+        self.assertEqual(sim_after_denial["status"], "ready")
+
+        print(
+            json.dumps(
+                {
+                    "allowed_status": 200,
+                    "controller_gateway": gateway,
+                    "denied_status": 503,
+                    "event_source_url": event_source_url,
+                    "sim_status_after_denial": 200,
+                },
+                sort_keys=True,
+            )
+        )
 
 
 class MultiHostDeploymentDocumentationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Follow up on Issue #71 and merged PR #238 by adding the missing reproducible split-host runtime evidence.

- Add a Docker runtime smoke using separate simulation and controller Compose projects.
- Dynamically discover the controller bridge gateway instead of hard-coding a host address.
- Prove an explicitly allow-listed non-loopback event source makes the controller ready and exposes remote runs.
- Prove a non-matching allow-list fails closed with HTTP 503 while the simulation peer remains ready.
- Replace the stale branch-based Task Packet boundary command with the fixed follow-up base commit.

No production code, public interfaces, contracts, Compose configuration, security policy, robot control, firmware, or simulation implementation is changed.

## Runtime evidence

The dedicated smoke produced:

```json
{
  "allowed_status": 200,
  "controller_gateway": "172.21.0.1",
  "denied_status": 503,
  "sim_status_after_denial": 200
}
```

The gateway and published ports are discovered dynamically and may differ between Docker environments.

## Testing

Runtime smoke:

```text
1 passed, 4 deselected
```

Focused Backend/deployment tests:

```text
41 passed
```

`make test`:

```text
825 passed, 260 subtests passed
```

`make check`:

```text
825 passed, 260 subtests passed
Ruff passed
Contract validation passed
Scenario validation passed for 12 frozen and 24 expanded manifests
Golden set validation passed for 50 tasks
Context validation passed
Scripted and offline demos passed
```

Task Packet boundary:

```text
passed against f821f417b1e202f310d5bf208a5136fa408fd789
```

`git diff --check`:

```text
passed
```

## Scope

Changed files:

- `tests/unit/test_multi_host_deployment.py`
- `docs/task_packets/issue-71-backend-egress-policy-phase-b.json`

The runtime smoke is image-gated during ordinary test collection. The Task Packet explicitly builds `workbench-1:issue-71-smoke` before executing the smoke, ensuring the evidence command runs the test rather than reporting a skip.

## Risks and fallback

- Docker engines that cannot route a published host port through the controller bridge gateway may report an environment limitation. The test must not be made to pass by weakening the allow-list.
- The smoke creates uniquely named Compose projects and removes them during cleanup.
- Rollback consists of reverting this test-and-evidence commit; no production behavior is affected.

## Required review

Please request explicit review from:

- Integration Owner
- Linux Owner

This PR supplies the remaining technical evidence but does not substitute for their approval.

Closes #71