### PR TITLE
feat(mcu): enforce command deduplication and sequence-wrap semantics

### DIFF
--- a/docs/architecture/mcu-command-dedup-v1.md
+++ b/docs/architecture/mcu-command-dedup-v1.md
@@ -1,0 +1,120 @@
+# MCU Command Deduplication V1
+
+Issue #61 implements the ordinary-command replay boundary between the strict
+Wire V1 decoder and the existing C safety state machine. It is allocation-free,
+uses no platform APIs, and runs from the same source on Host and QEMU.
+
+The frozen logical semantics remain in
+`docs/architecture/mcu-protocol-v1.md`. This document records the bounded C
+implementation choices; it does not add a field or change a Wire V1 value.
+
+## Serial classification
+
+Ordinary command IDs are `0..32767`. The complete low 15 bits are a serial
+number modulo 32768. For a candidate and the most recently accepted serial:
+
+```text
+delta = (candidate - last_accepted) mod 32768
+```
+
+- `delta == 0` identifies the current retained command;
+- `1 <= delta <= 16383` is serially new;
+- `16384 <= delta <= 32767` is stale or ambiguous unless the exact ID is still
+  in the configured replay window.
+
+The implementation retains eight accepted ordinary-command records. This
+covers the current host policy of one in-flight ordinary command plus its
+bounded retry attempts. A retained earlier ID may replay while it remains in
+that window. The ninth distinct accepted command overwrites the oldest slot;
+later traffic for the evicted ID fails with `duplicate_frame`.
+
+A half-range-new candidate takes precedence over an old cache entry with the
+same numeric ID. If that forward transition crosses from a larger ID to a
+smaller ID, the receiver clears every pre-wrap record before storing the new
+one. Consequently `32766 -> 32767 -> 0 -> 1` advances normally, but a delayed
+pre-wrap `32767` after `0` is stale and cannot replay an old ACK.
+
+The host must not exceed the eight-record retention budget. Expanding the
+in-flight policy requires an explicit review of this constant and the firmware
+storage budget; it must not silently rely on the 16384 half range as a queue.
+
+## New command and replay behavior
+
+`mcu_command_dedup_receive()` accepts only a completely validated ordinary
+`COMMAND`. The first serially new command dispatches exactly one event to the C
+safety state machine:
+
+| Opcode | Safety event | Successful mode |
+| --- | --- | --- |
+| `move` | `BEGIN_MOVE` | `moving` |
+| `grip_open` | `BEGIN_MOVE` | `moving` |
+| `grip_close` | `BEGIN_MOVE` | `moving` |
+| `hold` | `BEGIN_HOLD` | `holding` |
+| `heartbeat` | `HEARTBEAT` | current non-faulted mode |
+
+The resulting ordinary ACK is cached even if the state machine rejects the
+new event. That prevents the same ID from becoming executable later after a
+state change. A repeated ID with the same opcode returns the cached
+`result_code`, `fault_code`, and `device_mode` without dispatching that event
+again.
+
+`retry_count` is attempt metadata. The same count is an exact link replay; a
+strictly greater count is a protocol retry and is echoed in the replayed ACK.
+A decreasing count, including `255 -> 0`, is stale and rejected. Retry traffic
+does not extend the software watchdog deadline.
+
+A retained ID with a different opcode is a conflicting duplicate. Conflicts,
+decreasing attempts, and unretained stale or ambiguous IDs:
+
+1. do not dispatch the requested ordinary event;
+2. enter or preserve the fail-closed MCU fault state;
+3. return a rejected ordinary ACK with `duplicate_frame`; and
+4. cannot refresh the software watchdog.
+
+Malformed Wire V1 input is rejected before this API by the codec and does not
+enter replay history. If an invalid wire object reaches this function, it
+returns no record and does not mutate the state machine or dedup state.
+
+## Session and reset boundary
+
+Wire V1 has no boot/session epoch. `mcu_command_dedup_init()` therefore starts
+with ordinary dispatch closed and empty history. The transport may call
+`mcu_command_dedup_open_session(..., true)` only after it has discarded queued
+pre-session traffic and established the trusted out-of-band startup gate. A
+command received while closed produces no ACK and no state-machine event.
+
+An active session cannot be reopened to erase history. The trusted transport
+must explicitly close it, drain old traffic, and then open a fresh session.
+MCU reboot follows the same closed initialization path.
+
+An authorized safety-state reset is not a transport restart and does not clear
+replay history. A duplicate command after reset still replays its historical
+ACK without restarting motion. Neither serial wrap nor session establishment
+is reset authorization.
+
+## STOP independence
+
+STOP uses the disjoint `32768..65535` partition and does not enter this replay
+array. A valid STOP is routed directly to `mcu_watchdog_receive_stop()` before
+ordinary correlation handling. It remains processable when the ordinary
+window is full or the ordinary session gate is closed. Pending duplicate STOP
+handling, retry monotonicity, ACK handoff, and timeout behavior remain owned by
+`docs/architecture/mcu-watchdog-v1.md`.
+
+The transport is the single writer of the dedup, state-machine, and watchdog
+objects. If ingress can arrive from an ISR and a task, that owner must serialize
+the calls and preserve STOP-first dispatch; this core does not hide a lock or
+critical section inside platform-independent code.
+
+## Resource and evidence boundary
+
+The state contains exactly eight static entries and is compile-time bounded to
+256 bytes. It has no allocator, floating point, vendor header, register access,
+clock source, thread, or queue. Host and QEMU run the same exhaustive 15-bit
+delta corpus plus retained replay, conflict, eviction, retry-wrap, session,
+trusted-reset, and STOP-priority vectors.
+
+These results prove platform-independent correlation and state-machine dispatch
+behavior. They do not prove a CAN controller, STM32/CH32 HAL, physical bus,
+actuator execution, motor stopping, electrical safety, or hard-real-time
+latency. Those remain separate owner-gated evidence.

--- a/docs/task_packets/issue-61-mcu-command-dedup.json
+++ b/docs/task_packets/issue-61-mcu-command-dedup.json
@@ -1,0 +1,86 @@
+{
+  "issue": 61,
+  "human_owner": "TH3478",
+  "objective": "Implement allocation-free MCU ordinary-command replay protection with deterministic duplicate ACK replay, fixed-width serial wrap handling, a trusted startup-session gate, and shared Host/QEMU boundary evidence.",
+  "allowed_paths": [
+    "firmware/mcu/core/command_dedup.h",
+    "firmware/mcu/core/command_dedup.c",
+    "firmware/mcu/tests/command_dedup_tests.h",
+    "firmware/mcu/tests/command_dedup_tests.c",
+    "firmware/mcu/tests/main_host.c",
+    "firmware/mcu/hal/qemu/main_qemu.c",
+    "firmware/mcu/Makefile",
+    "firmware/mcu/README.md",
+    "docs/architecture/mcu-command-dedup-v1.md",
+    "docs/task_packets/issue-61-mcu-command-dedup.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "docs/architecture/mcu-protocol-v1.md",
+    "docs/architecture/mcu-wire-v1.md",
+    "docs/architecture/mcu-watchdog-v1.md",
+    "interfaces/json_schema/mcu_protocol.schema.json",
+    "interfaces/examples/mcu-frame-stop-ack.json",
+    "firmware/mcu/core/frame_codec.h",
+    "firmware/mcu/core/frame_codec.c",
+    "firmware/mcu/core/state_machine.h",
+    "firmware/mcu/core/state_machine.c",
+    "firmware/mcu/core/watchdog.h",
+    "firmware/mcu/core/watchdog.c",
+    "libs/hardware/**",
+    "firmware/virtual_mcu/**"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "libs/hardware/**",
+    "firmware/mcu/hal/ch32v307/**",
+    "firmware/virtual_mcu/**",
+    "robot/control/**",
+    "hardware/**",
+    "services/**",
+    ".github/**"
+  ],
+  "acceptance": [
+    "Ordinary command IDs use the frozen 15-bit serial and half-range comparison; max-minus-one, max, zero and one boundary vectors are deterministic.",
+    "The first structurally valid serial in a trusted session dispatches its state-machine event exactly once and produces one correlated ordinary ACK.",
+    "A retained command with matching ID and opcode replays the cached semantic ACK, echoes a non-decreasing retry_count and never dispatches the ordinary event again.",
+    "A retained command ID with a different opcode, a decreasing or wrapped retry_count, and a stale or ambiguous serial fail closed with duplicate_frame and no ordinary side effect.",
+    "The fixed eight-entry replay window evicts deterministically; out-of-window traffic is rejected and no dynamic allocation is used.",
+    "A forward serial wrap clears pre-wrap replay records before accepting zero so delayed old-epoch traffic cannot be accepted as a retry.",
+    "Initialization and session close disable ordinary dispatch; only a trusted gate that confirms queued traffic was discarded opens a fresh session, and an ordinary trusted reset does not erase replay history.",
+    "Structurally valid STOP traffic continues through the independent watchdog/STOP path and cannot be suppressed by a full ordinary-command window.",
+    "Only serially new accepted activity may refresh the software watchdog; duplicate, retry, conflict and stale traffic cannot extend its deadline.",
+    "The same exhaustive command-dedup tests run unchanged on Host and freestanding QEMU without vendor headers, floating point or hardware register access."
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-61-mcu-command-dedup.json",
+    "make -C firmware/mcu test-host",
+    "make -C firmware/mcu test-host-sanitize",
+    "make -C firmware/mcu test-qemu",
+    "make -C firmware/mcu verify-no-fp",
+    "make -C firmware/mcu size-check",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "Issue #61 Task Packet validation output.",
+    "Host command-dedup assertion and failure counts, including exhaustive serial boundary vectors.",
+    "ASan/UBSan output for the shared MCU corpus.",
+    "QEMU output from the same command-dedup test source.",
+    "verify-no-fp and size-check output for the freestanding image.",
+    "Repository test, contract, scenario and context-check output.",
+    "Final changed-path review and git diff --check proving the Task Packet boundary."
+  ],
+  "stop_conditions": [
+    "The implementation requires changing frozen JSON Schema, Pydantic models, Wire V1 numbers or logical protocol semantics.",
+    "An on-wire boot/session epoch or reset opcode would be required.",
+    "STOP would need to wait behind or consume the ordinary replay window.",
+    "The implementation requires a board HAL, vendor registers, motor control, host transport changes or physical CAN claims.",
+    "The configured host in-flight/retry budget cannot fit the fixed replay window.",
+    "The same core and test source cannot compile unchanged for Host and QEMU.",
+    "The implementation requires modifying .gitignore or unrelated local changes."
+  ]
+}

--- a/firmware/mcu/Makefile
+++ b/firmware/mcu/Makefile
@@ -16,7 +16,8 @@ HOSTCC  ?= cc
 
 BUILD   := build
 CORE    := $(wildcard core/*.c)
-SHARED_TESTS := tests/state_machine_tests.c tests/frame_codec_tests.c tests/watchdog_tests.c
+SHARED_TESTS := tests/state_machine_tests.c tests/frame_codec_tests.c tests/watchdog_tests.c \
+                tests/command_dedup_tests.c
 HOST_TESTS := $(SHARED_TESTS) tests/main_host.c
 
 # rv32imac: no FPU. -mabi=ilp32 (not ilp32f/d) so a stray double is a link error

--- a/firmware/mcu/README.md
+++ b/firmware/mcu/README.md
@@ -66,8 +66,9 @@ The platform-independent C safety state machine is implemented by Issue #53.
 Issue #54 adds the strict Classic CAN Wire V1 codec and shared Host/QEMU golden
 vectors. Issue #60 adds the allocation-free heartbeat watchdog, bounded STOP
 acknowledgement timing, fake-clock tests and QEMU machine-timer/watchdog
-evidence. The HAL CAN driver, command deduplication and physical CAN validation
-remain separate follow-up tasks.
+evidence. Issue #61 adds the fixed-memory ordinary-command replay window,
+trusted startup-session gate and shared Host/QEMU wraparound corpus. The HAL CAN
+driver and physical CAN validation remain separate follow-up tasks.
 
 ## Timing safety path
 
@@ -88,3 +89,20 @@ While the STOP handoff is pending, an equal `retry_count` is an exact
 link-level replay and a strictly greater count is a protocol-level retry.
 Decreasing or wrapped retry counts are stale and rejected without changing the
 pending ACK correlation.
+
+## Ordinary command replay protection
+
+`core/command_dedup.[ch]` is the platform-independent entry for decoded
+ordinary commands. It keeps eight cached semantic ACK records, applies the
+frozen 15-bit half-range comparison, clears pre-wrap records before accepting a
+new serial epoch, and never allocates. Exact duplicates and increasing
+protocol retries replay the original result without dispatching another safety
+event or refreshing the watchdog. Conflicting, decreasing, stale and evicted
+attempts fail closed with `duplicate_frame`.
+
+Boot starts with ordinary command dispatch closed. The transport must drain
+queued pre-session traffic before opening the trusted session gate; an ordinary
+safety reset does not erase replay history. STOP remains on the independent
+watchdog path and cannot be consumed by a full or closed ordinary window. The
+exact algorithm and evidence limits are documented in
+`docs/architecture/mcu-command-dedup-v1.md`.

--- a/firmware/mcu/core/command_dedup.c
+++ b/firmware/mcu/core/command_dedup.c
@@ -1,0 +1,424 @@
+#include "command_dedup.h"
+
+#define MCU_COMMAND_DEDUP_COOKIE 0x44454431u
+
+_Static_assert(sizeof(mcu_command_dedup_t) <= MCU_COMMAND_DEDUP_STORAGE_BUDGET_BYTES,
+               "command dedup state exceeds its fixed storage budget");
+
+static bool ordinary_opcode_is_valid(mcu_wire_opcode_t opcode)
+{
+    return opcode == MCU_WIRE_OPCODE_MOVE || opcode == MCU_WIRE_OPCODE_GRIP_OPEN ||
+           opcode == MCU_WIRE_OPCODE_GRIP_CLOSE || opcode == MCU_WIRE_OPCODE_HOLD ||
+           opcode == MCU_WIRE_OPCODE_HEARTBEAT;
+}
+
+static bool cached_response_is_valid(const mcu_command_replay_entry_t *entry)
+{
+    if (!entry->valid || entry->command_id > MCU_COMMAND_ID_MAX ||
+        !ordinary_opcode_is_valid(entry->opcode)) {
+        return false;
+    }
+    if (entry->result_code == MCU_WIRE_RESULT_ACCEPTED) {
+        return entry->fault_code == MCU_WIRE_FAULT_NONE &&
+               entry->device_mode >= MCU_WIRE_MODE_IDLE &&
+               entry->device_mode <= MCU_WIRE_MODE_STOPPED;
+    }
+    return entry->result_code == MCU_WIRE_RESULT_REJECTED &&
+           (entry->fault_code == MCU_WIRE_FAULT_DUPLICATE_FRAME ||
+            entry->fault_code == MCU_WIRE_FAULT_MALFORMED_FRAME) &&
+           entry->device_mode == MCU_WIRE_MODE_FAULTED;
+}
+
+static void clear_frame(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_COMMAND;
+    frame->command_id = 0u;
+    frame->sequence_no = 0u;
+    frame->opcode = MCU_WIRE_OPCODE_RESERVED;
+    frame->retry_count = 0u;
+    frame->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    frame->fault_code = MCU_WIRE_FAULT_NONE;
+    frame->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void clear_record(mcu_command_record_t *record)
+{
+    record->outcome = MCU_COMMAND_OUTCOME_NONE;
+    record->ack_available = false;
+    record->ordinary_event_dispatched = false;
+    record->watchdog_refreshed = false;
+    clear_frame(&record->ack);
+}
+
+static void clear_entry(mcu_command_replay_entry_t *entry)
+{
+    entry->valid = false;
+    entry->command_id = 0u;
+    entry->opcode = MCU_WIRE_OPCODE_RESERVED;
+    entry->last_retry_count = 0u;
+    entry->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    entry->fault_code = MCU_WIRE_FAULT_NONE;
+    entry->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void clear_history(mcu_command_dedup_t *dedup)
+{
+    unsigned i;
+
+    dedup->has_last_accepted = false;
+    dedup->last_accepted_id = 0u;
+    dedup->next_slot = 0u;
+    for (i = 0u; i < MCU_COMMAND_REPLAY_WINDOW_SIZE; i++) {
+        clear_entry(&dedup->entries[i]);
+    }
+}
+
+void mcu_command_dedup_init(mcu_command_dedup_t *dedup)
+{
+    if (dedup == 0) {
+        return;
+    }
+
+    dedup->initialized = MCU_COMMAND_DEDUP_COOKIE;
+    dedup->session_open = false;
+    clear_history(dedup);
+}
+
+bool mcu_command_dedup_is_valid(const mcu_command_dedup_t *dedup)
+{
+    unsigned i;
+    unsigned j;
+    unsigned last_matches = 0u;
+    unsigned valid_entries = 0u;
+
+    if (dedup == 0 || dedup->initialized != MCU_COMMAND_DEDUP_COOKIE ||
+        dedup->next_slot >= MCU_COMMAND_REPLAY_WINDOW_SIZE) {
+        return false;
+    }
+    if (dedup->has_last_accepted && dedup->last_accepted_id > MCU_COMMAND_ID_MAX) {
+        return false;
+    }
+
+    for (i = 0u; i < MCU_COMMAND_REPLAY_WINDOW_SIZE; i++) {
+        const mcu_command_replay_entry_t *entry = &dedup->entries[i];
+
+        if (!entry->valid) {
+            continue;
+        }
+        valid_entries++;
+        if (!cached_response_is_valid(entry)) {
+            return false;
+        }
+        if (dedup->has_last_accepted && entry->command_id == dedup->last_accepted_id) {
+            last_matches++;
+        }
+        for (j = i + 1u; j < MCU_COMMAND_REPLAY_WINDOW_SIZE; j++) {
+            if (dedup->entries[j].valid && dedup->entries[j].command_id == entry->command_id) {
+                return false;
+            }
+        }
+    }
+
+    if (!dedup->session_open) {
+        return !dedup->has_last_accepted && valid_entries == 0u && dedup->next_slot == 0u;
+    }
+    if (!dedup->has_last_accepted) {
+        return valid_entries == 0u && dedup->next_slot == 0u;
+    }
+    return valid_entries > 0u && last_matches == 1u;
+}
+
+bool mcu_command_dedup_open_session(mcu_command_dedup_t *dedup,
+                                    bool queued_traffic_discarded)
+{
+    if (!mcu_command_dedup_is_valid(dedup) || dedup->session_open ||
+        !queued_traffic_discarded) {
+        return false;
+    }
+
+    clear_history(dedup);
+    dedup->session_open = true;
+    return true;
+}
+
+bool mcu_command_dedup_close_session(mcu_command_dedup_t *dedup)
+{
+    if (!mcu_command_dedup_is_valid(dedup)) {
+        return false;
+    }
+
+    clear_history(dedup);
+    dedup->session_open = false;
+    return true;
+}
+
+static mcu_command_replay_entry_t *find_entry(mcu_command_dedup_t *dedup,
+                                               uint16_t command_id)
+{
+    unsigned i;
+
+    for (i = 0u; i < MCU_COMMAND_REPLAY_WINDOW_SIZE; i++) {
+        if (dedup->entries[i].valid && dedup->entries[i].command_id == command_id) {
+            return &dedup->entries[i];
+        }
+    }
+    return 0;
+}
+
+static mcu_wire_device_mode_t map_mode(mcu_device_mode_t mode)
+{
+    switch (mode) {
+    case MCU_DEVICE_MODE_IDLE:
+        return MCU_WIRE_MODE_IDLE;
+    case MCU_DEVICE_MODE_MOVING:
+        return MCU_WIRE_MODE_MOVING;
+    case MCU_DEVICE_MODE_HOLDING:
+        return MCU_WIRE_MODE_HOLDING;
+    case MCU_DEVICE_MODE_STOPPED:
+        return MCU_WIRE_MODE_STOPPED;
+    case MCU_DEVICE_MODE_FAULTED:
+    case MCU_DEVICE_MODE_COUNT:
+    default:
+        return MCU_WIRE_MODE_FAULTED;
+    }
+}
+
+static void make_ack(const mcu_wire_frame_t *command,
+                     mcu_wire_result_t result_code,
+                     mcu_wire_fault_t fault_code,
+                     mcu_wire_device_mode_t device_mode,
+                     mcu_wire_frame_t *ack)
+{
+    clear_frame(ack);
+    ack->kind = MCU_WIRE_FRAME_ACK;
+    ack->command_id = command->command_id;
+    ack->opcode = command->opcode;
+    ack->retry_count = command->retry_count;
+    ack->result_code = result_code;
+    ack->fault_code = fault_code;
+    ack->device_mode = device_mode;
+}
+
+static void make_cached_ack(const mcu_wire_frame_t *command,
+                            const mcu_command_replay_entry_t *entry,
+                            mcu_wire_frame_t *ack)
+{
+    make_ack(command,
+             entry->result_code,
+             entry->fault_code,
+             entry->device_mode,
+             ack);
+}
+
+static void raise_duplicate_fault(mcu_state_machine_t *machine)
+{
+    mcu_event_t event;
+    mcu_transition_result_t transition;
+
+    event.kind = MCU_EVENT_RAISE_FAULT;
+    event.fault_code = MCU_FAULT_DUPLICATE_FRAME;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(machine, &event, &transition);
+}
+
+static void reject_correlation(mcu_state_machine_t *machine,
+                               mcu_watchdog_t *watchdog,
+                               const mcu_wire_frame_t *command,
+                               uint64_t now_us,
+                               mcu_command_outcome_t outcome,
+                               mcu_watchdog_activity_t activity,
+                               mcu_command_record_t *record)
+{
+    raise_duplicate_fault(machine);
+    clear_record(record);
+    record->outcome = outcome;
+    record->ack_available = true;
+    make_ack(command,
+             MCU_WIRE_RESULT_REJECTED,
+             MCU_WIRE_FAULT_DUPLICATE_FRAME,
+             MCU_WIRE_MODE_FAULTED,
+             &record->ack);
+    record->watchdog_refreshed =
+      mcu_watchdog_note_activity(watchdog, machine, activity, now_us);
+}
+
+static mcu_event_kind_t opcode_to_event(mcu_wire_opcode_t opcode)
+{
+    switch (opcode) {
+    case MCU_WIRE_OPCODE_HOLD:
+        return MCU_EVENT_BEGIN_HOLD;
+    case MCU_WIRE_OPCODE_HEARTBEAT:
+        return MCU_EVENT_HEARTBEAT;
+    case MCU_WIRE_OPCODE_MOVE:
+    case MCU_WIRE_OPCODE_GRIP_OPEN:
+    case MCU_WIRE_OPCODE_GRIP_CLOSE:
+    case MCU_WIRE_OPCODE_RESERVED:
+    case MCU_WIRE_OPCODE_STOP:
+    case MCU_WIRE_OPCODE_COUNT:
+    default:
+        return MCU_EVENT_BEGIN_MOVE;
+    }
+}
+
+static void dispatch_new_command(mcu_state_machine_t *machine,
+                                 const mcu_wire_frame_t *command,
+                                 mcu_transition_result_t *transition)
+{
+    mcu_event_t event;
+
+    event.kind = opcode_to_event(command->opcode);
+    event.fault_code = MCU_FAULT_NONE;
+    event.reset_authorized = false;
+    event.cause_cleared = false;
+    mcu_sm_dispatch(machine, &event, transition);
+}
+
+static void cache_new_result(mcu_command_dedup_t *dedup,
+                             const mcu_wire_frame_t *command,
+                             const mcu_wire_frame_t *ack)
+{
+    mcu_command_replay_entry_t *entry = &dedup->entries[dedup->next_slot];
+
+    entry->valid = true;
+    entry->command_id = command->command_id;
+    entry->opcode = command->opcode;
+    entry->last_retry_count = command->retry_count;
+    entry->result_code = ack->result_code;
+    entry->fault_code = ack->fault_code;
+    entry->device_mode = ack->device_mode;
+    dedup->next_slot = (uint8_t)((dedup->next_slot + 1u) % MCU_COMMAND_REPLAY_WINDOW_SIZE);
+    dedup->has_last_accepted = true;
+    dedup->last_accepted_id = command->command_id;
+}
+
+static uint16_t serial_delta(uint16_t candidate, uint16_t last_accepted)
+{
+    return (uint16_t)((candidate - last_accepted) & MCU_COMMAND_SERIAL_MASK);
+}
+
+bool mcu_command_dedup_receive(mcu_command_dedup_t *dedup,
+                               mcu_state_machine_t *machine,
+                               mcu_watchdog_t *watchdog,
+                               const mcu_wire_frame_t *command,
+                               uint64_t now_us,
+                               mcu_command_record_t *record)
+{
+    uint16_t arbitration_id;
+    uint8_t encoded[MCU_WIRE_DLC];
+    uint8_t encoded_length;
+    mcu_command_replay_entry_t *entry;
+    mcu_transition_result_t transition;
+    uint16_t delta;
+    bool wrapped;
+
+    if (dedup == 0 || machine == 0 || watchdog == 0 || command == 0 || record == 0 ||
+        !mcu_command_dedup_is_valid(dedup) || !mcu_sm_is_valid(machine) ||
+        !mcu_watchdog_is_valid(watchdog)) {
+        return false;
+    }
+    if (mcu_frame_encode(command,
+                         &arbitration_id,
+                         encoded,
+                         sizeof(encoded),
+                         &encoded_length) != MCU_CODEC_OK ||
+        arbitration_id != MCU_CAN_ID_COMMAND || encoded_length != MCU_WIRE_DLC) {
+        return false;
+    }
+
+    clear_record(record);
+    if (!dedup->session_open) {
+        record->outcome = MCU_COMMAND_OUTCOME_SESSION_CLOSED;
+        return true;
+    }
+
+    delta = dedup->has_last_accepted
+              ? serial_delta(command->command_id, dedup->last_accepted_id)
+              : 1u;
+    entry = find_entry(dedup, command->command_id);
+    /* A half-range-new candidate wins over an old retained ID with the same
+     * numeric value. That is what distinguishes a genuine serial wrap from a
+     * delayed old-epoch replay when Wire V1 has no epoch field. */
+    if (dedup->has_last_accepted && delta != 0u &&
+        delta < MCU_COMMAND_SERIAL_HALF_RANGE) {
+        entry = 0;
+    }
+    if (entry != 0) {
+        if (entry->opcode != command->opcode) {
+            reject_correlation(machine,
+                               watchdog,
+                               command,
+                               now_us,
+                               MCU_COMMAND_OUTCOME_REJECTED_CONFLICT,
+                               MCU_WATCHDOG_ACTIVITY_DUPLICATE,
+                               record);
+            return true;
+        }
+        if (command->retry_count < entry->last_retry_count) {
+            reject_correlation(machine,
+                               watchdog,
+                               command,
+                               now_us,
+                               MCU_COMMAND_OUTCOME_REJECTED_RETRY,
+                               MCU_WATCHDOG_ACTIVITY_STALE,
+                               record);
+            return true;
+        }
+
+        record->outcome = MCU_COMMAND_OUTCOME_REPLAYED;
+        record->ack_available = true;
+        make_cached_ack(command, entry, &record->ack);
+        record->watchdog_refreshed = mcu_watchdog_note_activity(
+          watchdog,
+          machine,
+          command->retry_count == entry->last_retry_count
+            ? MCU_WATCHDOG_ACTIVITY_DUPLICATE
+            : MCU_WATCHDOG_ACTIVITY_RETRY,
+          now_us);
+        entry->last_retry_count = command->retry_count;
+        return true;
+    }
+
+    if (dedup->has_last_accepted &&
+        (delta == 0u || delta >= MCU_COMMAND_SERIAL_HALF_RANGE)) {
+        reject_correlation(machine,
+                           watchdog,
+                           command,
+                           now_us,
+                           MCU_COMMAND_OUTCOME_REJECTED_STALE,
+                           MCU_WATCHDOG_ACTIVITY_STALE,
+                           record);
+        return true;
+    }
+
+    wrapped = dedup->has_last_accepted && command->command_id < dedup->last_accepted_id;
+    if (wrapped) {
+        /* A forward max-to-zero transition begins a new serial epoch. Wire V1
+         * carries no epoch bit, so no pre-wrap cache entry may survive. */
+        clear_history(dedup);
+    }
+
+    dispatch_new_command(machine, command, &transition);
+    record->outcome = transition.result_code == MCU_RESULT_ACCEPTED
+                        ? MCU_COMMAND_OUTCOME_ACCEPTED_NEW
+                        : MCU_COMMAND_OUTCOME_REJECTED_NEW;
+    record->ack_available = true;
+    record->ordinary_event_dispatched = true;
+    if (transition.result_code == MCU_RESULT_ACCEPTED) {
+        make_ack(command,
+                 MCU_WIRE_RESULT_ACCEPTED,
+                 MCU_WIRE_FAULT_NONE,
+                 map_mode(transition.device_mode),
+                 &record->ack);
+    } else {
+        make_ack(command,
+                 MCU_WIRE_RESULT_REJECTED,
+                 MCU_WIRE_FAULT_MALFORMED_FRAME,
+                 MCU_WIRE_MODE_FAULTED,
+                 &record->ack);
+    }
+    cache_new_result(dedup, command, &record->ack);
+    record->watchdog_refreshed = mcu_watchdog_note_activity(
+      watchdog, machine, MCU_WATCHDOG_ACTIVITY_VALID_NEW, now_us);
+    return true;
+}

--- a/firmware/mcu/core/command_dedup.h
+++ b/firmware/mcu/core/command_dedup.h
@@ -1,0 +1,87 @@
+#ifndef MCU_COMMAND_DEDUP_H
+#define MCU_COMMAND_DEDUP_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "frame_codec.h"
+#include "state_machine.h"
+#include "watchdog.h"
+
+/* Ordinary command IDs use the low 15 bits as a serial number.  Eight
+ * retained results cover the current bounded host implementation (one
+ * in-flight command plus retries) while keeping firmware memory fixed. */
+#define MCU_COMMAND_SERIAL_MASK 0x7fffu
+#define MCU_COMMAND_SERIAL_HALF_RANGE 0x4000u
+#define MCU_COMMAND_REPLAY_WINDOW_SIZE 8u
+#define MCU_COMMAND_DEDUP_STORAGE_BUDGET_BYTES 256u
+
+typedef enum {
+    MCU_COMMAND_OUTCOME_NONE = 0,
+    MCU_COMMAND_OUTCOME_SESSION_CLOSED,
+    MCU_COMMAND_OUTCOME_ACCEPTED_NEW,
+    MCU_COMMAND_OUTCOME_REJECTED_NEW,
+    MCU_COMMAND_OUTCOME_REPLAYED,
+    MCU_COMMAND_OUTCOME_REJECTED_CONFLICT,
+    MCU_COMMAND_OUTCOME_REJECTED_STALE,
+    MCU_COMMAND_OUTCOME_REJECTED_RETRY,
+    MCU_COMMAND_OUTCOME_COUNT
+} mcu_command_outcome_t;
+
+typedef struct {
+    mcu_command_outcome_t outcome;
+    bool ack_available;
+    /* True only when a serially new ordinary command reached the safety state
+     * machine. Replays and correlation rejections never set this flag. */
+    bool ordinary_event_dispatched;
+    bool watchdog_refreshed;
+    mcu_wire_frame_t ack;
+} mcu_command_record_t;
+
+typedef struct {
+    bool valid;
+    uint16_t command_id;
+    mcu_wire_opcode_t opcode;
+    uint8_t last_retry_count;
+    mcu_wire_result_t result_code;
+    mcu_wire_fault_t fault_code;
+    mcu_wire_device_mode_t device_mode;
+} mcu_command_replay_entry_t;
+
+typedef struct {
+    uint32_t initialized;
+    bool session_open;
+    bool has_last_accepted;
+    uint16_t last_accepted_id;
+    uint8_t next_slot;
+    mcu_command_replay_entry_t entries[MCU_COMMAND_REPLAY_WINDOW_SIZE];
+} mcu_command_dedup_t;
+
+/* Boot initialization deliberately leaves ordinary command dispatch closed.
+ * STOP remains owned by mcu_watchdog_receive_stop() and is not gated here. */
+void mcu_command_dedup_init(mcu_command_dedup_t *dedup);
+bool mcu_command_dedup_is_valid(const mcu_command_dedup_t *dedup);
+
+/* This trusted transport gate may open only after queued pre-session traffic
+ * has been discarded. Reopening an already active session is rejected so a
+ * caller cannot silently erase replay history. */
+bool mcu_command_dedup_open_session(mcu_command_dedup_t *dedup,
+                                    bool queued_traffic_discarded);
+bool mcu_command_dedup_close_session(mcu_command_dedup_t *dedup);
+
+/* Receive one fully decoded ordinary COMMAND. Structurally invalid input and
+ * corrupt dependencies return false without modifying the output. A closed
+ * session returns a record with no ACK. Every other successful call returns a
+ * correlated ACK; only a serially new command dispatches an ordinary event.
+ *
+ * MOVE and grip commands enter MOVING, HOLD enters HOLDING, and HEARTBEAT
+ * preserves the current safe state. Only accepted serially new activity can
+ * refresh the software watchdog. */
+bool mcu_command_dedup_receive(mcu_command_dedup_t *dedup,
+                               mcu_state_machine_t *machine,
+                               mcu_watchdog_t *watchdog,
+                               const mcu_wire_frame_t *command,
+                               uint64_t now_us,
+                               mcu_command_record_t *record);
+
+#endif /* MCU_COMMAND_DEDUP_H */

--- a/firmware/mcu/hal/qemu/main_qemu.c
+++ b/firmware/mcu/hal/qemu/main_qemu.c
@@ -16,6 +16,7 @@
  *   - mtime advances, so FW5's watchdog has a clock to trust
  */
 #include "hal.h"
+#include "command_dedup_tests.h"
 #include "frame_codec_tests.h"
 #include "state_machine_tests.h"
 #include "watchdog.h"
@@ -170,6 +171,21 @@ static int run_watchdog_tests(void)
     return report.failures == 0u ? 0 : 6;
 }
 
+static int run_command_dedup_tests(void)
+{
+    mcu_test_report_t report;
+
+    mcu_command_dedup_run_tests(&report);
+    hal_puts("[mcu] command-dedup assertions=");
+    hal_put_u32(report.assertions);
+    hal_puts(" failures=");
+    hal_put_u32(report.failures);
+    hal_puts(" first_failure=");
+    hal_put_u32(report.first_failure);
+    hal_putc('\n');
+    return report.failures == 0u ? 0 : 10;
+}
+
 static int run_qemu_timing_evidence(void)
 {
     mcu_event_t begin_move;
@@ -242,6 +258,7 @@ int main(void)
     rc |= run_state_machine_tests();
     rc |= run_frame_codec_tests();
     rc |= run_watchdog_tests();
+    rc |= run_command_dedup_tests();
     rc |= run_qemu_timing_evidence();
 
     /* CAN is deliberately not checked: hal_can_init returns false until FW10,

--- a/firmware/mcu/tests/command_dedup_tests.c
+++ b/firmware/mcu/tests/command_dedup_tests.c
@@ -1,0 +1,851 @@
+#include "command_dedup_tests.h"
+
+#include <stdbool.h>
+
+#include "command_dedup.h"
+
+static void check(mcu_test_report_t *report, bool condition)
+{
+    report->assertions++;
+    if (!condition) {
+        report->failures++;
+        if (report->first_failure == 0u) {
+            report->first_failure = report->assertions;
+        }
+    }
+}
+
+static void make_command(mcu_wire_frame_t *command,
+                         uint16_t command_id,
+                         mcu_wire_opcode_t opcode,
+                         uint8_t retry_count)
+{
+    command->kind = MCU_WIRE_FRAME_COMMAND;
+    command->command_id = command_id;
+    command->sequence_no = 0u;
+    command->opcode = opcode;
+    command->retry_count = retry_count;
+    command->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    command->fault_code = MCU_WIRE_FAULT_NONE;
+    command->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void make_stop(mcu_wire_frame_t *stop, uint16_t command_id, uint8_t retry_count)
+{
+    make_command(stop, command_id, MCU_WIRE_OPCODE_STOP, retry_count);
+    stop->kind = MCU_WIRE_FRAME_STOP;
+}
+
+static void init_open(mcu_command_dedup_t *dedup,
+                      mcu_state_machine_t *machine,
+                      mcu_watchdog_t *watchdog)
+{
+    mcu_command_dedup_init(dedup);
+    mcu_sm_init(machine);
+    mcu_watchdog_init(watchdog, 0u);
+    (void)mcu_command_dedup_open_session(dedup, true);
+}
+
+static bool receive(mcu_command_dedup_t *dedup,
+                    mcu_state_machine_t *machine,
+                    mcu_watchdog_t *watchdog,
+                    uint16_t command_id,
+                    mcu_wire_opcode_t opcode,
+                    uint8_t retry_count,
+                    uint64_t now_us,
+                    mcu_command_record_t *record)
+{
+    mcu_wire_frame_t command;
+
+    make_command(&command, command_id, opcode, retry_count);
+    return mcu_command_dedup_receive(
+      dedup, machine, watchdog, &command, now_us, record);
+}
+
+static bool ack_is_encodable(const mcu_wire_frame_t *ack)
+{
+    uint16_t arbitration_id;
+    uint8_t encoded[MCU_WIRE_DLC];
+    uint8_t encoded_length;
+
+    return mcu_frame_encode(ack,
+                            &arbitration_id,
+                            encoded,
+                            sizeof(encoded),
+                            &encoded_length) == MCU_CODEC_OK &&
+           arbitration_id == MCU_CAN_ID_ACK && encoded_length == MCU_WIRE_DLC;
+}
+
+static bool semantic_ack_equal(const mcu_wire_frame_t *left,
+                               const mcu_wire_frame_t *right)
+{
+    return left->kind == right->kind && left->command_id == right->command_id &&
+           left->opcode == right->opcode && left->result_code == right->result_code &&
+           left->fault_code == right->fault_code && left->device_mode == right->device_mode;
+}
+
+static unsigned valid_entry_count(const mcu_command_dedup_t *dedup)
+{
+    unsigned count = 0u;
+    unsigned i;
+
+    for (i = 0u; i < MCU_COMMAND_REPLAY_WINDOW_SIZE; i++) {
+        if (dedup->entries[i].valid) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static void test_session_gate_and_restart_policy(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t record;
+
+    mcu_command_dedup_init(&dedup);
+    mcu_sm_init(&machine);
+    mcu_watchdog_init(&watchdog, 0u);
+    check(report, mcu_command_dedup_is_valid(&dedup));
+    check(report, sizeof(dedup) <= MCU_COMMAND_DEDUP_STORAGE_BUDGET_BYTES);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  73u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  1u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_SESSION_CLOSED);
+    check(report, !record.ack_available);
+    check(report, !record.ordinary_event_dispatched);
+    check(report, machine.state == MCU_STATE_IDLE);
+    check(report, !dedup.has_last_accepted);
+
+    check(report, !mcu_command_dedup_open_session(&dedup, false));
+    check(report, !dedup.session_open);
+    check(report, mcu_command_dedup_open_session(&dedup, true));
+    check(report, !mcu_command_dedup_open_session(&dedup, true));
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  73u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  2u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report, dedup.has_last_accepted && dedup.last_accepted_id == 73u);
+
+    check(report, mcu_command_dedup_close_session(&dedup));
+    check(report, mcu_command_dedup_is_valid(&dedup));
+    check(report, !dedup.session_open && !dedup.has_last_accepted);
+    check(report, valid_entry_count(&dedup) == 0u);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  73u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  3u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_SESSION_CLOSED);
+
+    /* The trusted transport has discarded old queued traffic, so an ID may
+     * become the first serial of the new session. */
+    check(report, mcu_command_dedup_open_session(&dedup, true));
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  73u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  4u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+}
+
+static void test_first_command_opcode_mapping(mcu_test_report_t *report)
+{
+    static const mcu_wire_opcode_t opcodes[] = {
+        MCU_WIRE_OPCODE_MOVE,
+        MCU_WIRE_OPCODE_GRIP_OPEN,
+        MCU_WIRE_OPCODE_GRIP_CLOSE,
+        MCU_WIRE_OPCODE_HOLD,
+        MCU_WIRE_OPCODE_HEARTBEAT,
+    };
+    static const mcu_wire_device_mode_t modes[] = {
+        MCU_WIRE_MODE_MOVING,
+        MCU_WIRE_MODE_MOVING,
+        MCU_WIRE_MODE_MOVING,
+        MCU_WIRE_MODE_HOLDING,
+        MCU_WIRE_MODE_IDLE,
+    };
+    unsigned i;
+
+    for (i = 0u; i < sizeof(opcodes) / sizeof(opcodes[0]); i++) {
+        mcu_command_dedup_t dedup;
+        mcu_state_machine_t machine;
+        mcu_watchdog_t watchdog;
+        mcu_command_record_t record;
+
+        init_open(&dedup, &machine, &watchdog);
+        check(report,
+              receive(&dedup,
+                      &machine,
+                      &watchdog,
+                      (uint16_t)(100u + i),
+                      opcodes[i],
+                      0u,
+                      1000u,
+                      &record));
+        check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+        check(report, record.ack_available);
+        check(report, record.ordinary_event_dispatched);
+        check(report, record.ack.result_code == MCU_WIRE_RESULT_ACCEPTED);
+        check(report, record.ack.fault_code == MCU_WIRE_FAULT_NONE);
+        check(report, record.ack.device_mode == modes[i]);
+        check(report, ack_is_encodable(&record.ack));
+        check(report,
+              record.watchdog_refreshed ==
+                (opcodes[i] != MCU_WIRE_OPCODE_HEARTBEAT));
+        check(report, mcu_command_dedup_is_valid(&dedup));
+    }
+}
+
+static void test_duplicate_and_retry_replay_once(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t first;
+    mcu_command_record_t replay;
+    uint64_t deadline;
+
+    init_open(&dedup, &machine, &watchdog);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  100u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  0u,
+                  1000u,
+                  &first));
+    check(report, first.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report, machine.state == MCU_STATE_EXECUTING);
+    check(report, watchdog.link_watchdog_armed);
+    deadline = watchdog.link_deadline_us;
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  100u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  0u,
+                  2000u,
+                  &replay));
+    check(report, replay.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+    check(report, !replay.ordinary_event_dispatched);
+    check(report, !replay.watchdog_refreshed);
+    check(report, semantic_ack_equal(&first.ack, &replay.ack));
+    check(report, replay.ack.retry_count == 0u);
+    check(report, watchdog.link_deadline_us == deadline);
+    check(report, machine.state == MCU_STATE_EXECUTING);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  100u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  1u,
+                  3000u,
+                  &replay));
+    check(report, replay.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+    check(report, replay.ack.retry_count == 1u);
+    check(report, semantic_ack_equal(&first.ack, &replay.ack));
+    check(report, watchdog.link_deadline_us == deadline);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  100u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  0u,
+                  4000u,
+                  &replay));
+    check(report, replay.outcome == MCU_COMMAND_OUTCOME_REJECTED_RETRY);
+    check(report, !replay.ordinary_event_dispatched);
+    check(report, replay.ack.result_code == MCU_WIRE_RESULT_REJECTED);
+    check(report, replay.ack.fault_code == MCU_WIRE_FAULT_DUPLICATE_FRAME);
+    check(report, replay.ack.device_mode == MCU_WIRE_MODE_FAULTED);
+    check(report, machine.state == MCU_STATE_FAULT);
+    check(report, machine.fault_code == MCU_FAULT_DUPLICATE_FRAME);
+    check(report, watchdog.link_deadline_us == deadline);
+    check(report, !watchdog.link_watchdog_armed);
+
+    /* The original semantic result remains immutable after the rejection. */
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  100u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  2u,
+                  5000u,
+                  &replay));
+    check(report, replay.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+    check(report, semantic_ack_equal(&first.ack, &replay.ack));
+    check(report, replay.ack.retry_count == 2u);
+    check(report, machine.state == MCU_STATE_FAULT);
+}
+
+static void test_retry_count_does_not_wrap(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t record;
+
+    init_open(&dedup, &machine, &watchdog);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  1u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  254u,
+                  1u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  1u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  255u,
+                  2u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  1u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  3u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_REJECTED_RETRY);
+    check(report, record.ack.fault_code == MCU_WIRE_FAULT_DUPLICATE_FRAME);
+}
+
+static void test_conflicting_duplicate_fails_closed(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t first;
+    mcu_command_record_t conflict;
+    mcu_command_record_t replay;
+
+    init_open(&dedup, &machine, &watchdog);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  5u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  1u,
+                  &first));
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  5u,
+                  MCU_WIRE_OPCODE_HOLD,
+                  0u,
+                  2u,
+                  &conflict));
+    check(report, conflict.outcome == MCU_COMMAND_OUTCOME_REJECTED_CONFLICT);
+    check(report, !conflict.ordinary_event_dispatched);
+    check(report, conflict.ack.result_code == MCU_WIRE_RESULT_REJECTED);
+    check(report, conflict.ack.fault_code == MCU_WIRE_FAULT_DUPLICATE_FRAME);
+    check(report, machine.state == MCU_STATE_FAULT);
+    check(report, machine.fault_code == MCU_FAULT_DUPLICATE_FRAME);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  5u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  1u,
+                  3u,
+                  &replay));
+    check(report, replay.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+    check(report, semantic_ack_equal(&first.ack, &replay.ack));
+    check(report, !replay.ordinary_event_dispatched);
+}
+
+static void test_rejected_new_result_is_replayed(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t first;
+    mcu_command_record_t replay;
+    mcu_event_t stop;
+    mcu_transition_result_t transition;
+
+    init_open(&dedup, &machine, &watchdog);
+    stop.kind = MCU_EVENT_STOP;
+    stop.fault_code = MCU_FAULT_NONE;
+    stop.reset_authorized = false;
+    stop.cause_cleared = false;
+    mcu_sm_dispatch(&machine, &stop, &transition);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  90u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  0u,
+                  1u,
+                  &first));
+    check(report, first.outcome == MCU_COMMAND_OUTCOME_REJECTED_NEW);
+    check(report, first.ordinary_event_dispatched);
+    check(report, first.ack.result_code == MCU_WIRE_RESULT_REJECTED);
+    check(report, first.ack.fault_code == MCU_WIRE_FAULT_MALFORMED_FRAME);
+    check(report, machine.state == MCU_STATE_FAULT);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  90u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  1u,
+                  2u,
+                  &replay));
+    check(report, replay.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+    check(report, !replay.ordinary_event_dispatched);
+    check(report, semantic_ack_equal(&first.ack, &replay.ack));
+}
+
+static void test_fixed_window_and_eviction(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t record;
+    unsigned i;
+
+    init_open(&dedup, &machine, &watchdog);
+    for (i = 0u; i < MCU_COMMAND_REPLAY_WINDOW_SIZE; i++) {
+        check(report,
+              receive(&dedup,
+                      &machine,
+                      &watchdog,
+                      (uint16_t)(100u + i),
+                      MCU_WIRE_OPCODE_HEARTBEAT,
+                      0u,
+                      i,
+                      &record));
+        check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    }
+    check(report, valid_entry_count(&dedup) == MCU_COMMAND_REPLAY_WINDOW_SIZE);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  100u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  1u,
+                  20u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  108u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  21u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report, valid_entry_count(&dedup) == MCU_COMMAND_REPLAY_WINDOW_SIZE);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  100u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  2u,
+                  22u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_REJECTED_STALE);
+    check(report, record.ack.fault_code == MCU_WIRE_FAULT_DUPLICATE_FRAME);
+    check(report, machine.state == MCU_STATE_FAULT);
+}
+
+static void test_all_serial_deltas(mcu_test_report_t *report)
+{
+    const uint16_t last = 12345u;
+    uint32_t candidate;
+
+    for (candidate = 0u; candidate <= MCU_COMMAND_ID_MAX; candidate++) {
+        mcu_command_dedup_t dedup;
+        mcu_state_machine_t machine;
+        mcu_watchdog_t watchdog;
+        mcu_command_record_t record;
+        uint16_t delta = (uint16_t)(((uint16_t)candidate - last) & MCU_COMMAND_SERIAL_MASK);
+
+        init_open(&dedup, &machine, &watchdog);
+        (void)receive(&dedup,
+                      &machine,
+                      &watchdog,
+                      last,
+                      MCU_WIRE_OPCODE_HEARTBEAT,
+                      0u,
+                      1u,
+                      &record);
+        check(report,
+              receive(&dedup,
+                      &machine,
+                      &watchdog,
+                      (uint16_t)candidate,
+                      MCU_WIRE_OPCODE_HEARTBEAT,
+                      0u,
+                      2u,
+                      &record));
+        if (delta == 0u) {
+            check(report, record.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+        } else if (delta < MCU_COMMAND_SERIAL_HALF_RANGE) {
+            check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+        } else {
+            check(report, record.outcome == MCU_COMMAND_OUTCOME_REJECTED_STALE);
+        }
+    }
+}
+
+static void test_wrap_boundaries_and_old_epoch_rejection(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t record;
+
+    init_open(&dedup, &machine, &watchdog);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  32766u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  1u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  32767u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  2u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  0u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  3u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report, valid_entry_count(&dedup) == 1u);
+    check(report, dedup.last_accepted_id == 0u);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  1u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  4u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+
+    init_open(&dedup, &machine, &watchdog);
+    (void)receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  32767u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  1u,
+                  &record);
+    (void)receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  0u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  2u,
+                  &record);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  32767u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  1u,
+                  3u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_REJECTED_STALE);
+    check(report, record.ack.fault_code == MCU_WIRE_FAULT_DUPLICATE_FRAME);
+}
+
+static void test_forward_wrap_beats_same_numeric_cached_id(mcu_test_report_t *report)
+{
+    static const uint16_t serials[] = {
+        0u, 5000u, 10000u, 15000u, 20000u, 25000u, 30000u, 32767u,
+    };
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t record;
+    unsigned i;
+
+    init_open(&dedup, &machine, &watchdog);
+    for (i = 0u; i < sizeof(serials) / sizeof(serials[0]); i++) {
+        check(report,
+              receive(&dedup,
+                      &machine,
+                      &watchdog,
+                      serials[i],
+                      MCU_WIRE_OPCODE_HEARTBEAT,
+                      0u,
+                      i,
+                      &record));
+        check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    }
+    check(report, valid_entry_count(&dedup) == MCU_COMMAND_REPLAY_WINDOW_SIZE);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  0u,
+                  MCU_WIRE_OPCODE_HEARTBEAT,
+                  0u,
+                  20u,
+                  &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_ACCEPTED_NEW);
+    check(report, record.ordinary_event_dispatched);
+    check(report, valid_entry_count(&dedup) == 1u);
+    check(report, dedup.last_accepted_id == 0u);
+}
+
+static void test_stop_bypasses_full_ordinary_window(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t command_record;
+    mcu_watchdog_record_t first_stop;
+    mcu_watchdog_record_t duplicate_stop;
+    mcu_wire_frame_t stop;
+    unsigned i;
+
+    init_open(&dedup, &machine, &watchdog);
+    for (i = 0u; i < MCU_COMMAND_REPLAY_WINDOW_SIZE; i++) {
+        (void)receive(&dedup,
+                      &machine,
+                      &watchdog,
+                      (uint16_t)i,
+                      MCU_WIRE_OPCODE_HEARTBEAT,
+                      0u,
+                      i,
+                      &command_record);
+    }
+    check(report, valid_entry_count(&dedup) == MCU_COMMAND_REPLAY_WINDOW_SIZE);
+
+    make_stop(&stop, MCU_STOP_ID_MIN + 61u, 0u);
+    check(report,
+          mcu_watchdog_receive_stop(&watchdog, &machine, &stop, 100u, &first_stop));
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, first_stop.kind == MCU_WATCHDOG_RECORD_STOP_ACK);
+    check(report, first_stop.frame.result_code == MCU_WIRE_RESULT_ACCEPTED);
+    check(report, valid_entry_count(&dedup) == MCU_COMMAND_REPLAY_WINDOW_SIZE);
+
+    check(report,
+          mcu_watchdog_receive_stop(
+            &watchdog, &machine, &stop, 101u, &duplicate_stop));
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, duplicate_stop.frame.result_code == MCU_WIRE_RESULT_ACCEPTED);
+
+    check(report, duplicate_stop.observed_at_us == first_stop.observed_at_us);
+    check(report, duplicate_stop.deadline_us == first_stop.deadline_us);
+    check(report,
+          mcu_watchdog_confirm_stop_ack(&watchdog,
+                                        stop.command_id,
+                                        stop.retry_count,
+                                        duplicate_stop.deadline_us));
+    check(report,
+          mcu_watchdog_receive_stop(
+            &watchdog, &machine, &stop, 102u, &duplicate_stop));
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, duplicate_stop.frame.result_code == MCU_WIRE_RESULT_ACCEPTED);
+
+    /* Boot/session gating is ordinary-command-only. */
+    mcu_command_dedup_init(&dedup);
+    mcu_sm_init(&machine);
+    mcu_watchdog_init(&watchdog, 0u);
+    make_stop(&stop, MCU_STOP_ID_MIN + 63u, 0u);
+    check(report, !dedup.session_open);
+    check(report,
+          mcu_watchdog_receive_stop(
+            &watchdog, &machine, &stop, 200u, &duplicate_stop));
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, duplicate_stop.frame.result_code == MCU_WIRE_RESULT_ACCEPTED);
+}
+
+static void test_trusted_reset_preserves_replay_history(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t first;
+    mcu_command_record_t replay;
+    mcu_watchdog_record_t stop_record;
+    mcu_wire_frame_t stop;
+    mcu_transition_result_t reset;
+
+    init_open(&dedup, &machine, &watchdog);
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  42u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  0u,
+                  1u,
+                  &first));
+    make_stop(&stop, MCU_STOP_ID_MIN + 62u, 0u);
+    check(report,
+          mcu_watchdog_receive_stop(&watchdog, &machine, &stop, 2u, &stop_record));
+    check(report,
+          mcu_watchdog_confirm_stop_ack(
+            &watchdog, stop.command_id, stop.retry_count, stop_record.deadline_us));
+    check(report,
+          mcu_watchdog_request_reset(
+            &watchdog, &machine, true, true, &reset));
+    check(report, machine.state == MCU_STATE_IDLE);
+    check(report, dedup.has_last_accepted && dedup.last_accepted_id == 42u);
+
+    check(report,
+          receive(&dedup,
+                  &machine,
+                  &watchdog,
+                  42u,
+                  MCU_WIRE_OPCODE_MOVE,
+                  1u,
+                  3u,
+                  &replay));
+    check(report, replay.outcome == MCU_COMMAND_OUTCOME_REPLAYED);
+    check(report, !replay.ordinary_event_dispatched);
+    check(report, semantic_ack_equal(&first.ack, &replay.ack));
+    check(report, machine.state == MCU_STATE_IDLE);
+    check(report, !watchdog.link_watchdog_armed);
+}
+
+static void test_invalid_input_and_corruption(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_command_record_t record;
+    mcu_wire_frame_t command;
+
+    init_open(&dedup, &machine, &watchdog);
+    make_command(&command, 1u, MCU_WIRE_OPCODE_HEARTBEAT, 0u);
+    record.outcome = MCU_COMMAND_OUTCOME_COUNT;
+    check(report,
+          !mcu_command_dedup_receive(
+            0, &machine, &watchdog, &command, 0u, &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_COUNT);
+    check(report,
+          !mcu_command_dedup_receive(
+            &dedup, 0, &watchdog, &command, 0u, &record));
+    check(report,
+          !mcu_command_dedup_receive(
+            &dedup, &machine, 0, &command, 0u, &record));
+    check(report,
+          !mcu_command_dedup_receive(
+            &dedup, &machine, &watchdog, 0, 0u, &record));
+    check(report,
+          !mcu_command_dedup_receive(
+            &dedup, &machine, &watchdog, &command, 0u, 0));
+
+    command.kind = MCU_WIRE_FRAME_STOP;
+    command.command_id = MCU_STOP_ID_MIN;
+    command.opcode = MCU_WIRE_OPCODE_STOP;
+    check(report,
+          !mcu_command_dedup_receive(
+            &dedup, &machine, &watchdog, &command, 0u, &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_COUNT);
+
+    dedup.initialized = 0u;
+    check(report, !mcu_command_dedup_is_valid(&dedup));
+    check(report,
+          !mcu_command_dedup_receive(
+            &dedup, &machine, &watchdog, &command, 0u, &record));
+    check(report, record.outcome == MCU_COMMAND_OUTCOME_COUNT);
+
+    mcu_command_dedup_init(0);
+    check(report, !mcu_command_dedup_is_valid(0));
+    check(report, !mcu_command_dedup_open_session(0, true));
+    check(report, !mcu_command_dedup_close_session(0));
+}
+
+void mcu_command_dedup_run_tests(mcu_test_report_t *report)
+{
+    report->assertions = 0u;
+    report->failures = 0u;
+    report->first_failure = 0u;
+
+    test_session_gate_and_restart_policy(report);
+    test_first_command_opcode_mapping(report);
+    test_duplicate_and_retry_replay_once(report);
+    test_retry_count_does_not_wrap(report);
+    test_conflicting_duplicate_fails_closed(report);
+    test_rejected_new_result_is_replayed(report);
+    test_fixed_window_and_eviction(report);
+    test_all_serial_deltas(report);
+    test_wrap_boundaries_and_old_epoch_rejection(report);
+    test_forward_wrap_beats_same_numeric_cached_id(report);
+    test_stop_bypasses_full_ordinary_window(report);
+    test_trusted_reset_preserves_replay_history(report);
+    test_invalid_input_and_corruption(report);
+}

--- a/firmware/mcu/tests/command_dedup_tests.h
+++ b/firmware/mcu/tests/command_dedup_tests.h
@@ -1,0 +1,8 @@
+#ifndef MCU_COMMAND_DEDUP_TESTS_H
+#define MCU_COMMAND_DEDUP_TESTS_H
+
+#include "state_machine_tests.h"
+
+void mcu_command_dedup_run_tests(mcu_test_report_t *report);
+
+#endif /* MCU_COMMAND_DEDUP_TESTS_H */

--- a/firmware/mcu/tests/main_host.c
+++ b/firmware/mcu/tests/main_host.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 
+#include "command_dedup_tests.h"
 #include "frame_codec_tests.h"
 #include "state_machine_tests.h"
 #include "watchdog_tests.h"
@@ -9,6 +10,7 @@ int main(void)
     mcu_test_report_t state_machine_report;
     mcu_test_report_t frame_codec_report;
     mcu_test_report_t watchdog_report;
+    mcu_test_report_t command_dedup_report;
 
     mcu_state_machine_run_tests(&state_machine_report);
     printf("[mcu-host] state-machine assertions=%u failures=%u first_failure=%u\n",
@@ -27,8 +29,14 @@ int main(void)
            (unsigned)watchdog_report.assertions,
            (unsigned)watchdog_report.failures,
            (unsigned)watchdog_report.first_failure);
+
+    mcu_command_dedup_run_tests(&command_dedup_report);
+    printf("[mcu-host] command-dedup assertions=%u failures=%u first_failure=%u\n",
+           (unsigned)command_dedup_report.assertions,
+           (unsigned)command_dedup_report.failures,
+           (unsigned)command_dedup_report.first_failure);
     return state_machine_report.failures == 0u && frame_codec_report.failures == 0u &&
-             watchdog_report.failures == 0u
+             watchdog_report.failures == 0u && command_dedup_report.failures == 0u
              ? 0
              : 1;
 }


### PR DESCRIPTION
## Related Issue

Closes #61

## What changed

- Added an allocation-free MCU command deduplication module with a fixed eight-entry ACK replay window.
- Defined 15-bit serial comparison and deterministic `32767 -> 0` wrap handling, including pre-wrap cache invalidation.
- Added trusted startup-session gating and monotonic retry handling.
- Replayed cached ACK semantics for valid duplicates without repeating side effects, while conflicting, stale, ambiguous, and decreasing-retry traffic fails closed.
- Kept STOP on its independent watchdog path so a full or closed ordinary-command window cannot suppress it.
- Added exhaustive host/QEMU vectors, architecture documentation, Task Packet evidence, and build integration.

## Interfaces affected

- Adds the internal MCU C API in `firmware/mcu/core/command_dedup.[ch]`.
- Integrates the shared tests into the host and QEMU test runners.
- Does not change Wire V1, JSON schemas, board HAL, motor control, or actuator behavior.

## Tests and commands

```sh
make -C firmware/mcu test-host
make -C firmware/mcu test-host-sanitize
make -C firmware/mcu test-qemu
make -C firmware/mcu size-check verify-no-fp
pytest -q
```

Additional static-analysis, conversion-warning, Task Packet, contract/scenario/context/golden, Ruff, formatting, strict MkDocs, and offline demo checks passed.

## Evidence

- MCU assertions passed: `436 + 20,637 + 184 + 65,778`.
- Boundary coverage includes max-1, max, zero, one, stale replay, conflicting duplicate, eviction, retry wrap/decrease, trusted restart, and duplicate STOP.
- ASan/UBSan and QEMU runs passed.
- Firmware remains within budget: `.text=22,340`, `.bss=196`.
- No floating-point instructions or allocator symbols were linked.
- Full repository suite passed with `824 passed`.

## Risks and rollback

- The startup gate relies on the transport to drain queued pre-session traffic before opening a trusted session because Wire V1 has no boot/session epoch.
- Evidence is limited to the platform-independent core and QEMU model; it does not prove physical CAN, board HAL, actuator execution, electrical safety, or hard-real-time behavior.
- Rollback is a revert of commit `ad97e90`.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.