### PR TITLE
test(kernel): emit validated wbcan stress evidence

### DIFF
--- a/docs/task_packets/linux-wbcan-saturation-stats.json
+++ b/docs/task_packets/linux-wbcan-saturation-stats.json
@@ -1,11 +1,12 @@
 {
   "issue": 157,
   "human_owner": "TH3478",
-  "objective": "Make wbcan netdev statistics race-safe and account for RX backlog drops under bounded saturation.",
+  "objective": "Make wbcan saturation evidence race-safe, bounded, machine-readable, and independently validated.",
   "allowed_paths": [
     "kernel/wbcan/wbcan.c",
     "kernel/wbcan/test_state_concurrency.py",
     "kernel/wbcan/Makefile",
+    "tests/unit/test_linux_driver_tests.py",
     "docs/task_packets/linux-wbcan-saturation-stats.json"
   ],
   "read_only_paths": [
@@ -23,6 +24,8 @@
     "RX backlog rejection increments rx_dropped instead of claiming rx_packets",
     "intentional drop-rx and allocation-failure paths remain observable in netdev statistics",
     "concurrent TX and stats sampling never observes a counter regression",
+    "the bounded stress entrypoint emits a versioned JSON report with environment, stage timing, and PASS or FAIL status",
+    "malformed, incomplete, failed, or non-virtual stress reports fail validation",
     "the existing seven fault modes and state lifecycle behavior remain unchanged",
     "no physical CAN, MCU, actuator, or hard-real-time evidence is claimed"
   ],
@@ -31,6 +34,8 @@
     "make -C kernel/wbcan checkpatch",
     "sudo make -C kernel/wbcan reload",
     "sudo make -C kernel/wbcan test",
+    "sudo make -C kernel/wbcan stress",
+    "python -m pytest tests/unit/test_linux_driver_tests.py -v",
     "python tools/scripts/check_task_packet.py docs/task_packets/linux-wbcan-saturation-stats.json",
     "git diff --check origin/main...HEAD"
   ],

--- a/kernel/wbcan/Makefile
+++ b/kernel/wbcan/Makefile
@@ -10,6 +10,7 @@
 KDIR  ?= /lib/modules/$(shell uname -r)/build
 PWD   := $(shell pwd)
 IFACE ?= wbcan0
+STRESS_REPORT ?= /tmp/wbcan-stress-report.json
 
 .PHONY: all clean load unload reload test stress checkpatch help
 
@@ -53,7 +54,9 @@ stress:
 		echo "load the module and bring $(IFACE) up before running stress"; \
 		exit 1; \
 	fi
-	@sudo python3 ./test_state_concurrency.py $(IFACE) /sys/kernel/debug/wbcan/$(IFACE)
+	@sudo python3 ./test_state_concurrency.py $(IFACE) /sys/kernel/debug/wbcan/$(IFACE) --report $(STRESS_REPORT)
+	@python3 ./test_state_concurrency.py --validate-report $(STRESS_REPORT)
+	@echo "wbcan stress evidence: $(STRESS_REPORT)"
 
 # The kernel's own checker. Catches the style issues a maintainer would.
 checkpatch:

--- a/kernel/wbcan/test_state_concurrency.py
+++ b/kernel/wbcan/test_state_concurrency.py
@@ -1,18 +1,34 @@
 #!/usr/bin/env python3
 """Bounded wbcan controller-state and queue concurrency probe."""
 
+import argparse
 import errno
+import json
+import platform
 import queue
 import select
 import socket
 import struct
 import subprocess
-import sys
 import threading
 import time
 from collections.abc import Callable
 from itertools import pairwise
 from pathlib import Path
+from typing import Any
+
+REPORT_SCHEMA_VERSION = "wbcan-stress-report-v1"
+REQUIRED_STAGES = (
+    "reconfiguration",
+    "link_lifecycle",
+    "stop_drain",
+    "bus_off_restart",
+    "restart_cancellation",
+    "restart_stop_race",
+    "queue_recovery",
+    "stats_sampling",
+    "cleanup",
+)
 
 FRAME = struct.Struct("=IB3x8s")
 ALLOWED_STATES = {
@@ -417,23 +433,95 @@ class Probe:
                     raise AssertionError(f"netdev statistic regressed: {name}")
 
 
-def main() -> int:
-    if len(sys.argv) != 3:
-        raise SystemExit(f"usage: {sys.argv[0]} INTERFACE DEBUGFS_DIRECTORY")
-    probe = Probe(sys.argv[1], Path(sys.argv[2]))
+def validate_stress_report(report: object) -> None:
+    if not isinstance(report, dict):
+        raise ValueError("stress report must be a JSON object")
+    if report.get("schema_version") != REPORT_SCHEMA_VERSION:
+        raise ValueError("stress report has an unsupported schema_version")
+    if report.get("scope") != "virtual-wbcan-only":
+        raise ValueError("stress report must retain the virtual-wbcan-only scope")
+    if report.get("result") not in {"PASS", "FAIL"}:
+        raise ValueError("stress report result must be PASS or FAIL")
+    for name in ("interface", "kernel", "python", "started_at", "completed_at"):
+        if not isinstance(report.get(name), str) or not report[name].strip():
+            raise ValueError(f"stress report requires non-empty {name}")
+    stages = report.get("stages")
+    if not isinstance(stages, list):
+        raise ValueError("stress report stages must be a list")
+    stage_names: list[str] = []
+    failed = False
+    for stage in stages:
+        if not isinstance(stage, dict):
+            raise ValueError("stress report stage must be an object")
+        name = stage.get("name")
+        result = stage.get("result")
+        duration_ms = stage.get("duration_ms")
+        if not isinstance(name, str) or not name:
+            raise ValueError("stress report stage requires a name")
+        if result not in {"PASS", "FAIL"}:
+            raise ValueError(f"stress report stage {name!r} has an invalid result")
+        if not isinstance(duration_ms, int) or isinstance(duration_ms, bool) or duration_ms < 0:
+            raise ValueError(f"stress report stage {name!r} has an invalid duration_ms")
+        if result == "FAIL":
+            failed = True
+            if not isinstance(stage.get("error"), str) or not stage["error"]:
+                raise ValueError(f"failed stress report stage {name!r} requires an error")
+        stage_names.append(name)
+    if len(stage_names) != len(set(stage_names)):
+        raise ValueError("stress report contains duplicate stages")
+    if report["result"] == "PASS" and (failed or tuple(stage_names) != REQUIRED_STAGES):
+        raise ValueError("passing stress report must contain every required passing stage in order")
+    if report["result"] == "FAIL" and not failed:
+        raise ValueError("failed stress report must contain a failed stage")
+
+
+def write_stress_report(path: Path, report: dict[str, Any]) -> None:
+    validate_stress_report(report)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _stage(probe: Probe, name: str, operation: Callable[[], None], stages: list[dict[str, Any]]) -> None:
+    started = time.monotonic()
+    try:
+        operation()
+    except Exception as exc:
+        stages.append(
+            {
+                "name": name,
+                "result": "FAIL",
+                "duration_ms": round((time.monotonic() - started) * 1000),
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        )
+        raise
+    stages.append({"name": name, "result": "PASS", "duration_ms": round((time.monotonic() - started) * 1000)})
+
+
+def run_probe(interface: str, debugfs: Path, report_path: Path | None) -> int:
+    probe = Probe(interface, debugfs)
+    started_at = time.time_ns()
+    stages: list[dict[str, Any]] = []
     failure: Exception | None = None
     try:
-        probe.exercise_reconfiguration()
-        probe.exercise_link_lifecycle()
-        probe.exercise_stop_drain()
-        probe.exercise_bus_off_restart()
-        probe.exercise_restart_cancellation()
-        probe.exercise_restart_stop_race()
-        probe.verify_queue_recovery()
-        probe.exercise_stats_sampling()
+        operations = (
+            ("reconfiguration", probe.exercise_reconfiguration),
+            ("link_lifecycle", probe.exercise_link_lifecycle),
+            ("stop_drain", probe.exercise_stop_drain),
+            ("bus_off_restart", probe.exercise_bus_off_restart),
+            ("restart_cancellation", probe.exercise_restart_cancellation),
+            ("restart_stop_race", probe.exercise_restart_stop_race),
+            ("queue_recovery", probe.verify_queue_recovery),
+            ("stats_sampling", probe.exercise_stats_sampling),
+        )
+        for name, operation in operations:
+            _stage(probe, name, operation, stages)
     except Exception as exc:  # noqa: BLE001 - preserve the probe failure through cleanup.
         failure = exc
     finally:
+        cleanup_started = time.monotonic()
         try:
             probe.restart_delay.write_text("0\n", encoding="ascii")
             probe.stop_delay.write_text("0\n", encoding="ascii")
@@ -442,13 +530,56 @@ def main() -> int:
             probe.command("ip", "link", "set", probe.interface, "type", "can", "restart-ms", "100")
             probe.command("ip", "link", "set", probe.interface, "up")
         except Exception as exc:  # noqa: BLE001 - report probe and cleanup failures together.
+            stages.append(
+                {
+                    "name": "cleanup",
+                    "result": "FAIL",
+                    "duration_ms": round((time.monotonic() - cleanup_started) * 1000),
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
             if failure is None:
                 failure = exc
             else:
                 failure = ExceptionGroup("probe and cleanup failures", [failure, exc])
+        else:
+            stages.append(
+                {"name": "cleanup", "result": "PASS", "duration_ms": round((time.monotonic() - cleanup_started) * 1000)}
+            )
+    if report_path is not None:
+        report = {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "scope": "virtual-wbcan-only",
+            "result": "FAIL" if failure is not None else "PASS",
+            "interface": interface,
+            "kernel": platform.release(),
+            "python": platform.python_version(),
+            "started_at": str(started_at),
+            "completed_at": str(time.time_ns()),
+            "stages": stages,
+        }
+        write_stress_report(report_path, report)
     if failure is not None:
         raise failure
     return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("interface", nargs="?")
+    parser.add_argument("debugfs", nargs="?", type=Path)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--validate-report", type=Path)
+    args = parser.parse_args()
+    if args.validate_report is not None:
+        if args.interface is not None or args.debugfs is not None or args.report is not None:
+            parser.error("--validate-report cannot be combined with probe arguments")
+        validate_stress_report(json.loads(args.validate_report.read_text(encoding="utf-8")))
+        print(f"wbcan stress report valid: {args.validate_report}")
+        return 0
+    if args.interface is None or args.debugfs is None:
+        parser.error("INTERFACE and DEBUGFS_DIRECTORY are required")
+    return run_probe(args.interface, args.debugfs, args.report)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_linux_driver_tests.py
+++ b/tests/unit/test_linux_driver_tests.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -6,10 +7,15 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "kernel" / "wbcan" / "validate_test_report.py"
 TEST_SCRIPT = ROOT / "kernel" / "wbcan" / "test_wbcan.sh"
+STRESS_PATH = ROOT / "kernel" / "wbcan" / "test_state_concurrency.py"
 SPEC = importlib.util.spec_from_file_location("validate_wbcan_report", MODULE_PATH)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
+STRESS_SPEC = importlib.util.spec_from_file_location("wbcan_stress", STRESS_PATH)
+assert STRESS_SPEC and STRESS_SPEC.loader
+STRESS = importlib.util.module_from_spec(STRESS_SPEC)
+STRESS_SPEC.loader.exec_module(STRESS)
 
 
 HEADER = "result\ttest_id\tname\texpected\tactual\n"
@@ -82,3 +88,44 @@ def test_fault_suite_fails_if_report_append_fails() -> None:
 
     assert '>> "$REPORT_FILE" || {' in script
     assert "cannot append to test report" in script
+
+
+def _stress_report() -> dict[str, object]:
+    return {
+        "schema_version": STRESS.REPORT_SCHEMA_VERSION,
+        "scope": "virtual-wbcan-only",
+        "result": "PASS",
+        "interface": "wbcan0",
+        "kernel": "test-kernel",
+        "python": "3.12.0",
+        "started_at": "1",
+        "completed_at": "2",
+        "stages": [{"name": name, "result": "PASS", "duration_ms": 1} for name in STRESS.REQUIRED_STAGES],
+    }
+
+
+def test_stress_report_accepts_complete_virtual_pass(tmp_path: Path) -> None:
+    report = _stress_report()
+    path = tmp_path / "stress.json"
+
+    STRESS.write_stress_report(path, report)
+    STRESS.validate_stress_report(json.loads(path.read_text(encoding="utf-8")))
+
+
+@pytest.mark.parametrize("mutation", ["missing_stage", "failed_without_error", "physical_scope", "duplicate_stage"])
+def test_stress_report_rejects_incomplete_or_untruthful_evidence(mutation: str) -> None:
+    report = _stress_report()
+    stages = report["stages"]
+    assert isinstance(stages, list)
+    if mutation == "missing_stage":
+        stages.pop()
+    elif mutation == "failed_without_error":
+        report["result"] = "FAIL"
+        stages[0]["result"] = "FAIL"
+    elif mutation == "physical_scope":
+        report["scope"] = "physical-can"
+    else:
+        stages.append(dict(stages[0]))
+
+    with pytest.raises(ValueError):
+        STRESS.validate_stress_report(report)


### PR DESCRIPTION
## Summary
- emit a versioned JSON artifact from the bounded wbcan concurrency probe
- record environment, ordered stage results, duration, and truthful PASS/FAIL status
- validate the artifact after make stress and reject incomplete, malformed, failed, duplicate, or physical-scope claims
- add portable regression coverage for the evidence contract

## Validation
- 853 passed, 1 skipped
- Ruff check and format passed
- Task Packet validation passed
- git diff --check passed

## Boundary
This advances #157. It remains virtual-wbcan-only and does not claim PREEMPT_RT, physical CAN, MCU, actuator, or hard-real-time validation.