### PR TITLE
fix(bsp): harden readiness evidence gates

### DIFF
--- a/bsp/validation/check_readiness.py
+++ b/bsp/validation/check_readiness.py
@@ -7,15 +7,32 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_GATE_IDS = {
+    "BSP-GATE-ARCH",
+    "BSP-GATE-SELECTION",
+    "BSP-GATE-CARRIER",
+    "BSP-GATE-MCU",
+    "BSP-GATE-SAFETY",
+    "BSP-GATE-IMAGE",
+    "BSP-GATE-CAN",
+    "BSP-GATE-VALIDATION",
+    "BSP-GATE-CAMERA",
+}
+BLOCKED_STATUS = "REPOSITORY_BASELINE_READY_PHYSICAL_BRINGUP_BLOCKED"
+READY_STATUS = "PHYSICAL_BRINGUP_EVIDENCE_COMPLETE"
 
 
-def check() -> list[str]:
-    readiness = yaml.safe_load((ROOT / "bsp/readiness.yaml").read_text(encoding="utf-8"))
+def validate_readiness(readiness: object, root: Path = ROOT) -> list[str]:
     errors: list[str] = []
+    if not isinstance(readiness, dict):
+        return ["BSP readiness must be a mapping"]
     gates = readiness.get("gates", [])
     allowed = set(readiness.get("allowed_statuses", []))
-    if len(gates) != 9 or len({gate.get("id") for gate in gates}) != 9:
-        errors.append("BSP readiness must contain nine unique gates")
+    if not isinstance(gates, list) or any(not isinstance(gate, dict) for gate in gates):
+        return ["BSP readiness gates must be a list of mappings"]
+    gate_ids = [gate.get("id") for gate in gates]
+    if len(gates) != len(EXPECTED_GATE_IDS) or set(gate_ids) != EXPECTED_GATE_IDS:
+        errors.append("BSP readiness must contain the exact nine controlled gates")
     if any(gate.get("status") not in allowed for gate in gates):
         errors.append("BSP readiness contains an uncontrolled status")
     if any(not gate.get("owner") or not gate.get("requirement") for gate in gates):
@@ -23,14 +40,39 @@ def check() -> list[str]:
     for gate in gates:
         evidence = gate.get("evidence")
         if gate.get("status") == "PASS":
-            path = ROOT / evidence if evidence and evidence != "NOT_ATTACHED" else None
-            if path is None or not path.is_file():
+            path = _repository_evidence_path(root, evidence)
+            if path is None:
                 errors.append(f"{gate.get('id')} claims PASS without repository evidence")
         elif evidence == "NOT_ATTACHED" and gate.get("status") not in {"BLOCKED", "NOT_EXECUTED"}:
             errors.append(f"{gate.get('id')} lacks evidence but is not blocked")
-    if readiness.get("physical_release_ready") is not False:
-        errors.append("physical release must remain false before bring-up")
+    all_pass = bool(gates) and all(gate.get("status") == "PASS" for gate in gates)
+    release_ready = readiness.get("physical_release_ready")
+    expected_status = READY_STATUS if all_pass else BLOCKED_STATUS
+    if release_ready is not all_pass:
+        errors.append("physical_release_ready must equal the all-gates-PASS result")
+    if readiness.get("status") != expected_status:
+        errors.append(f"BSP package status must be {expected_status}")
     return errors
+
+
+def _repository_evidence_path(root: Path, evidence: object) -> Path | None:
+    if not isinstance(evidence, str) or not evidence or evidence == "NOT_ATTACHED":
+        return None
+    relative = Path(evidence)
+    if relative.is_absolute() or any(part == ".." for part in relative.parts):
+        return None
+    root = root.resolve()
+    path = (root / relative).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return None
+    return path if path.is_file() else None
+
+
+def check() -> list[str]:
+    readiness = yaml.safe_load((ROOT / "bsp/readiness.yaml").read_text(encoding="utf-8"))
+    return validate_readiness(readiness)
 
 
 if __name__ == "__main__":

--- a/docs/task_packets/robot-bsp-implementation-v0.1.json
+++ b/docs/task_packets/robot-bsp-implementation-v0.1.json
@@ -22,6 +22,9 @@
     "no service or Linux resource can bypass MCU-SAFETY",
     "manifest validation rejects domain drift and unsafe physical-status promotion",
     "readiness gates require owners, controlled statuses and evidence before PASS",
+    "readiness uses the exact controlled gate set and rejects missing or invented gate identities",
+    "PASS evidence must be a regular file inside the repository rather than a directory or path escape",
+    "physical release readiness and package status are derived from whether every controlled gate is PASS",
     "one D435 head camera uses USB 3, UVC/V4L2, librealsense and a fail-closed physical calibration gate",
     "the composite D435 binds by librealsense serial instead of a conflicting shared video-device symlink",
     "camera deployment remains non-installable until JetPack, ROS, driver packages and purchased-unit identity are frozen"

--- a/tests/unit/test_bsp_manifests.py
+++ b/tests/unit/test_bsp_manifests.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from bsp.validation.check_readiness import check
+from bsp.validation.check_readiness import BLOCKED_STATUS, READY_STATUS, check, validate_readiness
 from bsp.validation.validate_manifests import (
     validate,
     validate_camera_deployment,
@@ -107,3 +107,55 @@ def test_camera_service_must_reject_placeholder_serial() -> None:
     )
 
     assert "camera systemd unit must reject the placeholder serial" in errors
+
+
+def load_readiness() -> dict:
+    return yaml.safe_load((ROOT / "bsp/readiness.yaml").read_text(encoding="utf-8"))
+
+
+def test_readiness_rejects_missing_or_unknown_controlled_gate() -> None:
+    changed = deepcopy(load_readiness())
+    changed["gates"].pop()
+    changed["gates"][0]["id"] = "BSP-GATE-UNCONTROLLED"
+
+    assert "BSP readiness must contain the exact nine controlled gates" in validate_readiness(changed)
+
+
+def test_readiness_rejects_evidence_outside_repository(tmp_path: Path) -> None:
+    changed = deepcopy(load_readiness())
+    changed["gates"][0]["evidence"] = "../outside.txt"
+
+    errors = validate_readiness(changed, tmp_path / "repo")
+
+    assert "BSP-GATE-ARCH claims PASS without repository evidence" in errors
+
+
+def test_readiness_rejects_directory_as_pass_evidence(tmp_path: Path) -> None:
+    changed = deepcopy(load_readiness())
+    root = tmp_path / "repo"
+    (root / "evidence").mkdir(parents=True)
+    changed["gates"][0]["evidence"] = "evidence"
+
+    errors = validate_readiness(changed, root)
+
+    assert "BSP-GATE-ARCH claims PASS without repository evidence" in errors
+
+
+def test_readiness_release_flag_and_package_status_follow_all_gates(tmp_path: Path) -> None:
+    changed = deepcopy(load_readiness())
+    root = tmp_path / "repo"
+    evidence = root / "evidence.txt"
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text("controlled evidence\n", encoding="ascii")
+    for gate in changed["gates"]:
+        gate["status"] = "PASS"
+        gate["evidence"] = "evidence.txt"
+    changed["physical_release_ready"] = True
+    changed["status"] = READY_STATUS
+
+    assert validate_readiness(changed, root) == []
+
+    changed["gates"][0]["status"] = "BLOCKED"
+    assert "physical_release_ready must equal the all-gates-PASS result" in validate_readiness(changed, root)
+    changed["physical_release_ready"] = False
+    assert f"BSP package status must be {BLOCKED_STATUS}" in validate_readiness(changed, root)


### PR DESCRIPTION
## Summary
- require the exact nine controlled BSP gates
- reject evidence paths that escape the repository or point to directories
- derive package status and physical release readiness from all-gates-PASS
- add regression coverage for gate drift and evidence spoofing

## Validation
- 860 passed, 1 environment skip
- BSP readiness and manifest validators passed
- Ruff and Task Packet validation passed
- git diff --check passed

## Boundary
Progresses BSP readiness integrity. This does not claim physical bring-up, procurement, or HIL completion; blocked/not-executed gates remain required.