### PR TITLE
perf(kernel): add wbcan latency baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,23 @@ jobs:
           WBCAN_TEST_REPORT: ${{ runner.temp }}/wbcan-test-report.tsv
         run: sudo env WBCAN_TEST_REPORT="$WBCAN_TEST_REPORT" ./kernel/wbcan/test_wbcan.sh wbcan0
 
+      - name: Run and validate latency baseline
+        id: latency_probe
+        env:
+          LATENCY_REPORT: ${{ runner.temp }}/wbcan-latency-report.json
+        run: |
+          sudo python3 kernel/wbcan/test_latency.py wbcan0 --warmup 50 --samples 1000 \
+            --report "$LATENCY_REPORT" --commit "$GITHUB_SHA"
+          python3 kernel/wbcan/test_latency.py --validate-report "$LATENCY_REPORT"
+
+      - name: Upload latency baseline
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: wbcan-latency-report
+          path: ${{ runner.temp }}/wbcan-latency-report.json
+          if-no-files-found: error
+
       - name: Validate structured driver test report
         id: fault_report
         if: always()

--- a/docs/task_packets/linux-wbcan-latency-baseline.json
+++ b/docs/task_packets/linux-wbcan-latency-baseline.json
@@ -1,0 +1,35 @@
+{
+  "issue": 154,
+  "human_owner": "TH3478",
+  "objective": "Produce bounded, machine-readable userspace-observed TX-to-RX latency evidence for virtual wbcan without implying physical or hard-real-time timing.",
+  "allowed_paths": [
+    "kernel/wbcan/test_latency.py",
+    "kernel/wbcan/Makefile",
+    ".github/workflows/ci.yml",
+    "tests/unit/test_linux_driver_tests.py",
+    "docs/task_packets/linux-wbcan-latency-baseline.json"
+  ],
+  "read_only_paths": ["kernel/wbcan/wbcan.c", "AGENTS.md"],
+  "forbidden": ["interfaces/**", "firmware/**", "robot/control/**"],
+  "acceptance": [
+    "the probe uses native SocketCAN and monotonic_ns with bounded warm-up and sample counts",
+    "strict JSON records commit, kernel, config hash availability, CPU affinity, preemption model, load profile and clock",
+    "P50, P95, P99, max, population-standard-deviation jitter and optional deadline misses are recorded",
+    "partial, duplicate, unexpected, invalid or clock-regressing samples fail visibly",
+    "deterministic synthetic unit tests validate percentile, jitter and report integrity",
+    "evidence scope remains virtual-wbcan-userspace and makes no physical CAN, MCU, actuator or hard-real-time claim"
+  ],
+  "commands": [
+    "make -C kernel/wbcan latency",
+    "python kernel/wbcan/test_latency.py --validate-report /tmp/wbcan-latency-report.json",
+    "python -m pytest tests/unit/test_linux_driver_tests.py -v",
+    "python tools/scripts/check_task_packet.py docs/task_packets/linux-wbcan-latency-baseline.json",
+    "git diff --check origin/main...HEAD"
+  ],
+  "evidence": ["versioned latency JSON", "portable unit test output", "kernel job output"],
+  "stop_conditions": [
+    "physical CAN timing is required",
+    "a percentile threshold would be invented from one hosted runner",
+    "a benchmark framework dependency is required"
+  ]
+}

--- a/kernel/wbcan/Makefile
+++ b/kernel/wbcan/Makefile
@@ -13,8 +13,11 @@ IFACE ?= wbcan0
 STRESS_REPORT ?= /tmp/wbcan-stress-report.json
 STRESS_PRODUCERS ?= 4
 STRESS_FRAMES ?= 250
+LATENCY_REPORT ?= /tmp/wbcan-latency-report.json
+LATENCY_SAMPLES ?= 1000
+LATENCY_WARMUP ?= 50
 
-.PHONY: all clean load unload reload test stress checkpatch help
+.PHONY: all clean load unload reload test stress latency checkpatch help
 
 all:
 	@if [ ! -d "$(KDIR)" ]; then \
@@ -61,6 +64,14 @@ stress:
 	@python3 ./test_state_concurrency.py --validate-report $(STRESS_REPORT)
 	@echo "wbcan stress evidence: $(STRESS_REPORT)"
 
+latency:
+	@if [ ! -d "/sys/class/net/$(IFACE)" ]; then \
+		echo "wbcan interface $(IFACE) is unavailable"; exit 1; \
+	fi
+	@python3 ./test_latency.py $(IFACE) --warmup $(LATENCY_WARMUP) --samples $(LATENCY_SAMPLES) \
+		--report $(LATENCY_REPORT) --commit "$${GITHUB_SHA:-unknown}"
+	@python3 ./test_latency.py --validate-report $(LATENCY_REPORT)
+
 # The kernel's own checker. Catches the style issues a maintainer would.
 checkpatch:
 	@if [ -x "$(KDIR)/scripts/checkpatch.pl" ]; then \
@@ -74,6 +85,7 @@ help:
 	@echo "make load      create and bring up the module-load singleton $(IFACE)"
 	@echo "make test      run the fault suite"
 	@echo "make stress    run the bounded concurrency and stats probe"
+	@echo "make latency   record virtual SocketCAN TX-to-RX latency evidence"
 	@echo "make checkpatch  kernel style check"
 	@echo "ip link add type wbcan is unsupported; unload before loading another"
 	@echo ""

--- a/kernel/wbcan/test_latency.py
+++ b/kernel/wbcan/test_latency.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Measure bounded userspace-observed TX-to-RX latency on virtual wbcan."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import select
+import socket
+import statistics
+import struct
+import time
+from pathlib import Path
+from typing import Any
+
+FRAME = struct.Struct("=IB3x8s")
+SCHEMA_VERSION = "wbcan-latency-report-v1"
+MIN_SAMPLES = 10
+MAX_SAMPLES = 100_000
+
+
+def percentile(values: list[int], percent: int) -> int:
+    if not values:
+        raise ValueError("latency samples must not be empty")
+    if not 0 <= percent <= 100:
+        raise ValueError("percentile must be between 0 and 100")
+    ordered = sorted(values)
+    index = max(0, (len(ordered) * percent + 99) // 100 - 1)
+    return ordered[index]
+
+
+def summarize(samples_ns: list[int], deadline_ns: int | None) -> dict[str, int | str | None]:
+    if any(not isinstance(sample, int) or isinstance(sample, bool) or sample < 0 for sample in samples_ns):
+        raise ValueError("latency samples must be non-negative integers")
+    if not samples_ns:
+        raise ValueError("latency samples must not be empty")
+    return {
+        "p50_ns": percentile(samples_ns, 50),
+        "p95_ns": percentile(samples_ns, 95),
+        "p99_ns": percentile(samples_ns, 99),
+        "max_ns": max(samples_ns),
+        "jitter_definition": "population-standard-deviation-ns",
+        "jitter_ns": round(statistics.pstdev(samples_ns)),
+        "deadline_ns": deadline_ns,
+        "missed_deadline_count": 0 if deadline_ns is None else sum(sample > deadline_ns for sample in samples_ns),
+    }
+
+
+def preemption_model() -> str:
+    for path in (Path("/sys/kernel/realtime"), Path("/sys/kernel/debug/sched/preempt")):
+        try:
+            value = path.read_text(encoding="ascii").strip()
+        except OSError:
+            continue
+        if value:
+            return value
+    return "unknown"
+
+
+def kernel_config_hash() -> str:
+    candidates = (Path("/proc/config.gz"), Path(f"/boot/config-{platform.release()}"))
+    for path in candidates:
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        return hashlib.sha256(data).hexdigest()
+    return "unavailable"
+
+
+def validate_report(report: object) -> None:
+    if not isinstance(report, dict):
+        raise ValueError("latency report must be an object")
+    if report.get("schema_version") != SCHEMA_VERSION or report.get("scope") != "virtual-wbcan-userspace":
+        raise ValueError("latency report schema or scope is invalid")
+    if report.get("result") not in {"PASS", "FAIL", "NOT_EXECUTED"}:
+        raise ValueError("latency report result is invalid")
+    for name in ("interface", "commit", "kernel", "kernel_config_sha256", "preemption_model", "clock"):
+        if not isinstance(report.get(name), str) or not report[name]:
+            raise ValueError(f"latency report requires {name}")
+    if report.get("clock") != "monotonic_ns":
+        raise ValueError("latency report clock must be monotonic_ns")
+    for name in ("cpu_count", "warmup_count", "sample_count", "message_size", "can_id"):
+        if not isinstance(report.get(name), int) or isinstance(report[name], bool) or report[name] < 0:
+            raise ValueError(f"latency report has invalid {name}")
+    affinity = report.get("cpu_affinity")
+    if not isinstance(affinity, list) or any(not isinstance(cpu, int) or cpu < 0 for cpu in affinity):
+        raise ValueError("latency report CPU affinity is invalid")
+    if report["result"] != "PASS":
+        if not isinstance(report.get("error"), str) or not report["error"]:
+            raise ValueError("non-passing latency report requires an error")
+        return
+    if not MIN_SAMPLES <= report["sample_count"] <= MAX_SAMPLES:
+        raise ValueError("passing latency report sample_count is outside the bounded range")
+    if report.get("loss") or report.get("duplicates") or report.get("reordered"):
+        raise ValueError("passing latency report cannot contain delivery anomalies")
+    summary = report.get("latency")
+    if not isinstance(summary, dict):
+        raise ValueError("passing latency report requires a latency summary")
+    for name in ("p50_ns", "p95_ns", "p99_ns", "max_ns", "jitter_ns", "missed_deadline_count"):
+        if not isinstance(summary.get(name), int) or isinstance(summary[name], bool) or summary[name] < 0:
+            raise ValueError(f"latency summary has invalid {name}")
+    if not summary["p50_ns"] <= summary["p95_ns"] <= summary["p99_ns"] <= summary["max_ns"]:
+        raise ValueError("latency percentiles must be monotonic")
+    if summary.get("jitter_definition") != "population-standard-deviation-ns":
+        raise ValueError("latency jitter definition is invalid")
+
+
+def write_report(path: Path, report: dict[str, Any]) -> None:
+    validate_report(report)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def measure(interface: str, warmup: int, sample_count: int, can_id: int, deadline_ns: int | None) -> list[int]:
+    sender = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+    receiver = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+    sender.bind((interface,))
+    receiver.bind((interface,))
+    received: list[int] = []
+    seen: set[int] = set()
+    total = warmup + sample_count
+    try:
+        for sequence in range(total):
+            started = time.monotonic_ns()
+            sender.send(FRAME.pack(can_id, 8, sequence.to_bytes(8, "big")))
+            if not select.select([receiver], [], [], 0.25)[0]:
+                raise AssertionError(f"latency frame {sequence} was not received within 250 ms")
+            frame_id, length, payload = FRAME.unpack(receiver.recv(FRAME.size))
+            observed_sequence = int.from_bytes(payload, "big")
+            if frame_id != can_id or length != 8 or observed_sequence != sequence or observed_sequence in seen:
+                raise AssertionError(
+                    f"unexpected latency frame: id={frame_id:#x} length={length} sequence={observed_sequence}"
+                )
+            seen.add(observed_sequence)
+            observed = time.monotonic_ns() - started
+            if observed < 0:
+                raise AssertionError("monotonic clock regressed")
+            if sequence >= warmup:
+                received.append(observed)
+        if len(seen) != total or len(received) != sample_count:
+            raise AssertionError(f"latency run incomplete: received {len(received)}/{sample_count} measured frames")
+        return received
+    finally:
+        sender.close()
+        receiver.close()
+
+
+def base_report(args: argparse.Namespace) -> dict[str, Any]:
+    try:
+        affinity = sorted(os.sched_getaffinity(0))
+    except AttributeError:
+        affinity = list(range(os.cpu_count() or 1))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scope": "virtual-wbcan-userspace",
+        "result": "NOT_EXECUTED",
+        "interface": args.interface,
+        "commit": args.commit,
+        "kernel": platform.release(),
+        "kernel_config_sha256": kernel_config_hash(),
+        "preemption_model": preemption_model(),
+        "cpu_count": os.cpu_count() or 1,
+        "cpu_affinity": affinity,
+        "load_profile": args.load_profile,
+        "clock": "monotonic_ns",
+        "warmup_count": args.warmup,
+        "sample_count": args.samples,
+        "message_size": 8,
+        "can_id": args.can_id,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("interface", nargs="?", default="wbcan0")
+    parser.add_argument("--warmup", type=int, default=50)
+    parser.add_argument("--samples", type=int, default=1000)
+    parser.add_argument("--can-id", type=lambda value: int(value, 0), default=0x760)
+    parser.add_argument("--deadline-ns", type=int)
+    parser.add_argument("--load-profile", choices=("idle", "controlled-load"), default="idle")
+    parser.add_argument("--commit", default=os.environ.get("GITHUB_SHA", "unknown"))
+    parser.add_argument("--report", type=Path, default=Path("/tmp/wbcan-latency-report.json"))
+    parser.add_argument("--validate-report", type=Path)
+    args = parser.parse_args()
+    if args.validate_report is not None:
+        validate_report(json.loads(args.validate_report.read_text(encoding="utf-8")))
+        print(f"wbcan latency report valid: {args.validate_report}")
+        return 0
+    if not 0 <= args.warmup <= MAX_SAMPLES:
+        parser.error(f"--warmup must be between 0 and {MAX_SAMPLES}")
+    if not MIN_SAMPLES <= args.samples <= MAX_SAMPLES:
+        parser.error(f"--samples must be between {MIN_SAMPLES} and {MAX_SAMPLES}")
+    if not 0 <= args.can_id <= 0x7FF:
+        parser.error("--can-id must be a standard 11-bit CAN ID")
+    if args.deadline_ns is not None and args.deadline_ns <= 0:
+        parser.error("--deadline-ns must be positive")
+    report = base_report(args)
+    try:
+        samples = measure(args.interface, args.warmup, args.samples, args.can_id, args.deadline_ns)
+        report.update(
+            {
+                "result": "PASS",
+                "loss": 0,
+                "duplicates": 0,
+                "reordered": 0,
+                "latency": summarize(samples, args.deadline_ns),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 - preserve failure as evidence.
+        report.update({"result": "FAIL", "error": f"{type(exc).__name__}: {exc}"})
+    write_report(args.report, report)
+    if report["result"] != "PASS":
+        raise SystemExit(report["error"])
+    print(f"wbcan latency evidence: {args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_linux_driver_tests.py
+++ b/tests/unit/test_linux_driver_tests.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "kernel" / "wbcan" / "validate_test_report.py"
 TEST_SCRIPT = ROOT / "kernel" / "wbcan" / "test_wbcan.sh"
 STRESS_PATH = ROOT / "kernel" / "wbcan" / "test_state_concurrency.py"
+LATENCY_PATH = ROOT / "kernel" / "wbcan" / "test_latency.py"
 SPEC = importlib.util.spec_from_file_location("validate_wbcan_report", MODULE_PATH)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -16,6 +17,10 @@ STRESS_SPEC = importlib.util.spec_from_file_location("wbcan_stress", STRESS_PATH
 assert STRESS_SPEC and STRESS_SPEC.loader
 STRESS = importlib.util.module_from_spec(STRESS_SPEC)
 STRESS_SPEC.loader.exec_module(STRESS)
+LATENCY_SPEC = importlib.util.spec_from_file_location("wbcan_latency", LATENCY_PATH)
+assert LATENCY_SPEC and LATENCY_SPEC.loader
+LATENCY = importlib.util.module_from_spec(LATENCY_SPEC)
+LATENCY_SPEC.loader.exec_module(LATENCY)
 
 
 HEADER = "result\ttest_id\tname\texpected\tactual\n"
@@ -191,3 +196,72 @@ def test_stress_report_records_but_accepts_complete_reordered_delivery() -> None
     saturation["details"]["producers"][0]["reordered"] = 3
 
     STRESS.validate_stress_report(report)
+
+
+def _latency_report() -> dict[str, object]:
+    return {
+        "schema_version": LATENCY.SCHEMA_VERSION,
+        "scope": "virtual-wbcan-userspace",
+        "result": "PASS",
+        "interface": "wbcan0",
+        "commit": "test-commit",
+        "kernel": "test-kernel",
+        "kernel_config_sha256": "unavailable",
+        "preemption_model": "unknown",
+        "cpu_count": 2,
+        "cpu_affinity": [0, 1],
+        "load_profile": "idle",
+        "clock": "monotonic_ns",
+        "warmup_count": 10,
+        "sample_count": 10,
+        "message_size": 8,
+        "can_id": 0x760,
+        "loss": 0,
+        "duplicates": 0,
+        "reordered": 0,
+        "latency": LATENCY.summarize(list(range(1, 11)), deadline_ns=8),
+    }
+
+
+def test_latency_summary_uses_nearest_rank_and_population_jitter() -> None:
+    summary = LATENCY.summarize(list(range(1, 101)), deadline_ns=90)
+
+    assert summary["p50_ns"] == 50
+    assert summary["p95_ns"] == 95
+    assert summary["p99_ns"] == 99
+    assert summary["max_ns"] == 100
+    assert summary["jitter_ns"] == 29
+    assert summary["missed_deadline_count"] == 10
+
+
+def test_latency_report_accepts_complete_virtual_evidence(tmp_path: Path) -> None:
+    report = _latency_report()
+    path = tmp_path / "latency.json"
+
+    LATENCY.write_report(path, report)
+    LATENCY.validate_report(json.loads(path.read_text(encoding="utf-8")))
+
+
+@pytest.mark.parametrize("mutation", ["physical_scope", "loss", "percentile_order", "bad_clock", "partial"])
+def test_latency_report_rejects_invalid_or_untruthful_evidence(mutation: str) -> None:
+    report = _latency_report()
+    if mutation == "physical_scope":
+        report["scope"] = "physical-can"
+    elif mutation == "loss":
+        report["loss"] = 1
+    elif mutation == "percentile_order":
+        report["latency"]["p95_ns"] = 0
+    elif mutation == "bad_clock":
+        report["clock"] = "wall-clock"
+    else:
+        report["sample_count"] = 9
+
+    with pytest.raises(ValueError):
+        LATENCY.validate_report(report)
+
+
+def test_latency_summary_rejects_negative_or_empty_samples() -> None:
+    with pytest.raises(ValueError):
+        LATENCY.summarize([], deadline_ns=None)
+    with pytest.raises(ValueError):
+        LATENCY.summarize([1, -1], deadline_ns=None)


### PR DESCRIPTION
## Summary
- add a dependency-free native SocketCAN latency probe using monotonic_ns
- emit strict JSON with environment, P50/P95/P99/max, jitter, delivery integrity, and optional deadline misses
- bound warm-up/sample counts and fail visibly on partial, duplicate, unexpected, or clock-regressing runs
- expose make latency and portable evidence-contract tests

## Validation
- 868 passed, 1 environment skip
- 23 focused Linux driver tests passed
- Ruff, Task Packet validation, and git diff --check passed

## Boundary
Progresses #154 and provides the baseline format needed by #155. Results are virtual userspace-observed send-to-receive latency, not physical CAN, MCU, actuator, or hard-real-time evidence.