### PR TITLE
test(kernel): add bounded recovery stress evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,22 @@ jobs:
         id: fault_suite
         env:
           WBCAN_TEST_REPORT: ${{ runner.temp }}/wbcan-test-report.tsv
-        run: sudo env WBCAN_TEST_REPORT="$WBCAN_TEST_REPORT" ./kernel/wbcan/test_wbcan.sh wbcan0
+          WBCAN_STRESS_REPORT: ${{ runner.temp }}/wbcan-stress-report.json
+        run: |
+          sudo env WBCAN_TEST_REPORT="$WBCAN_TEST_REPORT" WBCAN_STRESS_REPORT="$WBCAN_STRESS_REPORT" \
+            ./kernel/wbcan/test_wbcan.sh wbcan0
+
+      - name: Validate stress evidence
+        if: always()
+        run: python3 kernel/wbcan/test_state_concurrency.py --validate-report "$RUNNER_TEMP/wbcan-stress-report.json"
+
+      - name: Upload stress evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: wbcan-stress-report
+          path: ${{ runner.temp }}/wbcan-stress-report.json
+          if-no-files-found: error
 
       - name: Run and validate latency baseline
         id: latency_probe

--- a/docs/task_packets/linux-wbcan-saturation-stats.json
+++ b/docs/task_packets/linux-wbcan-saturation-stats.json
@@ -6,12 +6,13 @@
     "kernel/wbcan/wbcan.c",
     "kernel/wbcan/test_state_concurrency.py",
     "kernel/wbcan/Makefile",
+    "kernel/wbcan/test_wbcan.sh",
+    ".github/workflows/ci.yml",
     "tests/unit/test_linux_driver_tests.py",
     "docs/task_packets/linux-wbcan-saturation-stats.json"
   ],
   "read_only_paths": [
-    "AGENTS.md",
-    ".github/workflows/ci.yml"
+    "AGENTS.md"
   ],
   "forbidden": [
     "interfaces/**",
@@ -26,6 +27,9 @@
     "concurrent TX and stats sampling never observes a counter regression",
     "bounded concurrent producers use disjoint CAN IDs and deterministic sequence payloads",
     "normal saturation evidence reports per-producer sent, received, lost, duplicate, reordered, unexpected, and longest no-progress values",
+    "repeated transient tx-full injections deliver every retried frame exactly once and leave the queue usable",
+    "slow-receiver evidence separates expected socket-buffer loss from unexplained netdev rx_dropped events",
+    "CI validates and uploads the raw stress JSON even when a later gate fails",
     "the bounded stress entrypoint emits a versioned JSON report with environment, stage timing, and PASS or FAIL status",
     "malformed, incomplete, failed, or non-virtual stress reports fail validation",
     "the existing seven fault modes and state lifecycle behavior remain unchanged",

--- a/kernel/wbcan/test_state_concurrency.py
+++ b/kernel/wbcan/test_state_concurrency.py
@@ -27,6 +27,8 @@ REQUIRED_STAGES = (
     "restart_stop_race",
     "queue_recovery",
     "stats_sampling",
+    "repeated_tx_full",
+    "slow_receiver",
     "multi_producer_saturation",
     "cleanup",
 )
@@ -437,6 +439,71 @@ class Probe:
                 if current[name] < previous[name]:
                     raise AssertionError(f"netdev statistic regressed: {name}")
 
+    def exercise_repeated_tx_full(self, attempts: int = 16) -> dict[str, int]:
+        sender = self.raw_socket()
+        receiver = self.raw_socket()
+        delivered = 0
+        try:
+            for sequence in range(attempts):
+                self.arm("tx-full 1")
+                sender.send(FRAME.pack(0x73A, 8, sequence.to_bytes(8, "big")))
+                if not select.select([receiver], [], [], 1)[0]:
+                    raise AssertionError(f"tx-full retry {sequence} did not recover within one second")
+                can_id, length, payload = FRAME.unpack(receiver.recv(FRAME.size))
+                if can_id != 0x73A or length != 8 or int.from_bytes(payload, "big") != sequence:
+                    raise AssertionError(f"tx-full retry {sequence} delivered an unexpected frame")
+                if select.select([receiver], [], [], 0.01)[0]:
+                    raise AssertionError(f"tx-full retry {sequence} delivered a duplicate frame")
+                delivered += 1
+            self.verify_queue_recovery()
+        finally:
+            sender.close()
+            receiver.close()
+        return {"attempts": attempts, "delivered_once": delivered}
+
+    def exercise_slow_receiver(self, frame_count: int = 500) -> dict[str, int]:
+        self.arm("none 0")
+        sender = self.raw_socket()
+        receiver = self.raw_socket()
+        receiver.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1024)
+        receiver.setblocking(False)
+        before_dropped = self.netdev_stats()["rx_dropped"]
+        received: list[int] = []
+        try:
+            for sequence in range(frame_count):
+                sender.send(FRAME.pack(0x73B, 8, sequence.to_bytes(8, "big")))
+            time.sleep(0.05)
+            quiet_since = time.monotonic()
+            while time.monotonic() - quiet_since < 0.2:
+                if not select.select([receiver], [], [], 0.02)[0]:
+                    continue
+                can_id, length, payload = FRAME.unpack(receiver.recv(FRAME.size))
+                if can_id != 0x73B or length != 8:
+                    raise AssertionError("slow receiver observed an unexpected frame")
+                received.append(int.from_bytes(payload, "big"))
+                quiet_since = time.monotonic()
+            received_set = set(received)
+            duplicate = len(received) - len(received_set)
+            unexpected = len(received_set - set(range(frame_count)))
+            driver_dropped = self.netdev_stats()["rx_dropped"] - before_dropped
+            if duplicate or unexpected or driver_dropped:
+                raise AssertionError(
+                    "slow receiver produced unexplained delivery anomalies: "
+                    f"duplicate={duplicate} unexpected={unexpected} driver_rx_dropped={driver_dropped}"
+                )
+            self.verify_queue_recovery()
+            return {
+                "sent": frame_count,
+                "received": len(received),
+                "expected_socket_loss": frame_count - len(received_set),
+                "duplicate": duplicate,
+                "unexpected": unexpected,
+                "driver_rx_dropped": driver_dropped,
+            }
+        finally:
+            sender.close()
+            receiver.close()
+
     def exercise_multi_producer_saturation(self, producer_count: int, frames_per_producer: int) -> dict[str, Any]:
         self.arm("none 0")
         can_ids = tuple(0x740 + index for index in range(producer_count))
@@ -589,6 +656,10 @@ def validate_stress_report(report: object) -> None:
                 raise ValueError(f"failed stress report stage {name!r} requires an error")
         if name == "multi_producer_saturation" and result == "PASS":
             _validate_saturation_details(stage.get("details"))
+        if name == "repeated_tx_full" and result == "PASS":
+            _validate_tx_full_details(stage.get("details"))
+        if name == "slow_receiver" and result == "PASS":
+            _validate_slow_receiver_details(stage.get("details"))
         stage_names.append(name)
     if len(stage_names) != len(set(stage_names)):
         raise ValueError("stress report contains duplicate stages")
@@ -637,6 +708,30 @@ def _validate_saturation_details(details: object) -> None:
             raise ValueError(f"saturation producer {can_id} did not receive its bounded frame budget")
         if any(producer[name] for name in ("lost", "duplicate", "unexpected")):
             raise ValueError(f"saturation producer {can_id} contains unexplained delivery anomalies")
+
+
+def _validate_tx_full_details(details: object) -> None:
+    if not isinstance(details, dict):
+        raise ValueError("passing tx-full stage requires details")
+    attempts = details.get("attempts")
+    delivered = details.get("delivered_once")
+    if not isinstance(attempts, int) or isinstance(attempts, bool) or not 1 <= attempts <= 1000:
+        raise ValueError("tx-full attempts are outside the bounded range")
+    if delivered != attempts:
+        raise ValueError("every tx-full retry must deliver exactly once")
+
+
+def _validate_slow_receiver_details(details: object) -> None:
+    if not isinstance(details, dict):
+        raise ValueError("passing slow-receiver stage requires details")
+    for name in ("sent", "received", "expected_socket_loss", "duplicate", "unexpected", "driver_rx_dropped"):
+        value = details.get(name)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(f"slow-receiver evidence has invalid {name}")
+    if details["sent"] < 1 or details["received"] + details["expected_socket_loss"] != details["sent"]:
+        raise ValueError("slow-receiver delivery accounting is inconsistent")
+    if details["duplicate"] or details["unexpected"] or details["driver_rx_dropped"]:
+        raise ValueError("slow-receiver evidence contains unexplained driver anomalies")
 
 
 def write_stress_report(path: Path, report: dict[str, Any]) -> None:
@@ -688,6 +783,8 @@ def run_probe(
             ("restart_stop_race", probe.exercise_restart_stop_race),
             ("queue_recovery", probe.verify_queue_recovery),
             ("stats_sampling", probe.exercise_stats_sampling),
+            ("repeated_tx_full", probe.exercise_repeated_tx_full),
+            ("slow_receiver", probe.exercise_slow_receiver),
             (
                 "multi_producer_saturation",
                 lambda: probe.exercise_multi_producer_saturation(producer_count, frames_per_producer),

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -18,6 +18,7 @@ TEST_STOP_DELAY="/sys/module/wbcan/parameters/test_stop_delay_ms"
 PASS=0
 FAIL=0
 REPORT_FILE="${WBCAN_TEST_REPORT:-}"
+STRESS_REPORT_FILE="${WBCAN_STRESS_REPORT:-}"
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -546,7 +547,11 @@ clear_fault
 restart_if_bus_off
 
 # --- 16. state, queue, and fault-plane concurrency stays bounded -----------
-if python3 "$(dirname "$0")/test_state_concurrency.py" "$IFACE" "$DBG"
+stress_args=()
+if [ -n "$STRESS_REPORT_FILE" ]; then
+	stress_args+=(--report "$STRESS_REPORT_FILE")
+fi
+if python3 "$(dirname "$0")/test_state_concurrency.py" "$IFACE" "$DBG" "${stress_args[@]}"
 then
 	green "PASS  concurrent state and queue transitions stay bounded"
 	PASS=$((PASS + 1))

--- a/tests/unit/test_linux_driver_tests.py
+++ b/tests/unit/test_linux_driver_tests.py
@@ -115,6 +115,17 @@ def _stress_report() -> dict[str, object]:
         "frames_per_producer": 10,
         "producers": [producer, {**producer, "can_id": "0x741"}],
     }
+    tx_full = next(stage for stage in stages if stage["name"] == "repeated_tx_full")
+    tx_full["details"] = {"attempts": 16, "delivered_once": 16}
+    slow_receiver = next(stage for stage in stages if stage["name"] == "slow_receiver")
+    slow_receiver["details"] = {
+        "sent": 500,
+        "received": 100,
+        "expected_socket_loss": 400,
+        "duplicate": 0,
+        "unexpected": 0,
+        "driver_rx_dropped": 0,
+    }
     return {
         "schema_version": STRESS.REPORT_SCHEMA_VERSION,
         "scope": "virtual-wbcan-only",
@@ -197,6 +208,23 @@ def test_stress_report_records_but_accepts_complete_reordered_delivery() -> None
     saturation["details"]["producers"][0]["reordered"] = 3
 
     STRESS.validate_stress_report(report)
+
+
+def test_stress_report_rejects_tx_full_or_slow_receiver_anomaly() -> None:
+    report = _stress_report()
+    stages = report["stages"]
+    assert isinstance(stages, list)
+    tx_full = next(stage for stage in stages if stage["name"] == "repeated_tx_full")
+    tx_full["details"]["delivered_once"] = 15
+    with pytest.raises(ValueError, match="exactly once"):
+        STRESS.validate_stress_report(report)
+
+    report = _stress_report()
+    stages = report["stages"]
+    slow_receiver = next(stage for stage in stages if stage["name"] == "slow_receiver")
+    slow_receiver["details"]["driver_rx_dropped"] = 1
+    with pytest.raises(ValueError, match="driver anomalies"):
+        STRESS.validate_stress_report(report)
 
 
 def _latency_report() -> dict[str, object]:


### PR DESCRIPTION
## Summary
- add repeated tx-full retry and slow-receiver profiles to the bounded wbcan probe
- distinguish expected socket-buffer loss from unexplained driver rx_dropped, duplicate, or unexpected frames
- validate and upload raw stress JSON from the kernel job, including failed runs
- extend the Task Packet and portable evidence-contract tests

## Validation
- 27 focused Linux driver tests passed
- Ruff, workflow YAML, Task Packet, and diff checks passed
- full suite was 871 passed, 1 skipped before this narrow change

## Boundary
Progresses #157. Evidence remains virtual-wbcan-only; no physical CAN, PREEMPT_RT, actuator, or hard-real-time claim.