### PR TITLE
feat(bsp): define fail-closed image build inputs

### DIFF
--- a/bsp/boot/README.md
+++ b/bsp/boot/README.md
@@ -12,6 +12,12 @@ manual and schematic.
 - rootfs manifest, systemd unit list and firmware bundle hash
 - recovery image, rollback procedure and serial-console transcript
 
+The machine-readable source of truth is `bsp/image/build-inputs.yaml`. Run
+`python bsp/validation/validate_image_inputs.py` before attempting a build.
+The committed manifest deliberately remains `inputs_unresolved` and
+`build_ready: false` until every version, source, repository input and digest
+is frozen. Generated hashes never prove that the image booted on hardware.
+
 ## Bring-up order
 
 1. Boot with motion power isolated; verify console, storage, Ethernet and USB.

--- a/bsp/image/build-inputs.yaml
+++ b/bsp/image/build-inputs.yaml
@@ -1,0 +1,46 @@
+version: "0.1"
+target: NVIDIA_JETSON_ORIN_NANO_SUPER_DEVELOPER_KIT_8GB
+status: inputs_unresolved
+build_ready: false
+inputs:
+  jetpack:
+    version: TBD_COMPATIBILITY_SELECTION
+    source: TBD_VENDOR_HTTPS_URL
+    sha256: TBD_SHA256
+  l4t:
+    version: TBD_COMPATIBILITY_SELECTION
+    source: TBD_VENDOR_HTTPS_URL
+    sha256: TBD_SHA256
+  kernel:
+    version: TBD_L4T_KERNEL_VERSION
+    source: TBD_VENDOR_HTTPS_URL
+    sha256: TBD_SHA256
+    config: bsp/linux/robot_bsp.config
+    config_sha256: TBD_SHA256
+  device_tree:
+    source: TBD_CARRIER_DTS_PATH
+    source_sha256: TBD_SHA256
+    dtb_sha256: TBD_SHA256
+  rootfs:
+    base_source: TBD_VENDOR_HTTPS_URL
+    base_sha256: TBD_SHA256
+    package_lock: TBD_ROOTFS_PACKAGE_LOCK_PATH
+    package_lock_sha256: TBD_SHA256
+    services: bsp/rootfs/services.yaml
+    services_sha256: TBD_SHA256
+  recovery:
+    image_source: TBD_RECOVERY_IMAGE_PATH
+    image_sha256: TBD_SHA256
+    rollback_procedure: TBD_ROLLBACK_PROCEDURE_PATH
+  toolchain:
+    container_digest: TBD_OCI_DIGEST
+    compiler: TBD_COMPILER_VERSION
+outputs:
+  boot_image_sha256: NOT_BUILT
+  rootfs_image_sha256: NOT_BUILT
+  recovery_image_sha256: NOT_BUILT
+rules:
+  network_sources_require_https: true
+  all_build_inputs_require_sha256: true
+  unresolved_inputs_block_build: true
+  generated_output_hashes_do_not_imply_physical_boot: true

--- a/bsp/validation/validate_image_inputs.py
+++ b/bsp/validation/validate_image_inputs.py
@@ -1,0 +1,152 @@
+"""Validate fail-closed Jetson BSP image build inputs."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "bsp/image/build-inputs.yaml"
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+OCI_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+UNRESOLVED_PREFIXES = ("TBD_", "NOT_BUILT")
+
+
+def _unresolved(value: object) -> bool:
+    return not isinstance(value, str) or not value or value.startswith(UNRESOLVED_PREFIXES)
+
+
+def _repository_file(root: Path, value: object) -> Path | None:
+    if _unresolved(value):
+        return None
+    relative = Path(value)
+    if relative.is_absolute() or ".." in relative.parts:
+        return None
+    root = root.resolve()
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate if candidate.is_file() else None
+
+
+def validate_image_inputs(manifest: object, root: Path = ROOT) -> list[str]:
+    if not isinstance(manifest, dict):
+        return ["image build manifest must be a mapping"]
+    errors: list[str] = []
+    inputs = manifest.get("inputs")
+    outputs = manifest.get("outputs")
+    rules = manifest.get("rules")
+    if not isinstance(inputs, dict) or set(inputs) != {
+        "jetpack",
+        "l4t",
+        "kernel",
+        "device_tree",
+        "rootfs",
+        "recovery",
+        "toolchain",
+    }:
+        return ["image build manifest requires the exact controlled input groups"]
+    if not isinstance(outputs, dict) or set(outputs) != {
+        "boot_image_sha256",
+        "rootfs_image_sha256",
+        "recovery_image_sha256",
+    }:
+        errors.append("image build manifest requires the exact controlled outputs")
+    if not isinstance(rules, dict) or not all(value is True for value in rules.values()):
+        errors.append("image build manifest safety rules must all be true")
+
+    unresolved = False
+    for group_name in ("jetpack", "l4t"):
+        group = inputs.get(group_name, {})
+        if not isinstance(group, dict):
+            errors.append(f"{group_name} input must be a mapping")
+            continue
+        for field in ("version", "source", "sha256"):
+            unresolved |= _unresolved(group.get(field))
+        source = group.get("source")
+        if not _unresolved(source) and not source.startswith("https://"):
+            errors.append(f"{group_name} source must use HTTPS")
+        digest = group.get("sha256")
+        if not _unresolved(digest) and not SHA256.fullmatch(digest):
+            errors.append(f"{group_name} sha256 must be lowercase hexadecimal")
+
+    kernel = inputs.get("kernel", {})
+    device_tree = inputs.get("device_tree", {})
+    rootfs = inputs.get("rootfs", {})
+    recovery = inputs.get("recovery", {})
+    toolchain = inputs.get("toolchain", {})
+    for group_name, group in (
+        ("kernel", kernel),
+        ("device_tree", device_tree),
+        ("rootfs", rootfs),
+        ("recovery", recovery),
+        ("toolchain", toolchain),
+    ):
+        if not isinstance(group, dict):
+            errors.append(f"{group_name} input must be a mapping")
+            continue
+        unresolved |= any(_unresolved(value) for value in group.values())
+
+    for source_name, source in (
+        ("kernel", kernel.get("source") if isinstance(kernel, dict) else None),
+        ("rootfs", rootfs.get("base_source") if isinstance(rootfs, dict) else None),
+    ):
+        if not _unresolved(source) and not source.startswith("https://"):
+            errors.append(f"{source_name} source must use HTTPS")
+
+    digest_fields = (
+        kernel.get("sha256"),
+        kernel.get("config_sha256"),
+        device_tree.get("source_sha256"),
+        device_tree.get("dtb_sha256"),
+        rootfs.get("base_sha256"),
+        rootfs.get("package_lock_sha256"),
+        rootfs.get("services_sha256"),
+        recovery.get("image_sha256"),
+    )
+    for digest in digest_fields:
+        if not _unresolved(digest) and not SHA256.fullmatch(digest):
+            errors.append("image input sha256 values must be lowercase hexadecimal")
+    container_digest = toolchain.get("container_digest") if isinstance(toolchain, dict) else None
+    if not _unresolved(container_digest) and not OCI_DIGEST.fullmatch(container_digest):
+        errors.append("toolchain container_digest must be an OCI sha256 digest")
+
+    for field_name, value in (
+        ("kernel config", kernel.get("config")),
+        ("rootfs services", rootfs.get("services")),
+        ("rootfs package lock", rootfs.get("package_lock")),
+        ("device-tree source", device_tree.get("source")),
+        ("rollback procedure", recovery.get("rollback_procedure")),
+    ):
+        if not _unresolved(value) and _repository_file(root, value) is None:
+            errors.append(f"{field_name} must reference a repository file")
+
+    built_outputs = isinstance(outputs, dict) and all(SHA256.fullmatch(value or "") for value in outputs.values())
+    build_ready = manifest.get("build_ready") is True
+    if build_ready and unresolved:
+        errors.append("unresolved image inputs must block build_ready")
+    if build_ready and errors:
+        errors.append("invalid image inputs must block build_ready")
+    if built_outputs and not build_ready:
+        errors.append("built output hashes require build_ready inputs")
+    expected_status = "inputs_locked" if build_ready else "inputs_unresolved"
+    if manifest.get("status") != expected_status:
+        errors.append(f"image build status must be {expected_status}")
+    return errors
+
+
+def validate() -> list[str]:
+    return validate_image_inputs(yaml.safe_load(MANIFEST.read_text(encoding="utf-8")))
+
+
+if __name__ == "__main__":
+    failures = validate()
+    if failures:
+        for failure in failures:
+            print(f"FAIL {failure}")
+        raise SystemExit(1)
+    print("BSP image input validation passed")

--- a/bsp/validation/validate_manifests.py
+++ b/bsp/validation/validate_manifests.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 import yaml
 
+try:
+    from bsp.validation.validate_image_inputs import validate as validate_image_inputs
+except ModuleNotFoundError:  # Direct script execution from bsp/validation.
+    from validate_image_inputs import validate as validate_image_inputs
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -117,6 +122,7 @@ def validate() -> list[str]:
     launcher = (ROOT / "bsp/rootfs/libexec/camera-head-launch").read_text(encoding="utf-8")
     environment_example = (ROOT / "bsp/rootfs/camera-head.env.example").read_text(encoding="utf-8")
     errors.extend(validate_camera_deployment(deployment, unit, launcher, environment_example))
+    errors.extend(validate_image_inputs())
     return errors
 
 

--- a/docs/task_packets/robot-bsp-implementation-v0.1.json
+++ b/docs/task_packets/robot-bsp-implementation-v0.1.json
@@ -25,6 +25,9 @@
     "readiness uses the exact controlled gate set and rejects missing or invented gate identities",
     "PASS evidence must be a regular file inside the repository rather than a directory or path escape",
     "physical release readiness and package status are derived from whether every controlled gate is PASS",
+    "Jetson image inputs use a controlled manifest with versions, HTTPS sources, repository paths and SHA-256 digests",
+    "unresolved or invalid image inputs keep build_ready false and status inputs_unresolved",
+    "generated image hashes do not imply physical boot or BSP-GATE-IMAGE PASS",
     "one D435 head camera uses USB 3, UVC/V4L2, librealsense and a fail-closed physical calibration gate",
     "the composite D435 binds by librealsense serial instead of a conflicting shared video-device symlink",
     "camera deployment remains non-installable until JetPack, ROS, driver packages and purchased-unit identity are frozen"
@@ -33,6 +36,7 @@
     "python -m json.tool docs/task_packets/robot-bsp-implementation-v0.1.json",
     "python bsp/validation/validate_manifests.py",
     "python bsp/validation/check_readiness.py",
+    "python bsp/validation/validate_image_inputs.py",
     "python -m pytest tests/unit/test_bsp_manifests.py -q",
     "python -c \"from pathlib import Path; import yaml; d=yaml.safe_load(Path('bsp/validation/bringup-plan.yaml').read_text()); assert d['status']=='plan_not_executed' and all(x['result']=='NOT_EXECUTED' for x in d['tests'])\""
   ],

--- a/tests/unit/test_bsp_manifests.py
+++ b/tests/unit/test_bsp_manifests.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 
 from bsp.validation.check_readiness import BLOCKED_STATUS, READY_STATUS, check, validate_readiness
+from bsp.validation.validate_image_inputs import validate_image_inputs
 from bsp.validation.validate_manifests import (
     validate,
     validate_camera_deployment,
@@ -159,3 +160,51 @@ def test_readiness_release_flag_and_package_status_follow_all_gates(tmp_path: Pa
     assert "physical_release_ready must equal the all-gates-PASS result" in validate_readiness(changed, root)
     changed["physical_release_ready"] = False
     assert f"BSP package status must be {BLOCKED_STATUS}" in validate_readiness(changed, root)
+
+
+def load_image_inputs() -> dict:
+    return yaml.safe_load((ROOT / "bsp/image/build-inputs.yaml").read_text(encoding="utf-8"))
+
+
+def test_unresolved_image_inputs_are_valid_but_not_build_ready() -> None:
+    manifest = load_image_inputs()
+
+    assert manifest["build_ready"] is False
+    assert manifest["status"] == "inputs_unresolved"
+    assert validate_image_inputs(manifest) == []
+
+
+def test_image_inputs_reject_premature_ready_or_insecure_source() -> None:
+    manifest = deepcopy(load_image_inputs())
+    manifest["build_ready"] = True
+    manifest["status"] = "inputs_locked"
+    manifest["inputs"]["jetpack"]["source"] = "http://vendor.invalid/jetpack"
+
+    errors = validate_image_inputs(manifest)
+
+    assert "jetpack source must use HTTPS" in errors
+    assert "unresolved image inputs must block build_ready" in errors
+
+
+def test_image_inputs_reject_path_escape_and_directory(tmp_path: Path) -> None:
+    manifest = deepcopy(load_image_inputs())
+    manifest["inputs"]["kernel"]["config"] = "../outside.config"
+    manifest["inputs"]["rootfs"]["services"] = "bsp"
+    (tmp_path / "repo/bsp").mkdir(parents=True)
+
+    errors = validate_image_inputs(manifest, tmp_path / "repo")
+
+    assert "kernel config must reference a repository file" in errors
+    assert "rootfs services must reference a repository file" in errors
+
+
+def test_image_outputs_cannot_exist_before_inputs_are_locked() -> None:
+    manifest = deepcopy(load_image_inputs())
+    digest = "a" * 64
+    manifest["outputs"] = {
+        "boot_image_sha256": digest,
+        "rootfs_image_sha256": digest,
+        "recovery_image_sha256": digest,
+    }
+
+    assert "built output hashes require build_ready inputs" in validate_image_inputs(manifest)


### PR DESCRIPTION
## Summary
- add a machine-readable Jetson image build-input manifest for JetPack/L4T/kernel/DTB/rootfs/recovery/toolchain
- validate HTTPS sources, repository paths, SHA-256/OCI digests, exact input groups, and unresolved status
- integrate image validation into the BSP manifest gate while keeping inputs_unresolved/build_ready=false
- document that generated hashes never imply physical boot

## Validation
- 876 passed, 1 environment skip
- BSP image/readiness/manifest validators passed
- Ruff, workflow-independent Task Packet, and diff checks passed

## Boundary
Progresses #269/#130 software-side image reproducibility. No Jetson image was built and no physical boot, CAN, safety, or HIL PASS is claimed.