### PR TITLE
test(kernel): validate wbcan kernel diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
           sudo ip link set wbcan0 up
           ip -details link show wbcan0
 
+      - name: Mark kernel diagnostic scope
+        run: |
+          marker="wbcan-diagnostics-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "WBCAN_DIAGNOSTIC_MARKER=$marker" >> "$GITHUB_ENV"
+          printf '<6>%s\n' "$marker" | sudo tee /dev/kmsg >/dev/null
+
       - name: Run the fault suite
         id: fault_suite
         env:
@@ -124,6 +130,34 @@ jobs:
       - name: Validate stress evidence
         if: always()
         run: python3 kernel/wbcan/test_state_concurrency.py --validate-report "$RUNNER_TEMP/wbcan-stress-report.json"
+
+      - name: Capture and validate kernel diagnostics
+        if: always()
+        env:
+          DMESG_LOG: ${{ runner.temp }}/wbcan-dmesg.log
+          SLABINFO_LOG: ${{ runner.temp }}/wbcan-slabinfo.txt
+          MEMINFO_LOG: ${{ runner.temp }}/wbcan-meminfo.txt
+          DIAGNOSTIC_REPORT: ${{ runner.temp }}/wbcan-kernel-diagnostics.json
+        run: |
+          sudo dmesg > "$DMESG_LOG"
+          sudo cat /proc/slabinfo > "$SLABINFO_LOG"
+          cat /proc/meminfo > "$MEMINFO_LOG"
+          python3 kernel/wbcan/validate_kernel_diagnostics.py \
+            --dmesg "$DMESG_LOG" --slabinfo "$SLABINFO_LOG" --meminfo "$MEMINFO_LOG" \
+            --kernel "$(uname -r)" --marker "$WBCAN_DIAGNOSTIC_MARKER" --report "$DIAGNOSTIC_REPORT"
+          python3 kernel/wbcan/validate_kernel_diagnostics.py --validate-report "$DIAGNOSTIC_REPORT"
+
+      - name: Upload kernel diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: wbcan-kernel-diagnostics
+          path: |
+            ${{ runner.temp }}/wbcan-dmesg.log
+            ${{ runner.temp }}/wbcan-slabinfo.txt
+            ${{ runner.temp }}/wbcan-meminfo.txt
+            ${{ runner.temp }}/wbcan-kernel-diagnostics.json
+          if-no-files-found: error
 
       - name: Upload stress evidence
         if: always()

--- a/docs/task_packets/linux-wbcan-saturation-stats.json
+++ b/docs/task_packets/linux-wbcan-saturation-stats.json
@@ -7,6 +7,7 @@
     "kernel/wbcan/test_state_concurrency.py",
     "kernel/wbcan/Makefile",
     "kernel/wbcan/test_wbcan.sh",
+    "kernel/wbcan/validate_kernel_diagnostics.py",
     ".github/workflows/ci.yml",
     "tests/unit/test_linux_driver_tests.py",
     "docs/task_packets/linux-wbcan-saturation-stats.json"
@@ -30,6 +31,7 @@
     "repeated transient tx-full injections deliver every retried frame exactly once and leave the queue usable",
     "slow-receiver evidence separates expected socket-buffer loss from unexplained netdev rx_dropped events",
     "CI validates and uploads the raw stress JSON even when a later gate fails",
+    "CI captures dmesg, slabinfo, and meminfo and fails closed on kernel warning signatures",
     "the bounded stress entrypoint emits a versioned JSON report with environment, stage timing, and PASS or FAIL status",
     "malformed, incomplete, failed, or non-virtual stress reports fail validation",
     "the existing seven fault modes and state lifecycle behavior remain unchanged",
@@ -50,6 +52,7 @@
     "privileged wbcan fault suite output",
     "concurrent netdev statistics sampling output",
     "per-producer bounded saturation accounting in the versioned JSON artifact",
+    "kernel diagnostic JSON and raw resource snapshots",
     "marker-delimited dmesg without kernel warnings"
   ],
   "stop_conditions": [

--- a/kernel/wbcan/validate_kernel_diagnostics.py
+++ b/kernel/wbcan/validate_kernel_diagnostics.py
@@ -1,0 +1,109 @@
+"""Fail-closed validation for bounded wbcan kernel diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "wbcan-kernel-diagnostics-v1"
+WARNING_PATTERNS = (
+    r"BUG:",
+    r"WARNING:",
+    r"lockdep",
+    r"KASAN:",
+    r"UBSAN:",
+    r"soft lockup",
+    r"hung task",
+    r"refcount",
+    r"sleeping function called from invalid context",
+    r"RCU stall",
+)
+
+
+def validate_report(report: object) -> None:
+    if not isinstance(report, dict):
+        raise ValueError("diagnostic report must be an object")
+    if report.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("diagnostic report schema_version is invalid")
+    if report.get("scope") != "virtual-wbcan-kernel-job":
+        raise ValueError("diagnostic report scope is invalid")
+    if report.get("result") not in {"PASS", "FAIL", "NOT_EXECUTED"}:
+        raise ValueError("diagnostic report result is invalid")
+    for name in ("kernel", "marker", "dmesg_path", "slabinfo_path", "meminfo_path"):
+        if not isinstance(report.get(name), str) or not report[name]:
+            raise ValueError(f"diagnostic report requires {name}")
+    warnings = report.get("warnings")
+    if not isinstance(warnings, list) or any(not isinstance(item, str) or not item for item in warnings):
+        raise ValueError("diagnostic report warnings must be a list of strings")
+    if report["result"] == "PASS" and warnings:
+        raise ValueError("passing diagnostic report cannot contain warnings")
+    if report["result"] == "FAIL" and not warnings:
+        raise ValueError("failed diagnostic report must contain warning matches")
+    for name in ("dmesg_bytes", "scoped_dmesg_bytes", "slabinfo_bytes", "meminfo_bytes"):
+        if not isinstance(report.get(name), int) or isinstance(report[name], bool) or report[name] < 0:
+            raise ValueError(f"diagnostic report has invalid {name}")
+
+
+def scan_dmesg(text: str) -> list[str]:
+    warnings: list[str] = []
+    for line in text.splitlines():
+        if any(re.search(pattern, line, flags=re.IGNORECASE) for pattern in WARNING_PATTERNS):
+            warnings.append(line.strip())
+    return warnings
+
+
+def build_report(dmesg: Path, slabinfo: Path, meminfo: Path, kernel: str, marker: str) -> dict[str, Any]:
+    dmesg_text = dmesg.read_text(encoding="utf-8", errors="replace")
+    slabinfo_text = slabinfo.read_text(encoding="utf-8", errors="replace")
+    meminfo_text = meminfo.read_text(encoding="utf-8", errors="replace")
+    if not marker or marker not in dmesg_text:
+        raise ValueError("diagnostic marker is missing from dmesg")
+    scoped_dmesg = dmesg_text.split(marker, 1)[1]
+    warnings = scan_dmesg(scoped_dmesg)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scope": "virtual-wbcan-kernel-job",
+        "result": "FAIL" if warnings else "PASS",
+        "kernel": kernel,
+        "marker": marker,
+        "dmesg_path": str(dmesg),
+        "slabinfo_path": str(slabinfo),
+        "meminfo_path": str(meminfo),
+        "dmesg_bytes": len(dmesg_text.encode("utf-8")),
+        "scoped_dmesg_bytes": len(scoped_dmesg.encode("utf-8")),
+        "slabinfo_bytes": len(slabinfo_text.encode("utf-8")),
+        "meminfo_bytes": len(meminfo_text.encode("utf-8")),
+        "warnings": warnings,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dmesg", type=Path)
+    parser.add_argument("--slabinfo", type=Path)
+    parser.add_argument("--meminfo", type=Path)
+    parser.add_argument("--kernel")
+    parser.add_argument("--marker")
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--validate-report", type=Path)
+    args = parser.parse_args()
+    if args.validate_report is not None:
+        validate_report(json.loads(args.validate_report.read_text(encoding="utf-8")))
+        print(f"kernel diagnostic report valid: {args.validate_report}")
+        return 0
+    if not args.dmesg or not args.slabinfo or not args.meminfo or not args.kernel or not args.report or not args.marker:
+        parser.error("--dmesg, --slabinfo, --meminfo, --kernel, --marker, and --report are required")
+    report = build_report(args.dmesg, args.slabinfo, args.meminfo, args.kernel, args.marker)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    validate_report(report)
+    if report["result"] != "PASS":
+        raise SystemExit(f"kernel diagnostic warnings found: {len(report['warnings'])}")
+    print(f"kernel diagnostic report: {args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_linux_driver_tests.py
+++ b/tests/unit/test_linux_driver_tests.py
@@ -10,6 +10,7 @@ MODULE_PATH = ROOT / "kernel" / "wbcan" / "validate_test_report.py"
 TEST_SCRIPT = ROOT / "kernel" / "wbcan" / "test_wbcan.sh"
 STRESS_PATH = ROOT / "kernel" / "wbcan" / "test_state_concurrency.py"
 LATENCY_PATH = ROOT / "kernel" / "wbcan" / "test_latency.py"
+DIAGNOSTICS_PATH = ROOT / "kernel" / "wbcan" / "validate_kernel_diagnostics.py"
 SPEC = importlib.util.spec_from_file_location("validate_wbcan_report", MODULE_PATH)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -22,6 +23,10 @@ LATENCY_SPEC = importlib.util.spec_from_file_location("wbcan_latency", LATENCY_P
 assert LATENCY_SPEC and LATENCY_SPEC.loader
 LATENCY = importlib.util.module_from_spec(LATENCY_SPEC)
 LATENCY_SPEC.loader.exec_module(LATENCY)
+DIAGNOSTICS_SPEC = importlib.util.spec_from_file_location("wbcan_diagnostics", DIAGNOSTICS_PATH)
+assert DIAGNOSTICS_SPEC and DIAGNOSTICS_SPEC.loader
+DIAGNOSTICS = importlib.util.module_from_spec(DIAGNOSTICS_SPEC)
+DIAGNOSTICS_SPEC.loader.exec_module(DIAGNOSTICS)
 
 
 HEADER = "result\ttest_id\tname\texpected\tactual\n"
@@ -325,3 +330,53 @@ def test_wbcan_status_snapshot_does_not_take_tx_lock_or_format_under_private_loc
 
     assert "netif_tx_lock" not in status_show
     assert status_show.index("spin_unlock_irqrestore") < status_show.index("seq_printf")
+
+
+def test_kernel_diagnostics_pass_report_requires_empty_warning_matches(tmp_path: Path) -> None:
+    dmesg = tmp_path / "dmesg.log"
+    slabinfo = tmp_path / "slabinfo"
+    meminfo = tmp_path / "meminfo"
+    dmesg.write_text("boot WARNING: unrelated\ntest-marker\nwbcan: registered\n", encoding="ascii")
+    slabinfo.write_text("slabinfo - version: 2.1\n", encoding="ascii")
+    meminfo.write_text("MemTotal: 1 kB\n", encoding="ascii")
+
+    report = DIAGNOSTICS.build_report(dmesg, slabinfo, meminfo, "test-kernel", "test-marker")
+
+    assert report["result"] == "PASS"
+    DIAGNOSTICS.validate_report(report)
+
+
+def test_kernel_diagnostics_rejects_warning_signatures_and_malformed_pass() -> None:
+    assert DIAGNOSTICS.scan_dmesg("INFO ok\nBUG: bad\nlockdep: held\n") == ["BUG: bad", "lockdep: held"]
+    with pytest.raises(ValueError, match="cannot contain warnings"):
+        DIAGNOSTICS.validate_report(
+            {
+                "schema_version": DIAGNOSTICS.SCHEMA_VERSION,
+                "scope": "virtual-wbcan-kernel-job",
+                "result": "PASS",
+                "kernel": "test",
+                "marker": "marker",
+                "dmesg_path": "dmesg",
+                "slabinfo_path": "slab",
+                "meminfo_path": "mem",
+                "dmesg_bytes": 1,
+                "scoped_dmesg_bytes": 1,
+                "slabinfo_bytes": 1,
+                "meminfo_bytes": 1,
+                "warnings": ["BUG: bad"],
+            }
+        )
+
+
+def test_kernel_diagnostics_requires_marker_and_scans_only_scoped_log(tmp_path: Path) -> None:
+    dmesg = tmp_path / "dmesg.log"
+    slabinfo = tmp_path / "slabinfo"
+    meminfo = tmp_path / "meminfo"
+    dmesg.write_text("boot WARNING: unrelated\nmarker\nBUG: wbcan failure\n", encoding="ascii")
+    slabinfo.write_text("slab\n", encoding="ascii")
+    meminfo.write_text("mem\n", encoding="ascii")
+
+    report = DIAGNOSTICS.build_report(dmesg, slabinfo, meminfo, "test", "marker")
+    assert report["warnings"] == ["BUG: wbcan failure"]
+    with pytest.raises(ValueError, match="marker is missing"):
+        DIAGNOSTICS.build_report(dmesg, slabinfo, meminfo, "test", "absent-marker")


### PR DESCRIPTION
## Summary
- validate dmesg against lockdep, KASAN/UBSAN, soft-lockup, hung-task, refcount, RCU, and invalid-context warning signatures
- capture and upload dmesg, slabinfo, meminfo, and a machine-readable diagnostics report from the kernel job
- preserve stress evidence on later gate failures
- extend the #157 Task Packet and portable tests

## Validation
- 878 passed, 1 environment skip
- 29 focused Linux driver tests passed
- Ruff, workflow YAML, Task Packet, and diff checks passed

## Boundary
Progresses #157 resource/lifetime evidence. This is virtual wbcan kernel-job evidence, not physical CAN, PREEMPT_RT, or actuator validation.