### PR TITLE
fix(mcu): align CAN HAL with Wire V1

### DIFF
--- a/docs/architecture/mcu-can-hal-boundary-v1.md
+++ b/docs/architecture/mcu-can-hal-boundary-v1.md
@@ -1,0 +1,142 @@
+# MCU CAN HAL Boundary V1
+
+Status: **platform-independent bridge implemented; physical target transport
+NOT_EXECUTED** for Issue #180.
+
+This boundary connects the raw CAN controller envelope in
+`firmware/mcu/core/hal.h` to the frozen MCU CAN Wire V1 codec. It removes the
+former ambiguity between a CAN arbitration identifier and a logical command
+identifier without changing any Wire V1 number or payload byte.
+
+## Identifier boundary
+
+The two identifiers have different widths and authorities:
+
+| Name | Width | Location | Meaning |
+| --- | ---: | --- | --- |
+| `arbitration_id` | 11 bits | CAN envelope | Selects one Wire V1 frame kind and arbitration priority. |
+| `command_id` | 16 bits | payload bytes 1..2 | Correlates an ordinary command or STOP and selects its disjoint ID partition. |
+
+A STOP therefore uses arbitration ID `0x080` while its payload command ID is
+`0x8000..0xffff`. A target HAL must never write the logical command ID into a
+CAN arbitration register.
+
+`hal_can_frame` contains:
+
+- `arbitration_id`, which must be at most `0x7ff`;
+- `dlc`;
+- an explicit flags byte for extended-ID, RTR, error and CAN FD metadata; and
+- eight Classic CAN data bytes.
+
+The flags are not C bit-fields. Every target must translate its controller
+status into the declared masks explicitly, avoiding compiler-specific layout.
+
+## One encoding authority
+
+`mcu_can_bridge_encode()` calls `mcu_frame_encode()` and then constructs a raw
+standard Classic CAN data envelope. `mcu_can_bridge_decode()` validates the raw
+envelope before calling `mcu_frame_decode()`. There is no second frame-kind or
+payload mapping in the HAL.
+
+The decoder publishes no logical frame unless all of these conditions pass:
+
+1. flags are exactly `HAL_CAN_FRAME_FLAG_NONE`;
+2. `arbitration_id <= 0x7ff`;
+3. DLC is exactly eight;
+4. the arbitration ID is one of the five frozen Wire V1 IDs; and
+5. version, reserved bytes, enum values, ID partitions and cross-field
+   semantics all pass the existing codec.
+
+Extended, RTR, error, CAN FD, unknown-flag, out-of-range-ID, unknown-ID,
+wrong-DLC and malformed Wire V1 inputs produce a bounded bridge rejection
+record. They do not dispatch a state-machine event, create an ACK, enter replay
+history or refresh the software watchdog. If execution is already active,
+malformed traffic cannot keep it alive; only a valid serially new ordinary
+command may refresh the existing deadline.
+
+## MCU ingress direction and routing
+
+The MCU ingress accepts only `STOP` and ordinary `COMMAND` kinds:
+
+```text
+raw HAL envelope
+  -> strict envelope validation
+  -> mcu_frame_decode()
+  -> STOP: mcu_watchdog_receive_stop()
+  -> COMMAND: mcu_command_dedup_receive()
+  -> response: mcu_frame_encode() -> hal_can_send()
+```
+
+The STOP branch is tested before ordinary-command handling. It bypasses both
+the trusted ordinary-session gate and the fixed replay window; a missing or
+corrupt ordinary dedup object cannot suppress this path. ACK, STOP_ACK and
+telemetry frames are valid MCU-originated encodings, but are rejected as
+wrong-direction traffic if received by this MCU ingress and never reach safety
+state.
+
+`mcu_can_bridge_poll()` consumes at most one HAL frame per call. The target is
+the single writer of the bridge, state machine, watchdog and dedup objects; it
+must serialize ISR/task ownership and configure controller filters/FIFO policy
+so STOP priority is preserved. The core does not create a hidden or unbounded
+receive queue.
+
+## Response handoff
+
+`hal_can_send() == true` means only that the complete encoded frame was handed
+to the target transport. It does not prove arbitration, wire delivery, remote
+receipt, motor state or physical stopping.
+
+For an accepted STOP, a successful HAL handoff confirms the existing bounded
+STOP_ACK slot through `mcu_watchdog_confirm_stop_ack()`. If the HAL rejects the
+send, the ACK remains pending and the existing STOP timeout/retry policy stays
+active. Ordinary ACK results remain in the dedup cache, so a host retry can
+request the same semantic response without executing the command again.
+
+## Priority evidence
+
+Wire V1 retains the strict numeric order:
+
+```text
+STOP 0x080 < STOP_ACK 0x081 < COMMAND 0x100 < ACK 0x101 < TELEMETRY 0x180
+```
+
+The bounded Host fake accepts a set of pending frames and exposes the lowest
+arbitration ID first, retaining insertion order for equal IDs. A regression
+queues an ordinary command before STOP and proves STOP is still dispatched and
+handed off first while the ordinary session is closed. This is deterministic
+logic evidence only; it is not bus timing, controller FIFO, ISR latency or
+electrical arbitration evidence.
+
+## Six-domain BSP compatibility gate
+
+BSP V0.1 assigns logical node IDs to `MCU-BASE`, both arm controllers, both
+tool controllers and `MCU-SAFETY`, but its concrete multi-node arbitration
+bit allocation is still an implementation gate. Wire V1 currently assigns all
+11 arbitration bits to five exact frame-kind IDs and carries no node field in
+the eight-byte payload. Multiple independently responding domains therefore
+cannot be placed on one shared bus by silently OR-ing a node ID into these
+values: that would change the frozen contract and can create colliding ACKs.
+
+This bridge remains a single logical Wire V1 endpoint until the Protocol,
+Firmware, Linux and Electrical owners approve one of the following in a
+separate versioned decision:
+
+- a new arbitration layout with explicit source/destination ownership;
+- physically separated buses that preserve the existing IDs; or
+- a new payload/transport version with bounded node addressing.
+
+No option is selected or inferred by Issue #180's platform-independent slice.
+
+## Target evidence matrix
+
+| Target | Bridge/codec logic | CAN transport | Evidence boundary |
+| --- | --- | --- | --- |
+| Host fake | `PASS` | `PASS` for bounded fake queues | No controller, wire or physical timing. |
+| RISC-V QEMU | `PASS` | `NOT_EXECUTED` | `hal_can_init/send/recv` remain false-returning stubs. |
+| Legacy CH32V307 target | build source absent | `NOT_EXECUTED` | No board HAL, linker/startup package or board run. |
+| BSP STM32H563 / STM32G0B1 | target absent | `NOT_EXECUTED` | No approved clock, pin, transceiver, filter, IRQ, linker or vendor HAL inputs. |
+
+The Host/QEMU tests prove envelope validation, codec reuse, direction gates,
+STOP-first dispatch and transport-handoff state semantics. They do not prove a
+real STM32 peripheral, six-domain arbitration, bitrate, bus-off recovery,
+physical CAN, actuators, E-stop behavior or hard-real-time deadlines.

--- a/docs/architecture/mcu-wire-v1.md
+++ b/docs/architecture/mcu-wire-v1.md
@@ -1,6 +1,7 @@
 # MCU CAN Wire V1
 
-Status: **firmware-owned binary contract** for Issue #54.
+Status: **firmware-owned binary contract** for Issue #54, connected to the raw
+HAL envelope by Issue #180.
 
 This document maps the frozen logical MCU protocol v1.0 into one Classic CAN
 data frame. The logical contract remains normative for frame meaning. Wire V1
@@ -17,6 +18,11 @@ models.
 - Byte 0 is the compact protocol version. Logical version `"1.0"` is `0x10`.
 - CAN's frame CRC is the transport integrity check; Wire V1 adds no payload
   checksum.
+
+The raw controller boundary and rejection order are defined in
+`docs/architecture/mcu-can-hal-boundary-v1.md`. In particular,
+`hal_can_frame.arbitration_id` is the 11-bit value in the table below, while
+the logical 16-bit `command_id` remains inside payload bytes 1..2.
 
 The logical `frame_id`, `sent_at_us` and `clock_id` fields are adapter/evidence
 metadata and are not transmitted in the eight-byte CAN payload. A bridge owns
@@ -143,5 +149,7 @@ semantics are invalid. The encoder validates the complete logical wire object
 and destination capacity before writing any output byte.
 
 Wire V1 does not implement command deduplication, watchdog scheduling, host
-transport dispatch, CAN controller registers, bus-off recovery or electrical
-validation. Those remain separate issues and hardware evidence gates.
+transport dispatch, CAN controller registers, bus-off recovery, multi-node
+addressing or electrical validation. The Issue #180 bridge validates the raw
+envelope and routes decoded frames, but real target drivers and physical
+evidence remain separate owner-gated work.

--- a/docs/architecture/robot-bsp-can-v0.1.md
+++ b/docs/architecture/robot-bsp-can-v0.1.md
@@ -58,3 +58,10 @@ arbitration-ID table, bitrate/FD data phase, termination, transceiver part,
 device-tree nodes, and per-domain recovery tests. `wbcan` can validate the
 software semantics, but cannot provide bus-load, EMC, wire-latency or physical
 recovery evidence.
+
+The existing MCU Wire V1 contract uses five exact 11-bit frame-kind IDs and
+does not encode a node address. Issue #180's HAL bridge deliberately preserves
+those frozen values, so it proves one logical endpoint only. Six domains must
+not share those response IDs until an owner-approved versioned arbitration or
+bus-segmentation decision prevents ambiguous/colliding ACK and telemetry
+traffic. See `docs/architecture/mcu-can-hal-boundary-v1.md`.

--- a/docs/task_packets/issue-180-mcu-can-hal-boundary.json
+++ b/docs/task_packets/issue-180-mcu-can-hal-boundary.json
@@ -1,0 +1,92 @@
+{
+  "issue": 180,
+  "human_owner": "TH3478",
+  "objective": "Implement the bounded platform-independent MCU HAL/Wire V1 bridge: distinguish 11-bit arbitration IDs from payload command IDs, reject invalid raw envelopes before safety dispatch, route STOP before ordinary deduplication, and provide shared logic plus Host fake-HAL evidence without claiming a physical target.",
+  "allowed_paths": [
+    "firmware/mcu/core/hal.h",
+    "firmware/mcu/core/can_bridge.h",
+    "firmware/mcu/core/can_bridge.c",
+    "firmware/mcu/hal/host/hal_host.c",
+    "firmware/mcu/hal/host/hal_host_test.h",
+    "firmware/mcu/hal/qemu/main_qemu.c",
+    "firmware/mcu/tests/can_bridge_tests.h",
+    "firmware/mcu/tests/can_bridge_tests.c",
+    "firmware/mcu/tests/can_bridge_host_tests.h",
+    "firmware/mcu/tests/can_bridge_host_tests.c",
+    "firmware/mcu/tests/main_host.c",
+    "firmware/mcu/Makefile",
+    "firmware/mcu/README.md",
+    "docs/architecture/mcu-can-hal-boundary-v1.md",
+    "docs/architecture/mcu-wire-v1.md",
+    "docs/architecture/robot-bsp-can-v0.1.md",
+    "docs/task_packets/issue-180-mcu-can-hal-boundary.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "docs/architecture/mcu-protocol-v1.md",
+    "docs/architecture/mcu-watchdog-v1.md",
+    "docs/architecture/mcu-command-dedup-v1.md",
+    "interfaces/json_schema/mcu_protocol.schema.json",
+    "interfaces/examples/mcu-frame-stop-ack.json",
+    "firmware/mcu/core/frame_codec.h",
+    "firmware/mcu/core/frame_codec.c",
+    "firmware/mcu/core/state_machine.h",
+    "firmware/mcu/core/state_machine.c",
+    "firmware/mcu/core/watchdog.h",
+    "firmware/mcu/core/watchdog.c",
+    "firmware/mcu/core/command_dedup.h",
+    "firmware/mcu/core/command_dedup.c"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/mcu/hal/ch32v307/**",
+    "firmware/virtual_mcu/**",
+    "robot/control/**",
+    "hardware/**",
+    "services/**",
+    ".github/**"
+  ],
+  "acceptance": [
+    "The HAL names the standard 11-bit arbitration_id separately from the logical 16-bit command_id carried in Wire V1 payload bytes 1..2.",
+    "Raw extended-ID, RTR, error, CAN FD, unknown-flag, out-of-range-ID and wrong-DLC envelopes are rejected before codec publication or safety-state mutation.",
+    "The bridge uses mcu_frame_encode and mcu_frame_decode as its only frame-kind, arbitration-ID and payload mapping authority.",
+    "All five valid Wire V1 kinds round-trip through the HAL conversion, while unknown IDs, bad versions, nonzero reserved bytes and invalid cross-field payloads fail closed with unchanged decode output.",
+    "MCU ingress accepts only STOP and ordinary COMMAND directions; ACK, STOP_ACK and telemetry ingress cannot reach the state machine.",
+    "STOP arbitration ID 0x080 retains priority while its payload command ID remains at least 0x8000, and STOP bypasses the closed ordinary session gate plus a missing, corrupt or full replay window.",
+    "A successful STOP_ACK HAL handoff confirms the bounded watchdog slot; a failed handoff leaves it pending for the existing retry/timeout policy.",
+    "The fixed-capacity Host fake covers send and receive paths, all five frame kinds, malformed input, bounded send failure and STOP-before-command arbitration without allocation.",
+    "Shared bridge logic runs unchanged on Host and QEMU; QEMU and physical target CAN transport remain explicitly NOT_EXECUTED.",
+    "The documentation records that frozen Wire V1 has no six-domain node address and forbids inventing a multi-node mapping without a separately approved versioned decision."
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-180-mcu-can-hal-boundary.json",
+    "make -C firmware/mcu host-test",
+    "make -C firmware/mcu codec-sanitize",
+    "make -C firmware/mcu qemu-test",
+    "make -C firmware/mcu verify-no-fp",
+    "make -C firmware/mcu size-check",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "Issue #180 Task Packet validation output and final changed-path audit.",
+    "Host shared bridge and fake-HAL assertion counts covering every Wire V1 kind, malformed envelopes and STOP priority.",
+    "ASan/UBSan output for the complete shared and Host fake MCU corpus.",
+    "QEMU shared bridge output together with its explicit CAN transport NOT_EXECUTED marker.",
+    "verify-no-fp and size-check output for the freestanding image.",
+    "Repository test, contract, scenario and context-check output.",
+    "Target evidence matrix and six-domain compatibility gate in docs/architecture/mcu-can-hal-boundary-v1.md."
+  ],
+  "stop_conditions": [
+    "The implementation requires changing frozen Wire V1 IDs, payload bytes, JSON Schema, Pydantic models or logical protocol semantics.",
+    "A six-domain mapping would require inventing an unapproved arbitration layout, node field or collision policy.",
+    "A real STM32 or legacy CH32 target would require unapproved pin, clock, transceiver, filter, IRQ, linker, startup or vendor-register data.",
+    "STOP would need to wait behind or consume the ordinary replay window.",
+    "The same platform-independent bridge and test source cannot compile unchanged for Host and QEMU.",
+    "Host/QEMU or fake evidence would be presented as physical controller, CAN bus, actuator, E-stop or hard-real-time proof.",
+    "The implementation requires modifying .gitignore or unrelated local changes."
+  ]
+}

--- a/firmware/mcu/Makefile
+++ b/firmware/mcu/Makefile
@@ -17,8 +17,8 @@ HOSTCC  ?= cc
 BUILD   := build
 CORE    := $(wildcard core/*.c)
 SHARED_TESTS := tests/state_machine_tests.c tests/frame_codec_tests.c tests/watchdog_tests.c \
-                tests/command_dedup_tests.c
-HOST_TESTS := $(SHARED_TESTS) tests/main_host.c
+                tests/command_dedup_tests.c tests/can_bridge_tests.c
+HOST_TESTS := $(SHARED_TESTS) tests/can_bridge_host_tests.c tests/main_host.c
 
 # rv32imac: no FPU. -mabi=ilp32 (not ilp32f/d) so a stray double is a link error
 # rather than silently pulling in soft-float.
@@ -34,7 +34,8 @@ HOSTSANFLAGS := $(HOSTFLAGS) -fsanitize=address,undefined -fno-omit-frame-pointe
 MAX_TEXT := 32768
 MAX_BSS  := 8192
 
-.PHONY: all host host-sanitize qemu board test-host test-host-sanitize test-qemu size-check verify-no-fp clean
+.PHONY: all host host-sanitize qemu board test-host test-host-sanitize test-qemu \
+        host-test codec-sanitize qemu-test size-check verify-no-fp clean
 
 all: host qemu
 
@@ -59,6 +60,10 @@ test-host-sanitize: host-sanitize
 	 UBSAN_OPTIONS=halt_on_error=1 \
 	 $(BUILD)/host/test-runner-sanitize
 
+# Issue-facing aliases retained alongside the established target names.
+host-test: test-host
+codec-sanitize: test-host-sanitize
+
 # ---------------------------------------------------------------- qemu target
 qemu: $(BUILD)/qemu/mcu.elf
 
@@ -82,6 +87,8 @@ test-qemu: qemu
 	@qemu-system-riscv32 -machine virt -nographic -bios none \
 	  -kernel $(BUILD)/qemu/mcu.elf \
 	  -no-reboot -semihosting-config enable=on,target=native
+
+qemu-test: test-qemu
 
 # --------------------------------------------------------------- board target
 board: $(BUILD)/board/mcu.elf

--- a/firmware/mcu/README.md
+++ b/firmware/mcu/README.md
@@ -7,7 +7,7 @@ Decision and rationale: `docs/decisions/ADR-0003-mcu-riscv-qemu.md`.
 
 ```
 core/           platform-independent C. State machine, frame codec,
-                watchdog timing, dedup, ring buffers.
+                HAL/Wire bridge, watchdog timing, dedup, ring buffers.
                 No peripheral registers. No vendor headers.
 hal/qemu/       QEMU target, CTU CAN FD over PCI. Used by CI.
 hal/ch32v307/   real board, CH32V307 CAN peripheral. P3.
@@ -46,6 +46,7 @@ QEMU models SJA1000 and CTU CAN FD, not the CH32V307 CAN peripheral.
 | Watchdog timing under a real timer interrupt | Bit timing (BRP/TSEG1/TSEG2/SJW) |
 | Dedup across sequence wraparound | Error frames, bus-off recovery |
 | Frame codec, ID partition enforcement | Electrical behaviour, EMI |
+| Raw-envelope rejection and STOP-first bridge logic | Controller FIFO/IRQ and wire arbitration |
 | Absence of malloc and FP instructions | Brownout, power-on reset |
 
 ## Build
@@ -67,8 +68,24 @@ Issue #54 adds the strict Classic CAN Wire V1 codec and shared Host/QEMU golden
 vectors. Issue #60 adds the allocation-free heartbeat watchdog, bounded STOP
 acknowledgement timing, fake-clock tests and QEMU machine-timer/watchdog
 evidence. Issue #61 adds the fixed-memory ordinary-command replay window,
-trusted startup-session gate and shared Host/QEMU wraparound corpus. The HAL CAN
-driver and physical CAN validation remain separate follow-up tasks.
+trusted startup-session gate and shared Host/QEMU wraparound corpus. Issue #180
+adds the strict raw HAL/Wire V1 bridge and bounded Host fake CAN transport. The
+QEMU and physical target CAN drivers, six-domain arbitration and physical CAN
+validation remain separate owner-gated follow-up work and are `NOT_EXECUTED`.
+
+## CAN HAL/Wire boundary
+
+`core/can_bridge.[ch]` is the only raw-envelope mapping. The HAL exposes an
+11-bit `arbitration_id`, DLC, explicit extended/RTR/error/FD flags and eight
+data bytes. The logical 16-bit `command_id` remains in Wire V1 payload bytes
+1..2. Only a flag-free, DLC-8 standard frame with a known Wire V1 ID can be
+decoded; malformed or wrong-direction traffic produces no state-machine event.
+
+MCU ingress checks STOP before ordinary command routing. A valid STOP bypasses
+the ordinary startup-session gate and dedup window, and its ACK is confirmed
+only after `hal_can_send()` accepts the transport handoff. The complete
+contract, fake evidence and physical/multi-node limits are documented in
+`docs/architecture/mcu-can-hal-boundary-v1.md`.
 
 ## Timing safety path
 

--- a/firmware/mcu/core/can_bridge.c
+++ b/firmware/mcu/core/can_bridge.c
@@ -1,0 +1,316 @@
+#include "can_bridge.h"
+
+_Static_assert(HAL_CAN_CLASSIC_DLC_MAX == MCU_WIRE_DLC,
+               "HAL Classic CAN payload must match Wire V1 DLC");
+_Static_assert(MCU_CAN_ID_TELEMETRY <= HAL_CAN_STANDARD_ID_MAX,
+               "Wire V1 identifiers must fit the standard CAN envelope");
+
+static void clear_wire_frame(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_COMMAND;
+    frame->command_id = 0u;
+    frame->sequence_no = 0u;
+    frame->opcode = MCU_WIRE_OPCODE_RESERVED;
+    frame->retry_count = 0u;
+    frame->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    frame->fault_code = MCU_WIRE_FAULT_NONE;
+    frame->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void copy_wire_frame(mcu_wire_frame_t *destination,
+                            const mcu_wire_frame_t *source)
+{
+    destination->kind = source->kind;
+    destination->command_id = source->command_id;
+    destination->sequence_no = source->sequence_no;
+    destination->opcode = source->opcode;
+    destination->retry_count = source->retry_count;
+    destination->result_code = source->result_code;
+    destination->fault_code = source->fault_code;
+    destination->device_mode = source->device_mode;
+}
+
+static void copy_hal_frame(hal_can_frame *destination,
+                           const hal_can_frame *source)
+{
+    unsigned i;
+
+    destination->arbitration_id = source->arbitration_id;
+    destination->dlc = source->dlc;
+    destination->flags = source->flags;
+    for (i = 0u; i < HAL_CAN_CLASSIC_DLC_MAX; i++) {
+        destination->data[i] = source->data[i];
+    }
+}
+
+static void clear_record(mcu_can_bridge_record_t *record)
+{
+    record->outcome = MCU_CAN_BRIDGE_OUTCOME_NONE;
+    record->status = MCU_CAN_BRIDGE_OK;
+    record->request_decoded = false;
+    record->ordinary_event_dispatched = false;
+    record->stop_path_entered = false;
+    record->response_available = false;
+    record->response_handed_off = false;
+    clear_wire_frame(&record->request);
+    clear_wire_frame(&record->response);
+}
+
+static void copy_record(mcu_can_bridge_record_t *destination,
+                        const mcu_can_bridge_record_t *source)
+{
+    destination->outcome = source->outcome;
+    destination->status = source->status;
+    destination->request_decoded = source->request_decoded;
+    destination->ordinary_event_dispatched = source->ordinary_event_dispatched;
+    destination->stop_path_entered = source->stop_path_entered;
+    destination->response_available = source->response_available;
+    destination->response_handed_off = source->response_handed_off;
+    copy_wire_frame(&destination->request, &source->request);
+    copy_wire_frame(&destination->response, &source->response);
+}
+
+static mcu_can_bridge_status_t map_codec_status(mcu_codec_status_t status)
+{
+    switch (status) {
+    case MCU_CODEC_OK:
+        return MCU_CAN_BRIDGE_OK;
+    case MCU_CODEC_INVALID_ARGUMENT:
+        return MCU_CAN_BRIDGE_INVALID_ARGUMENT;
+    case MCU_CODEC_INVALID_LENGTH:
+        return MCU_CAN_BRIDGE_INVALID_DLC;
+    case MCU_CODEC_UNSUPPORTED_ID:
+        return MCU_CAN_BRIDGE_UNSUPPORTED_ID;
+    case MCU_CODEC_INVALID_VERSION:
+        return MCU_CAN_BRIDGE_INVALID_VERSION;
+    case MCU_CODEC_NONZERO_RESERVED:
+        return MCU_CAN_BRIDGE_NONZERO_RESERVED;
+    case MCU_CODEC_INVALID_FIELD:
+        return MCU_CAN_BRIDGE_INVALID_WIRE_FIELD;
+    case MCU_CODEC_BUFFER_TOO_SMALL:
+    default:
+        return MCU_CAN_BRIDGE_CORE_REJECTED;
+    }
+}
+
+mcu_can_bridge_status_t mcu_can_bridge_encode(const mcu_wire_frame_t *frame,
+                                              hal_can_frame *encoded)
+{
+    hal_can_frame local;
+    uint8_t encoded_length = 0u;
+    mcu_codec_status_t codec_status;
+
+    if (frame == 0 || encoded == 0) {
+        return MCU_CAN_BRIDGE_INVALID_ARGUMENT;
+    }
+
+    local.arbitration_id = 0u;
+    local.dlc = 0u;
+    local.flags = (uint8_t)HAL_CAN_FRAME_FLAG_NONE;
+    codec_status = mcu_frame_encode(frame,
+                                    &local.arbitration_id,
+                                    local.data,
+                                    sizeof(local.data),
+                                    &encoded_length);
+    if (codec_status != MCU_CODEC_OK) {
+        return map_codec_status(codec_status);
+    }
+    if (local.arbitration_id > HAL_CAN_STANDARD_ID_MAX) {
+        return MCU_CAN_BRIDGE_INVALID_ARBITRATION_ID;
+    }
+    if (encoded_length != MCU_WIRE_DLC || encoded_length > HAL_CAN_CLASSIC_DLC_MAX) {
+        return MCU_CAN_BRIDGE_CORE_REJECTED;
+    }
+
+    local.dlc = encoded_length;
+    copy_hal_frame(encoded, &local);
+    return MCU_CAN_BRIDGE_OK;
+}
+
+mcu_can_bridge_status_t mcu_can_bridge_decode(const hal_can_frame *encoded,
+                                              mcu_wire_frame_t *frame)
+{
+    mcu_wire_frame_t decoded;
+    mcu_codec_status_t codec_status;
+
+    if (encoded == 0 || frame == 0) {
+        return MCU_CAN_BRIDGE_INVALID_ARGUMENT;
+    }
+    if (encoded->flags != (uint8_t)HAL_CAN_FRAME_FLAG_NONE) {
+        return MCU_CAN_BRIDGE_INVALID_FLAGS;
+    }
+    if (encoded->arbitration_id > HAL_CAN_STANDARD_ID_MAX) {
+        return MCU_CAN_BRIDGE_INVALID_ARBITRATION_ID;
+    }
+    if (encoded->dlc != MCU_WIRE_DLC) {
+        return MCU_CAN_BRIDGE_INVALID_DLC;
+    }
+
+    codec_status = mcu_frame_decode(encoded->arbitration_id,
+                                    encoded->data,
+                                    encoded->dlc,
+                                    &decoded);
+    if (codec_status != MCU_CODEC_OK) {
+        return map_codec_status(codec_status);
+    }
+
+    copy_wire_frame(frame, &decoded);
+    return MCU_CAN_BRIDGE_OK;
+}
+
+mcu_can_bridge_status_t mcu_can_bridge_send(const mcu_wire_frame_t *frame)
+{
+    hal_can_frame encoded;
+    mcu_can_bridge_status_t status = mcu_can_bridge_encode(frame, &encoded);
+
+    if (status != MCU_CAN_BRIDGE_OK) {
+        return status;
+    }
+    return hal_can_send(&encoded) ? MCU_CAN_BRIDGE_OK
+                                  : MCU_CAN_BRIDGE_HAL_SEND_FAILED;
+}
+
+static bool safety_dependencies_are_valid(const mcu_state_machine_t *machine,
+                                          const mcu_watchdog_t *watchdog)
+{
+    return mcu_sm_is_valid(machine) && mcu_watchdog_is_valid(watchdog);
+}
+
+bool mcu_can_bridge_process_frame(mcu_command_dedup_t *dedup,
+                                  mcu_state_machine_t *machine,
+                                  mcu_watchdog_t *watchdog,
+                                  const hal_can_frame *encoded,
+                                  uint64_t now_us,
+                                  mcu_can_bridge_record_t *record)
+{
+    mcu_can_bridge_record_t local;
+    mcu_can_bridge_status_t status;
+
+    if (machine == 0 || watchdog == 0 || encoded == 0 || record == 0 ||
+        !safety_dependencies_are_valid(machine, watchdog)) {
+        return false;
+    }
+
+    clear_record(&local);
+    status = mcu_can_bridge_decode(encoded, &local.request);
+    if (status != MCU_CAN_BRIDGE_OK) {
+        local.outcome = MCU_CAN_BRIDGE_OUTCOME_REJECTED;
+        local.status = status;
+        copy_record(record, &local);
+        return true;
+    }
+    local.request_decoded = true;
+
+    /* STOP is deliberately tested before the ordinary path. It bypasses the
+     * session gate and replay window and is never converted into a command. */
+    if (local.request.kind == MCU_WIRE_FRAME_STOP) {
+        mcu_watchdog_record_t stop_record;
+
+        local.stop_path_entered = true;
+        if (!mcu_watchdog_receive_stop(watchdog,
+                                       machine,
+                                       &local.request,
+                                       now_us,
+                                       &stop_record)) {
+            local.outcome = MCU_CAN_BRIDGE_OUTCOME_REJECTED;
+            local.status = MCU_CAN_BRIDGE_CORE_REJECTED;
+            copy_record(record, &local);
+            return true;
+        }
+        local.outcome = MCU_CAN_BRIDGE_OUTCOME_STOP_HANDLED;
+        local.response_available = true;
+        copy_wire_frame(&local.response, &stop_record.frame);
+        copy_record(record, &local);
+        return true;
+    }
+
+    if (local.request.kind == MCU_WIRE_FRAME_COMMAND) {
+        mcu_command_record_t command_record;
+
+        if (dedup == 0 || !mcu_command_dedup_is_valid(dedup) ||
+            !mcu_command_dedup_receive(dedup,
+                                       machine,
+                                       watchdog,
+                                       &local.request,
+                                       now_us,
+                                       &command_record)) {
+            local.outcome = MCU_CAN_BRIDGE_OUTCOME_REJECTED;
+            local.status = MCU_CAN_BRIDGE_CORE_REJECTED;
+            copy_record(record, &local);
+            return true;
+        }
+        local.ordinary_event_dispatched = command_record.ordinary_event_dispatched;
+        if (!command_record.ack_available) {
+            local.outcome = MCU_CAN_BRIDGE_OUTCOME_SESSION_CLOSED;
+            copy_record(record, &local);
+            return true;
+        }
+        local.outcome = MCU_CAN_BRIDGE_OUTCOME_COMMAND_HANDLED;
+        local.response_available = true;
+        copy_wire_frame(&local.response, &command_record.ack);
+        copy_record(record, &local);
+        return true;
+    }
+
+    /* ACK, STOP_ACK and telemetry are MCU-originated under Wire V1. A frame
+     * with one of those IDs on the MCU ingress is validly encoded but has the
+     * wrong direction and must not reach safety state. */
+    local.outcome = MCU_CAN_BRIDGE_OUTCOME_REJECTED;
+    local.status = MCU_CAN_BRIDGE_UNEXPECTED_DIRECTION;
+    copy_record(record, &local);
+    return true;
+}
+
+bool mcu_can_bridge_poll(mcu_command_dedup_t *dedup,
+                         mcu_state_machine_t *machine,
+                         mcu_watchdog_t *watchdog,
+                         uint64_t now_us,
+                         mcu_can_bridge_record_t *record)
+{
+    hal_can_frame encoded;
+    mcu_can_bridge_record_t local;
+    mcu_can_bridge_status_t send_status;
+
+    if (machine == 0 || watchdog == 0 || record == 0 ||
+        !safety_dependencies_are_valid(machine, watchdog)) {
+        return false;
+    }
+    if (!hal_can_recv(&encoded)) {
+        clear_record(&local);
+        local.outcome = MCU_CAN_BRIDGE_OUTCOME_NO_FRAME;
+        local.status = MCU_CAN_BRIDGE_NO_FRAME;
+        copy_record(record, &local);
+        return true;
+    }
+    if (!mcu_can_bridge_process_frame(dedup,
+                                      machine,
+                                      watchdog,
+                                      &encoded,
+                                      now_us,
+                                      &local)) {
+        return false;
+    }
+    if (!local.response_available) {
+        copy_record(record, &local);
+        return true;
+    }
+
+    send_status = mcu_can_bridge_send(&local.response);
+    if (send_status != MCU_CAN_BRIDGE_OK) {
+        local.status = send_status;
+        copy_record(record, &local);
+        return true;
+    }
+    local.response_handed_off = true;
+
+    if (local.response.kind == MCU_WIRE_FRAME_STOP_ACK &&
+        local.response.result_code == MCU_WIRE_RESULT_ACCEPTED &&
+        !mcu_watchdog_confirm_stop_ack(watchdog,
+                                       local.response.command_id,
+                                       local.response.retry_count,
+                                       now_us)) {
+        local.status = MCU_CAN_BRIDGE_CORE_REJECTED;
+    }
+    copy_record(record, &local);
+    return true;
+}

--- a/firmware/mcu/core/can_bridge.h
+++ b/firmware/mcu/core/can_bridge.h
@@ -1,0 +1,88 @@
+#ifndef MCU_CAN_BRIDGE_H
+#define MCU_CAN_BRIDGE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "command_dedup.h"
+#include "frame_codec.h"
+#include "hal.h"
+#include "state_machine.h"
+#include "watchdog.h"
+
+/* Exact diagnostics for the boundary at which an input was rejected.  A
+ * rejected raw or Wire V1 frame never reaches the safety state machine. */
+typedef enum {
+    MCU_CAN_BRIDGE_OK = 0,
+    MCU_CAN_BRIDGE_NO_FRAME,
+    MCU_CAN_BRIDGE_INVALID_ARGUMENT,
+    MCU_CAN_BRIDGE_INVALID_FLAGS,
+    MCU_CAN_BRIDGE_INVALID_ARBITRATION_ID,
+    MCU_CAN_BRIDGE_INVALID_DLC,
+    MCU_CAN_BRIDGE_UNSUPPORTED_ID,
+    MCU_CAN_BRIDGE_INVALID_VERSION,
+    MCU_CAN_BRIDGE_NONZERO_RESERVED,
+    MCU_CAN_BRIDGE_INVALID_WIRE_FIELD,
+    MCU_CAN_BRIDGE_UNEXPECTED_DIRECTION,
+    MCU_CAN_BRIDGE_CORE_REJECTED,
+    MCU_CAN_BRIDGE_HAL_SEND_FAILED,
+    MCU_CAN_BRIDGE_STATUS_COUNT
+} mcu_can_bridge_status_t;
+
+typedef enum {
+    MCU_CAN_BRIDGE_OUTCOME_NONE = 0,
+    MCU_CAN_BRIDGE_OUTCOME_NO_FRAME,
+    MCU_CAN_BRIDGE_OUTCOME_REJECTED,
+    MCU_CAN_BRIDGE_OUTCOME_SESSION_CLOSED,
+    MCU_CAN_BRIDGE_OUTCOME_COMMAND_HANDLED,
+    MCU_CAN_BRIDGE_OUTCOME_STOP_HANDLED,
+    MCU_CAN_BRIDGE_OUTCOME_COUNT
+} mcu_can_bridge_outcome_t;
+
+typedef struct {
+    mcu_can_bridge_outcome_t outcome;
+    mcu_can_bridge_status_t status;
+    bool request_decoded;
+    bool ordinary_event_dispatched;
+    bool stop_path_entered;
+    bool response_available;
+    bool response_handed_off;
+    mcu_wire_frame_t request;
+    mcu_wire_frame_t response;
+} mcu_can_bridge_record_t;
+
+/* These conversion functions are the only mapping between the raw HAL
+ * envelope and Wire V1. Outputs remain untouched when conversion fails. */
+mcu_can_bridge_status_t mcu_can_bridge_encode(const mcu_wire_frame_t *frame,
+                                              hal_can_frame *encoded);
+mcu_can_bridge_status_t mcu_can_bridge_decode(const hal_can_frame *encoded,
+                                              mcu_wire_frame_t *frame);
+
+/* Encode one complete Wire V1 frame and hand it to the target HAL. A true HAL
+ * return means transport handoff only, not bus delivery or actuator proof. */
+mcu_can_bridge_status_t mcu_can_bridge_send(const mcu_wire_frame_t *frame);
+
+/* Process one already-received raw envelope without calling hal_can_send().
+ * This is shared by Host/QEMU logic tests. dedup may be null or corrupt for a
+ * STOP because the safety path is independent; an ordinary command then
+ * fails closed. If an accepted STOP response is returned, the caller still
+ * owns transport handoff confirmation. */
+bool mcu_can_bridge_process_frame(mcu_command_dedup_t *dedup,
+                                  mcu_state_machine_t *machine,
+                                  mcu_watchdog_t *watchdog,
+                                  const hal_can_frame *encoded,
+                                  uint64_t now_us,
+                                  mcu_can_bridge_record_t *record);
+
+/* Consume at most one frame from the non-blocking HAL, route STOP directly to
+ * the watchdog path before ordinary-command handling, and send any response.
+ * Successful handoff of an accepted STOP_ACK confirms its bounded core slot.
+ * The owning target must serialize calls and configure controller/FIFO
+ * priority; this function does not hide an unbounded receive queue. */
+bool mcu_can_bridge_poll(mcu_command_dedup_t *dedup,
+                         mcu_state_machine_t *machine,
+                         mcu_watchdog_t *watchdog,
+                         uint64_t now_us,
+                         mcu_can_bridge_record_t *record);
+
+#endif /* MCU_CAN_BRIDGE_H */

--- a/firmware/mcu/core/hal.h
+++ b/firmware/mcu/core/hal.h
@@ -43,15 +43,33 @@ void hal_timer_disarm(void);
 void hal_timer_enable(void);
 
 /* ----------------------------------------------------------------------- CAN
- * Frame as it goes on the wire. Matches mcu_protocol.schema.json.
+ * Raw controller envelope, before Wire V1 decoding.  The arbitration ID is
+ * the standard 11-bit CAN identifier; it is not the logical 16-bit command
+ * ID stored in payload bytes 1..2.  Keeping those names distinct prevents a
+ * STOP command_id (>= 0x8000) from being written into an 11-bit controller
+ * register.
  *
- * QEMU gives us CTU CAN FD over PCI; the board gives us the CH32V307
- * peripheral. Neither detail appears above this line.
+ * flags is deliberately a byte rather than C bit-fields so every target maps
+ * controller metadata explicitly.  Wire V1 accepts only flags == NONE,
+ * DLC == 8 and arbitration_id <= 0x7ff.  The bridge rejects all other
+ * envelopes before decoding or safety-state mutation.
  */
+#define HAL_CAN_STANDARD_ID_MAX 0x07ffu
+#define HAL_CAN_CLASSIC_DLC_MAX 8u
+
+typedef enum {
+    HAL_CAN_FRAME_FLAG_NONE = 0u,
+    HAL_CAN_FRAME_FLAG_EXTENDED_ID = 1u << 0,
+    HAL_CAN_FRAME_FLAG_REMOTE = 1u << 1,
+    HAL_CAN_FRAME_FLAG_ERROR = 1u << 2,
+    HAL_CAN_FRAME_FLAG_FD = 1u << 3
+} hal_can_frame_flag_t;
+
 typedef struct {
-    uint16_t id;        /* <=32767 command, >=32768 stop. Enforced in FW4. */
-    uint8_t  len;       /* 0..8 */
-    uint8_t  data[8];
+    uint16_t arbitration_id;
+    uint8_t dlc;
+    uint8_t flags;
+    uint8_t data[HAL_CAN_CLASSIC_DLC_MAX];
 } hal_can_frame;
 
 bool hal_can_init(void);

--- a/firmware/mcu/hal/host/hal_host.c
+++ b/firmware/mcu/hal/host/hal_host.c
@@ -1,4 +1,5 @@
 #include "hal.h"
+#include "hal_host_test.h"
 
 #include <stdio.h>
 
@@ -8,6 +9,24 @@ static uint32_t host_wdt_timeout_ms;
 static uint64_t host_wdt_deadline_us;
 static uint32_t host_wdt_feeds;
 static bool host_wdt_running;
+static bool host_can_initialized;
+static hal_can_frame host_can_rx[HAL_HOST_CAN_QUEUE_CAPACITY];
+static hal_can_frame host_can_tx[HAL_HOST_CAN_QUEUE_CAPACITY];
+static uint8_t host_can_rx_count;
+static uint8_t host_can_tx_count;
+
+static void copy_can_frame(hal_can_frame *destination,
+                           const hal_can_frame *source)
+{
+    unsigned i;
+
+    destination->arbitration_id = source->arbitration_id;
+    destination->dlc = source->dlc;
+    destination->flags = source->flags;
+    for (i = 0u; i < HAL_CAN_CLASSIC_DLC_MAX; i++) {
+        destination->data[i] = source->data[i];
+    }
+}
 
 static bool host_deadline_reached(uint64_t now_us, uint64_t deadline_us)
 {
@@ -63,19 +82,93 @@ void hal_timer_enable(void)
 
 bool hal_can_init(void)
 {
-    return false;
+    host_can_initialized = true;
+    host_can_rx_count = 0u;
+    host_can_tx_count = 0u;
+    return true;
 }
 
 bool hal_can_send(const hal_can_frame *frame)
 {
-    (void)frame;
-    return false;
+    if (!host_can_initialized || frame == 0 ||
+        host_can_tx_count >= HAL_HOST_CAN_QUEUE_CAPACITY) {
+        return false;
+    }
+
+    copy_can_frame(&host_can_tx[host_can_tx_count], frame);
+    host_can_tx_count++;
+    return true;
 }
 
 bool hal_can_recv(hal_can_frame *frame)
 {
-    (void)frame;
-    return false;
+    uint8_t selected = 0u;
+    uint8_t index;
+
+    if (!host_can_initialized || frame == 0 || host_can_rx_count == 0u) {
+        return false;
+    }
+
+    /* The fake models a set of frames that completed arbitration before the
+     * receiver polls. Lower standard IDs win; equal IDs retain insertion
+     * order. This is deterministic logic evidence, not physical bus timing. */
+    for (index = 1u; index < host_can_rx_count; index++) {
+        if (host_can_rx[index].arbitration_id <
+            host_can_rx[selected].arbitration_id) {
+            selected = index;
+        }
+    }
+    copy_can_frame(frame, &host_can_rx[selected]);
+    for (index = selected; index + 1u < host_can_rx_count; index++) {
+        copy_can_frame(&host_can_rx[index], &host_can_rx[index + 1u]);
+    }
+    host_can_rx_count--;
+    return true;
+}
+
+void hal_host_can_reset(void)
+{
+    host_can_initialized = false;
+    host_can_rx_count = 0u;
+    host_can_tx_count = 0u;
+}
+
+bool hal_host_can_inject_rx(const hal_can_frame *frame)
+{
+    if (!host_can_initialized || frame == 0 ||
+        host_can_rx_count >= HAL_HOST_CAN_QUEUE_CAPACITY) {
+        return false;
+    }
+
+    copy_can_frame(&host_can_rx[host_can_rx_count], frame);
+    host_can_rx_count++;
+    return true;
+}
+
+bool hal_host_can_take_tx(hal_can_frame *frame)
+{
+    uint8_t index;
+
+    if (!host_can_initialized || frame == 0 || host_can_tx_count == 0u) {
+        return false;
+    }
+
+    copy_can_frame(frame, &host_can_tx[0]);
+    for (index = 0u; index + 1u < host_can_tx_count; index++) {
+        copy_can_frame(&host_can_tx[index], &host_can_tx[index + 1u]);
+    }
+    host_can_tx_count--;
+    return true;
+}
+
+uint8_t hal_host_can_rx_count(void)
+{
+    return host_can_rx_count;
+}
+
+uint8_t hal_host_can_tx_count(void)
+{
+    return host_can_tx_count;
 }
 
 void hal_wdt_start(uint32_t timeout_ms)

--- a/firmware/mcu/hal/host/hal_host_test.h
+++ b/firmware/mcu/hal/host/hal_host_test.h
@@ -1,0 +1,20 @@
+#ifndef MCU_HAL_HOST_TEST_H
+#define MCU_HAL_HOST_TEST_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "hal.h"
+
+/* Fixed test-only queues for the x86_64 fake HAL. They model bounded
+ * transport handoff and deterministic arbitration; they are not a board CAN
+ * driver or evidence of physical delivery. */
+#define HAL_HOST_CAN_QUEUE_CAPACITY 16u
+
+void hal_host_can_reset(void);
+bool hal_host_can_inject_rx(const hal_can_frame *frame);
+bool hal_host_can_take_tx(hal_can_frame *frame);
+uint8_t hal_host_can_rx_count(void);
+uint8_t hal_host_can_tx_count(void);
+
+#endif /* MCU_HAL_HOST_TEST_H */

--- a/firmware/mcu/hal/qemu/main_qemu.c
+++ b/firmware/mcu/hal/qemu/main_qemu.c
@@ -16,6 +16,7 @@
  *   - mtime advances, so FW5's watchdog has a clock to trust
  */
 #include "hal.h"
+#include "can_bridge_tests.h"
 #include "command_dedup_tests.h"
 #include "frame_codec_tests.h"
 #include "state_machine_tests.h"
@@ -186,6 +187,21 @@ static int run_command_dedup_tests(void)
     return report.failures == 0u ? 0 : 10;
 }
 
+static int run_can_bridge_tests(void)
+{
+    mcu_test_report_t report;
+
+    mcu_can_bridge_run_tests(&report);
+    hal_puts("[mcu] can-bridge assertions=");
+    hal_put_u32(report.assertions);
+    hal_puts(" failures=");
+    hal_put_u32(report.failures);
+    hal_puts(" first_failure=");
+    hal_put_u32(report.first_failure);
+    hal_putc('\n');
+    return report.failures == 0u ? 0 : 11;
+}
+
 static int run_qemu_timing_evidence(void)
 {
     mcu_event_t begin_move;
@@ -259,11 +275,13 @@ int main(void)
     rc |= run_frame_codec_tests();
     rc |= run_watchdog_tests();
     rc |= run_command_dedup_tests();
+    rc |= run_can_bridge_tests();
     rc |= run_qemu_timing_evidence();
 
-    /* CAN is deliberately not checked: hal_can_init returns false until FW10,
-     * and a smoke test that skipped over that would be misleading. */
-    hal_puts("[mcu] skip CAN - hal_can_init is a stub until FW10\n");
+    /* The platform-independent HAL/Wire boundary is covered above. QEMU CAN
+     * transport remains explicit NOT_EXECUTED because these HAL functions are
+     * still false-returning stubs. */
+    hal_puts("[mcu] CAN transport NOT_EXECUTED - QEMU HAL is a stub\n");
 
     return rc;
 }

--- a/firmware/mcu/tests/can_bridge_host_tests.c
+++ b/firmware/mcu/tests/can_bridge_host_tests.c
@@ -1,0 +1,253 @@
+#include "can_bridge_host_tests.h"
+
+#include <stdbool.h>
+
+#include "can_bridge.h"
+#include "hal_host_test.h"
+
+static void check(mcu_test_report_t *report, bool condition)
+{
+    report->assertions++;
+    if (!condition) {
+        report->failures++;
+        if (report->first_failure == 0u) {
+            report->first_failure = report->assertions;
+        }
+    }
+}
+
+static void clear_wire_frame(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_COMMAND;
+    frame->command_id = 0u;
+    frame->sequence_no = 0u;
+    frame->opcode = MCU_WIRE_OPCODE_RESERVED;
+    frame->retry_count = 0u;
+    frame->result_code = MCU_WIRE_RESULT_ACCEPTED;
+    frame->fault_code = MCU_WIRE_FAULT_NONE;
+    frame->device_mode = MCU_WIRE_MODE_IDLE;
+}
+
+static void make_frame(mcu_wire_frame_kind_t kind, mcu_wire_frame_t *frame)
+{
+    clear_wire_frame(frame);
+    frame->kind = kind;
+    switch (kind) {
+    case MCU_WIRE_FRAME_COMMAND:
+        frame->command_id = 7u;
+        frame->opcode = MCU_WIRE_OPCODE_MOVE;
+        break;
+    case MCU_WIRE_FRAME_ACK:
+        frame->command_id = 7u;
+        frame->opcode = MCU_WIRE_OPCODE_MOVE;
+        frame->device_mode = MCU_WIRE_MODE_MOVING;
+        break;
+    case MCU_WIRE_FRAME_TELEMETRY:
+        frame->sequence_no = 11u;
+        break;
+    case MCU_WIRE_FRAME_STOP:
+        frame->command_id = MCU_STOP_ID_MIN;
+        frame->opcode = MCU_WIRE_OPCODE_STOP;
+        break;
+    case MCU_WIRE_FRAME_STOP_ACK:
+        frame->command_id = MCU_STOP_ID_MIN;
+        frame->opcode = MCU_WIRE_OPCODE_STOP;
+        frame->device_mode = MCU_WIRE_MODE_STOPPED;
+        break;
+    case MCU_WIRE_FRAME_KIND_COUNT:
+    default:
+        break;
+    }
+}
+
+static bool wire_frames_equal(const mcu_wire_frame_t *left,
+                              const mcu_wire_frame_t *right)
+{
+    return left->kind == right->kind && left->command_id == right->command_id &&
+           left->sequence_no == right->sequence_no && left->opcode == right->opcode &&
+           left->retry_count == right->retry_count && left->result_code == right->result_code &&
+           left->fault_code == right->fault_code && left->device_mode == right->device_mode;
+}
+
+static void initialize_core(mcu_command_dedup_t *dedup,
+                            mcu_state_machine_t *machine,
+                            mcu_watchdog_t *watchdog)
+{
+    mcu_command_dedup_init(dedup);
+    mcu_sm_init(machine);
+    mcu_watchdog_init(watchdog, 1u);
+}
+
+static void test_fake_hal_sends_all_wire_kinds(mcu_test_report_t *report)
+{
+    unsigned kind;
+
+    hal_host_can_reset();
+    check(report, hal_can_init());
+    for (kind = 0u; kind < MCU_WIRE_FRAME_KIND_COUNT; kind++) {
+        mcu_wire_frame_t original;
+        mcu_wire_frame_t decoded;
+        hal_can_frame encoded;
+
+        make_frame((mcu_wire_frame_kind_t)kind, &original);
+        check(report, mcu_can_bridge_send(&original) == MCU_CAN_BRIDGE_OK);
+        check(report, hal_host_can_tx_count() == 1u);
+        check(report, hal_host_can_take_tx(&encoded));
+        check(report, mcu_can_bridge_decode(&encoded, &decoded) == MCU_CAN_BRIDGE_OK);
+        check(report, wire_frames_equal(&original, &decoded));
+        check(report, hal_host_can_tx_count() == 0u);
+    }
+}
+
+static void test_poll_no_frame_and_malformed_input(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_can_bridge_record_t record;
+    mcu_wire_frame_t command;
+    hal_can_frame encoded;
+
+    hal_host_can_reset();
+    check(report, hal_can_init());
+    initialize_core(&dedup, &machine, &watchdog);
+    check(report, mcu_command_dedup_open_session(&dedup, true));
+    check(report, mcu_can_bridge_poll(&dedup, &machine, &watchdog, 10u, &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_NO_FRAME);
+    check(report, record.status == MCU_CAN_BRIDGE_NO_FRAME);
+
+    make_frame(MCU_WIRE_FRAME_COMMAND, &command);
+    check(report, mcu_can_bridge_encode(&command, &encoded) == MCU_CAN_BRIDGE_OK);
+    encoded.flags = (uint8_t)HAL_CAN_FRAME_FLAG_REMOTE;
+    check(report, hal_host_can_inject_rx(&encoded));
+    check(report, mcu_can_bridge_poll(&dedup, &machine, &watchdog, 11u, &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_REJECTED);
+    check(report, record.status == MCU_CAN_BRIDGE_INVALID_FLAGS);
+    check(report, !record.request_decoded);
+    check(report, !record.response_handed_off);
+    check(report, hal_host_can_tx_count() == 0u);
+    check(report, machine.state == MCU_STATE_IDLE);
+    check(report, !dedup.has_last_accepted);
+}
+
+static void test_fake_arbitration_routes_stop_first(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_can_bridge_record_t record;
+    mcu_wire_frame_t command;
+    mcu_wire_frame_t stop;
+    mcu_wire_frame_t decoded_response;
+    hal_can_frame command_encoded;
+    hal_can_frame stop_encoded;
+    hal_can_frame response_encoded;
+
+    hal_host_can_reset();
+    check(report, hal_can_init());
+    initialize_core(&dedup, &machine, &watchdog);
+    make_frame(MCU_WIRE_FRAME_COMMAND, &command);
+    make_frame(MCU_WIRE_FRAME_STOP, &stop);
+    check(report, mcu_can_bridge_encode(&command, &command_encoded) == MCU_CAN_BRIDGE_OK);
+    check(report, mcu_can_bridge_encode(&stop, &stop_encoded) == MCU_CAN_BRIDGE_OK);
+    check(report, command_encoded.arbitration_id > stop_encoded.arbitration_id);
+
+    /* Inject ordinary traffic first. Both are pending before poll, so the
+     * fake's deterministic arbitration must still expose STOP first. */
+    check(report, hal_host_can_inject_rx(&command_encoded));
+    check(report, hal_host_can_inject_rx(&stop_encoded));
+    check(report, hal_host_can_rx_count() == 2u);
+    check(report, mcu_can_bridge_poll(&dedup, &machine, &watchdog, 20u, &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_STOP_HANDLED);
+    check(report, record.stop_path_entered);
+    check(report, record.response_handed_off);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, !watchdog.stop_ack_pending);
+    check(report, hal_host_can_rx_count() == 1u);
+    check(report, hal_host_can_take_tx(&response_encoded));
+    check(report, response_encoded.arbitration_id == MCU_CAN_ID_STOP_ACK);
+    check(report, mcu_can_bridge_decode(&response_encoded, &decoded_response) == MCU_CAN_BRIDGE_OK);
+    check(report, decoded_response.kind == MCU_WIRE_FRAME_STOP_ACK);
+    check(report, decoded_response.command_id == stop.command_id);
+
+    /* Ordinary dispatch is still closed, so the queued command cannot undo
+     * the STOP or create a response after it is polled. */
+    check(report, mcu_can_bridge_poll(&dedup, &machine, &watchdog, 21u, &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_SESSION_CLOSED);
+    check(report, !record.ordinary_event_dispatched);
+    check(report, !record.response_available);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, hal_host_can_tx_count() == 0u);
+}
+
+static void test_poll_stop_ignores_corrupt_dedup(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_can_bridge_record_t record;
+    mcu_wire_frame_t stop;
+    hal_can_frame stop_encoded;
+
+    hal_host_can_reset();
+    check(report, hal_can_init());
+    initialize_core(&dedup, &machine, &watchdog);
+    dedup.initialized = 0u;
+    make_frame(MCU_WIRE_FRAME_STOP, &stop);
+    check(report, mcu_can_bridge_encode(&stop, &stop_encoded) == MCU_CAN_BRIDGE_OK);
+    check(report, hal_host_can_inject_rx(&stop_encoded));
+    check(report, mcu_can_bridge_poll(&dedup, &machine, &watchdog, 25u, &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_STOP_HANDLED);
+    check(report, record.response_handed_off);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+}
+
+static void test_failed_stop_handoff_remains_pending(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_can_bridge_record_t record;
+    mcu_wire_frame_t stop;
+    mcu_wire_frame_t telemetry;
+    hal_can_frame stop_encoded;
+    hal_can_frame filler;
+    unsigned index;
+
+    hal_host_can_reset();
+    check(report, hal_can_init());
+    initialize_core(&dedup, &machine, &watchdog);
+    make_frame(MCU_WIRE_FRAME_STOP, &stop);
+    make_frame(MCU_WIRE_FRAME_TELEMETRY, &telemetry);
+    check(report, mcu_can_bridge_encode(&stop, &stop_encoded) == MCU_CAN_BRIDGE_OK);
+    check(report, mcu_can_bridge_encode(&telemetry, &filler) == MCU_CAN_BRIDGE_OK);
+    for (index = 0u; index < HAL_HOST_CAN_QUEUE_CAPACITY; index++) {
+        check(report, hal_can_send(&filler));
+    }
+    check(report, hal_host_can_inject_rx(&stop_encoded));
+    check(report, mcu_can_bridge_poll(&dedup, &machine, &watchdog, 30u, &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_STOP_HANDLED);
+    check(report, record.status == MCU_CAN_BRIDGE_HAL_SEND_FAILED);
+    check(report, record.response_available);
+    check(report, !record.response_handed_off);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, watchdog.stop_ack_pending);
+    check(report, watchdog.stop_command_id == stop.command_id);
+}
+
+void mcu_can_bridge_host_run_tests(mcu_test_report_t *report)
+{
+    if (report == 0) {
+        return;
+    }
+
+    report->assertions = 0u;
+    report->failures = 0u;
+    report->first_failure = 0u;
+
+    test_fake_hal_sends_all_wire_kinds(report);
+    test_poll_no_frame_and_malformed_input(report);
+    test_fake_arbitration_routes_stop_first(report);
+    test_poll_stop_ignores_corrupt_dedup(report);
+    test_failed_stop_handoff_remains_pending(report);
+}

--- a/firmware/mcu/tests/can_bridge_host_tests.h
+++ b/firmware/mcu/tests/can_bridge_host_tests.h
@@ -1,0 +1,8 @@
+#ifndef MCU_CAN_BRIDGE_HOST_TESTS_H
+#define MCU_CAN_BRIDGE_HOST_TESTS_H
+
+#include "state_machine_tests.h"
+
+void mcu_can_bridge_host_run_tests(mcu_test_report_t *report);
+
+#endif /* MCU_CAN_BRIDGE_HOST_TESTS_H */

--- a/firmware/mcu/tests/can_bridge_tests.c
+++ b/firmware/mcu/tests/can_bridge_tests.c
@@ -1,0 +1,474 @@
+#include "can_bridge_tests.h"
+
+#include <stdbool.h>
+
+#include "can_bridge.h"
+
+typedef struct {
+    mcu_wire_frame_t frame;
+    uint16_t arbitration_id;
+} bridge_vector_t;
+
+static const bridge_vector_t bridge_vectors[] = {
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_COMMAND,
+            .command_id = 42u,
+            .opcode = MCU_WIRE_OPCODE_MOVE,
+            .retry_count = 2u,
+        },
+        .arbitration_id = MCU_CAN_ID_COMMAND,
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_ACK,
+            .command_id = 42u,
+            .opcode = MCU_WIRE_OPCODE_MOVE,
+            .retry_count = 2u,
+            .result_code = MCU_WIRE_RESULT_ACCEPTED,
+            .fault_code = MCU_WIRE_FAULT_NONE,
+            .device_mode = MCU_WIRE_MODE_MOVING,
+        },
+        .arbitration_id = MCU_CAN_ID_ACK,
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_TELEMETRY,
+            .sequence_no = 9u,
+            .fault_code = MCU_WIRE_FAULT_NONE,
+            .device_mode = MCU_WIRE_MODE_IDLE,
+        },
+        .arbitration_id = MCU_CAN_ID_TELEMETRY,
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_STOP,
+            .command_id = MCU_STOP_ID_MIN,
+            .opcode = MCU_WIRE_OPCODE_STOP,
+            .retry_count = 1u,
+        },
+        .arbitration_id = MCU_CAN_ID_STOP,
+    },
+    {
+        .frame = {
+            .kind = MCU_WIRE_FRAME_STOP_ACK,
+            .command_id = MCU_STOP_ID_MIN,
+            .opcode = MCU_WIRE_OPCODE_STOP,
+            .retry_count = 1u,
+            .result_code = MCU_WIRE_RESULT_ACCEPTED,
+            .fault_code = MCU_WIRE_FAULT_NONE,
+            .device_mode = MCU_WIRE_MODE_STOPPED,
+        },
+        .arbitration_id = MCU_CAN_ID_STOP_ACK,
+    },
+};
+
+static void check(mcu_test_report_t *report, bool condition)
+{
+    report->assertions++;
+    if (!condition) {
+        report->failures++;
+        if (report->first_failure == 0u) {
+            report->first_failure = report->assertions;
+        }
+    }
+}
+
+static void copy_wire_frame(mcu_wire_frame_t *destination,
+                            const mcu_wire_frame_t *source)
+{
+    destination->kind = source->kind;
+    destination->command_id = source->command_id;
+    destination->sequence_no = source->sequence_no;
+    destination->opcode = source->opcode;
+    destination->retry_count = source->retry_count;
+    destination->result_code = source->result_code;
+    destination->fault_code = source->fault_code;
+    destination->device_mode = source->device_mode;
+}
+
+static bool wire_frames_equal(const mcu_wire_frame_t *left,
+                              const mcu_wire_frame_t *right)
+{
+    return left->kind == right->kind && left->command_id == right->command_id &&
+           left->sequence_no == right->sequence_no && left->opcode == right->opcode &&
+           left->retry_count == right->retry_count && left->result_code == right->result_code &&
+           left->fault_code == right->fault_code && left->device_mode == right->device_mode;
+}
+
+static void copy_hal_frame(hal_can_frame *destination,
+                           const hal_can_frame *source)
+{
+    unsigned i;
+
+    destination->arbitration_id = source->arbitration_id;
+    destination->dlc = source->dlc;
+    destination->flags = source->flags;
+    for (i = 0u; i < HAL_CAN_CLASSIC_DLC_MAX; i++) {
+        destination->data[i] = source->data[i];
+    }
+}
+
+static bool hal_frames_equal(const hal_can_frame *left,
+                             const hal_can_frame *right)
+{
+    unsigned i;
+
+    if (left->arbitration_id != right->arbitration_id || left->dlc != right->dlc ||
+        left->flags != right->flags) {
+        return false;
+    }
+    for (i = 0u; i < HAL_CAN_CLASSIC_DLC_MAX; i++) {
+        if (left->data[i] != right->data[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void set_wire_sentinel(mcu_wire_frame_t *frame)
+{
+    frame->kind = MCU_WIRE_FRAME_KIND_COUNT;
+    frame->command_id = 0xa55au;
+    frame->sequence_no = 0x5aa55aa5u;
+    frame->opcode = MCU_WIRE_OPCODE_COUNT;
+    frame->retry_count = 0xa5u;
+    frame->result_code = MCU_WIRE_RESULT_COUNT;
+    frame->fault_code = MCU_WIRE_FAULT_COUNT;
+    frame->device_mode = MCU_WIRE_MODE_COUNT;
+}
+
+static void set_hal_sentinel(hal_can_frame *frame)
+{
+    unsigned i;
+
+    frame->arbitration_id = 0x0555u;
+    frame->dlc = 0xa5u;
+    frame->flags = 0x5au;
+    for (i = 0u; i < HAL_CAN_CLASSIC_DLC_MAX; i++) {
+        frame->data[i] = (uint8_t)(0xa0u + i);
+    }
+}
+
+static void initialize_core(mcu_command_dedup_t *dedup,
+                            mcu_state_machine_t *machine,
+                            mcu_watchdog_t *watchdog,
+                            bool open_session,
+                            mcu_test_report_t *report)
+{
+    mcu_command_dedup_init(dedup);
+    mcu_sm_init(machine);
+    mcu_watchdog_init(watchdog, 1u);
+    if (open_session) {
+        check(report, mcu_command_dedup_open_session(dedup, true));
+    }
+}
+
+static void expect_decode_failure(mcu_test_report_t *report,
+                                  const hal_can_frame *encoded,
+                                  mcu_can_bridge_status_t expected)
+{
+    mcu_wire_frame_t decoded;
+    mcu_wire_frame_t before;
+
+    set_wire_sentinel(&decoded);
+    copy_wire_frame(&before, &decoded);
+    check(report, mcu_can_bridge_decode(encoded, &decoded) == expected);
+    check(report, wire_frames_equal(&decoded, &before));
+}
+
+static void test_all_wire_kinds_round_trip(mcu_test_report_t *report)
+{
+    unsigned index;
+
+    check(report, HAL_CAN_STANDARD_ID_MAX == 0x07ffu);
+    check(report, HAL_CAN_CLASSIC_DLC_MAX == MCU_WIRE_DLC);
+    check(report, MCU_CAN_ID_STOP < MCU_CAN_ID_STOP_ACK);
+    check(report, MCU_CAN_ID_STOP_ACK < MCU_CAN_ID_COMMAND);
+    check(report, MCU_CAN_ID_COMMAND < MCU_CAN_ID_ACK);
+    check(report, MCU_CAN_ID_ACK < MCU_CAN_ID_TELEMETRY);
+
+    for (index = 0u; index < sizeof(bridge_vectors) / sizeof(bridge_vectors[0]); index++) {
+        hal_can_frame encoded;
+        mcu_wire_frame_t decoded;
+
+        set_hal_sentinel(&encoded);
+        set_wire_sentinel(&decoded);
+        check(report, mcu_can_bridge_encode(&bridge_vectors[index].frame, &encoded) ==
+                        MCU_CAN_BRIDGE_OK);
+        check(report, encoded.arbitration_id == bridge_vectors[index].arbitration_id);
+        check(report, encoded.dlc == MCU_WIRE_DLC);
+        check(report, encoded.flags == (uint8_t)HAL_CAN_FRAME_FLAG_NONE);
+        check(report, encoded.data[0] == MCU_WIRE_VERSION_V1);
+        check(report, mcu_can_bridge_decode(&encoded, &decoded) == MCU_CAN_BRIDGE_OK);
+        check(report, wire_frames_equal(&decoded, &bridge_vectors[index].frame));
+    }
+
+    {
+        hal_can_frame encoded;
+        hal_can_frame before;
+        mcu_wire_frame_t invalid;
+
+        set_hal_sentinel(&encoded);
+        copy_hal_frame(&before, &encoded);
+        copy_wire_frame(&invalid, &bridge_vectors[0].frame);
+        invalid.command_id = MCU_STOP_ID_MIN;
+        check(report, mcu_can_bridge_encode(&invalid, &encoded) ==
+                        MCU_CAN_BRIDGE_INVALID_WIRE_FIELD);
+        check(report, hal_frames_equal(&encoded, &before));
+    }
+
+    check(report, mcu_can_bridge_encode(0, 0) == MCU_CAN_BRIDGE_INVALID_ARGUMENT);
+    check(report, mcu_can_bridge_decode(0, 0) == MCU_CAN_BRIDGE_INVALID_ARGUMENT);
+}
+
+static void test_raw_envelope_and_wire_rejections(mcu_test_report_t *report)
+{
+    hal_can_frame valid;
+    hal_can_frame invalid;
+    unsigned dlc;
+    unsigned flags;
+
+    check(report, mcu_can_bridge_encode(&bridge_vectors[0].frame, &valid) == MCU_CAN_BRIDGE_OK);
+
+    for (flags = 1u; flags <= UINT8_MAX; flags++) {
+        copy_hal_frame(&invalid, &valid);
+        invalid.flags = (uint8_t)flags;
+        expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_INVALID_FLAGS);
+    }
+
+    copy_hal_frame(&invalid, &valid);
+    invalid.arbitration_id = HAL_CAN_STANDARD_ID_MAX + 1u;
+    expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_INVALID_ARBITRATION_ID);
+
+    for (dlc = 0u; dlc <= UINT8_MAX; dlc++) {
+        if (dlc == MCU_WIRE_DLC) {
+            continue;
+        }
+        copy_hal_frame(&invalid, &valid);
+        invalid.dlc = (uint8_t)dlc;
+        expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_INVALID_DLC);
+    }
+
+    copy_hal_frame(&invalid, &valid);
+    invalid.arbitration_id = HAL_CAN_STANDARD_ID_MAX;
+    expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_UNSUPPORTED_ID);
+
+    copy_hal_frame(&invalid, &valid);
+    invalid.data[0] = 0x11u;
+    expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_INVALID_VERSION);
+
+    copy_hal_frame(&invalid, &valid);
+    invalid.data[5] = 1u;
+    expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_NONZERO_RESERVED);
+
+    copy_hal_frame(&invalid, &valid);
+    invalid.data[1] = 0x80u;
+    invalid.data[2] = 0x00u;
+    expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_INVALID_WIRE_FIELD);
+
+    copy_hal_frame(&invalid, &valid);
+    invalid.data[3] = (uint8_t)MCU_WIRE_OPCODE_STOP;
+    expect_decode_failure(report, &invalid, MCU_CAN_BRIDGE_INVALID_WIRE_FIELD);
+}
+
+static void check_core_unchanged(mcu_test_report_t *report,
+                                 const mcu_command_dedup_t *dedup,
+                                 const mcu_state_machine_t *machine,
+                                 const mcu_watchdog_t *watchdog)
+{
+    check(report, mcu_command_dedup_is_valid(dedup));
+    check(report, !dedup->has_last_accepted);
+    check(report, machine->state == MCU_STATE_IDLE);
+    check(report, machine->device_mode == MCU_DEVICE_MODE_IDLE);
+    check(report, machine->fault_code == MCU_FAULT_NONE);
+    check(report, !watchdog->link_watchdog_armed);
+    check(report, !watchdog->stop_ack_pending);
+}
+
+static void test_rejected_ingress_has_no_safety_side_effect(mcu_test_report_t *report)
+{
+    static const unsigned wrong_direction_vectors[] = {1u, 2u, 4u};
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_can_bridge_record_t record;
+    hal_can_frame encoded;
+    unsigned index;
+
+    initialize_core(&dedup, &machine, &watchdog, true, report);
+    check(report, mcu_can_bridge_encode(&bridge_vectors[0].frame, &encoded) == MCU_CAN_BRIDGE_OK);
+    encoded.flags = (uint8_t)HAL_CAN_FRAME_FLAG_EXTENDED_ID;
+    check(report, mcu_can_bridge_process_frame(&dedup,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               100u,
+                                               &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_REJECTED);
+    check(report, record.status == MCU_CAN_BRIDGE_INVALID_FLAGS);
+    check(report, !record.request_decoded);
+    check(report, !record.response_available);
+    check_core_unchanged(report, &dedup, &machine, &watchdog);
+
+    initialize_core(&dedup, &machine, &watchdog, true, report);
+    check(report, mcu_can_bridge_encode(&bridge_vectors[0].frame, &encoded) == MCU_CAN_BRIDGE_OK);
+    encoded.data[0] = 0x11u;
+    check(report, mcu_can_bridge_process_frame(&dedup,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               101u,
+                                               &record));
+    check(report, record.status == MCU_CAN_BRIDGE_INVALID_VERSION);
+    check_core_unchanged(report, &dedup, &machine, &watchdog);
+
+    for (index = 0u;
+         index < sizeof(wrong_direction_vectors) / sizeof(wrong_direction_vectors[0]);
+         index++) {
+        initialize_core(&dedup, &machine, &watchdog, true, report);
+        check(report,
+              mcu_can_bridge_encode(&bridge_vectors[wrong_direction_vectors[index]].frame,
+                                    &encoded) == MCU_CAN_BRIDGE_OK);
+        check(report, mcu_can_bridge_process_frame(&dedup,
+                                                   &machine,
+                                                   &watchdog,
+                                                   &encoded,
+                                                   102u + index,
+                                                   &record));
+        check(report, record.request_decoded);
+        check(report, record.status == MCU_CAN_BRIDGE_UNEXPECTED_DIRECTION);
+        check(report, !record.response_available);
+        check_core_unchanged(report, &dedup, &machine, &watchdog);
+    }
+
+    initialize_core(&dedup, &machine, &watchdog, false, report);
+    dedup.initialized = 0u;
+    check(report, mcu_can_bridge_encode(&bridge_vectors[0].frame, &encoded) == MCU_CAN_BRIDGE_OK);
+    check(report, mcu_can_bridge_process_frame(&dedup,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               106u,
+                                               &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_REJECTED);
+    check(report, record.status == MCU_CAN_BRIDGE_CORE_REJECTED);
+    check(report, !record.ordinary_event_dispatched);
+    check(report, !record.response_available);
+    check(report, machine.state == MCU_STATE_IDLE);
+}
+
+static void test_session_gate_and_valid_command(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_can_bridge_record_t record;
+    hal_can_frame encoded;
+
+    initialize_core(&dedup, &machine, &watchdog, false, report);
+    check(report, mcu_can_bridge_encode(&bridge_vectors[0].frame, &encoded) == MCU_CAN_BRIDGE_OK);
+    check(report, mcu_can_bridge_process_frame(&dedup,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               200u,
+                                               &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_SESSION_CLOSED);
+    check(report, record.request_decoded);
+    check(report, !record.ordinary_event_dispatched);
+    check(report, !record.response_available);
+    check(report, machine.state == MCU_STATE_IDLE);
+
+    initialize_core(&dedup, &machine, &watchdog, true, report);
+    check(report, mcu_can_bridge_process_frame(&dedup,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               201u,
+                                               &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_COMMAND_HANDLED);
+    check(report, record.status == MCU_CAN_BRIDGE_OK);
+    check(report, record.ordinary_event_dispatched);
+    check(report, record.response_available);
+    check(report, !record.response_handed_off);
+    check(report, record.response.kind == MCU_WIRE_FRAME_ACK);
+    check(report, record.response.command_id == bridge_vectors[0].frame.command_id);
+    check(report, record.response.result_code == MCU_WIRE_RESULT_ACCEPTED);
+    check(report, machine.state == MCU_STATE_EXECUTING);
+    check(report, watchdog.link_watchdog_armed);
+
+    check(report, mcu_can_bridge_process_frame(&dedup,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               202u,
+                                               &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_COMMAND_HANDLED);
+    check(report, !record.ordinary_event_dispatched);
+    check(report, record.response.result_code == MCU_WIRE_RESULT_ACCEPTED);
+    check(report, machine.state == MCU_STATE_EXECUTING);
+    check(report, watchdog.link_deadline_us == 201u + MCU_SOFTWARE_WATCHDOG_TIMEOUT_US);
+}
+
+static void test_stop_bypasses_ordinary_session(mcu_test_report_t *report)
+{
+    mcu_command_dedup_t dedup;
+    mcu_state_machine_t machine;
+    mcu_watchdog_t watchdog;
+    mcu_can_bridge_record_t record;
+    hal_can_frame encoded;
+    hal_can_frame response;
+
+    initialize_core(&dedup, &machine, &watchdog, false, report);
+    check(report, mcu_can_bridge_encode(&bridge_vectors[3].frame, &encoded) == MCU_CAN_BRIDGE_OK);
+    check(report, encoded.arbitration_id == MCU_CAN_ID_STOP);
+    check(report, encoded.data[1] == 0x80u && encoded.data[2] == 0x00u);
+    check(report, mcu_can_bridge_process_frame(&dedup,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               300u,
+                                               &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_STOP_HANDLED);
+    check(report, record.stop_path_entered);
+    check(report, !record.ordinary_event_dispatched);
+    check(report, record.response_available);
+    check(report, record.response.kind == MCU_WIRE_FRAME_STOP_ACK);
+    check(report, record.response.command_id >= MCU_STOP_ID_MIN);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+    check(report, watchdog.stop_ack_pending);
+    check(report, mcu_can_bridge_encode(&record.response, &response) == MCU_CAN_BRIDGE_OK);
+    check(report, response.arbitration_id == MCU_CAN_ID_STOP_ACK);
+
+    /* Ordinary replay state is not a STOP dependency. A missing dedup object
+     * cannot suppress a newly initialized watchdog/state-machine STOP path. */
+    mcu_sm_init(&machine);
+    mcu_watchdog_init(&watchdog, 2u);
+    check(report, mcu_can_bridge_process_frame(0,
+                                               &machine,
+                                               &watchdog,
+                                               &encoded,
+                                               301u,
+                                               &record));
+    check(report, record.outcome == MCU_CAN_BRIDGE_OUTCOME_STOP_HANDLED);
+    check(report, record.stop_path_entered);
+    check(report, machine.state == MCU_STATE_SAFE_STOP);
+}
+
+void mcu_can_bridge_run_tests(mcu_test_report_t *report)
+{
+    if (report == 0) {
+        return;
+    }
+
+    report->assertions = 0u;
+    report->failures = 0u;
+    report->first_failure = 0u;
+
+    test_all_wire_kinds_round_trip(report);
+    test_raw_envelope_and_wire_rejections(report);
+    test_rejected_ingress_has_no_safety_side_effect(report);
+    test_session_gate_and_valid_command(report);
+    test_stop_bypasses_ordinary_session(report);
+}

--- a/firmware/mcu/tests/can_bridge_tests.h
+++ b/firmware/mcu/tests/can_bridge_tests.h
@@ -1,0 +1,8 @@
+#ifndef MCU_CAN_BRIDGE_TESTS_H
+#define MCU_CAN_BRIDGE_TESTS_H
+
+#include "state_machine_tests.h"
+
+void mcu_can_bridge_run_tests(mcu_test_report_t *report);
+
+#endif /* MCU_CAN_BRIDGE_TESTS_H */

--- a/firmware/mcu/tests/main_host.c
+++ b/firmware/mcu/tests/main_host.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+#include "can_bridge_host_tests.h"
+#include "can_bridge_tests.h"
 #include "command_dedup_tests.h"
 #include "frame_codec_tests.h"
 #include "state_machine_tests.h"
@@ -11,6 +13,8 @@ int main(void)
     mcu_test_report_t frame_codec_report;
     mcu_test_report_t watchdog_report;
     mcu_test_report_t command_dedup_report;
+    mcu_test_report_t can_bridge_report;
+    mcu_test_report_t can_bridge_host_report;
 
     mcu_state_machine_run_tests(&state_machine_report);
     printf("[mcu-host] state-machine assertions=%u failures=%u first_failure=%u\n",
@@ -35,8 +39,21 @@ int main(void)
            (unsigned)command_dedup_report.assertions,
            (unsigned)command_dedup_report.failures,
            (unsigned)command_dedup_report.first_failure);
+
+    mcu_can_bridge_run_tests(&can_bridge_report);
+    printf("[mcu-host] can-bridge assertions=%u failures=%u first_failure=%u\n",
+           (unsigned)can_bridge_report.assertions,
+           (unsigned)can_bridge_report.failures,
+           (unsigned)can_bridge_report.first_failure);
+
+    mcu_can_bridge_host_run_tests(&can_bridge_host_report);
+    printf("[mcu-host] can-bridge-host assertions=%u failures=%u first_failure=%u\n",
+           (unsigned)can_bridge_host_report.assertions,
+           (unsigned)can_bridge_host_report.failures,
+           (unsigned)can_bridge_host_report.first_failure);
     return state_machine_report.failures == 0u && frame_codec_report.failures == 0u &&
-             watchdog_report.failures == 0u && command_dedup_report.failures == 0u
+             watchdog_report.failures == 0u && command_dedup_report.failures == 0u &&
+             can_bridge_report.failures == 0u && can_bridge_host_report.failures == 0u
              ? 0
              : 1;
 }


### PR DESCRIPTION
## Related Issue

Partially addresses #180.

## What changed

- Renamed the raw HAL identifier boundary to an explicit 11-bit `arbitration_id`, separate from the 16-bit logical `command_id` in Wire V1 payload bytes 1..2.
- Added explicit DLC and extended-ID, RTR, error, and CAN FD flags to the raw HAL envelope.
- Added an allocation-free HAL/Wire V1 bridge that uses the existing codec as the only identifier and payload mapping authority.
- Rejects malformed raw envelopes, invalid Wire V1 payloads, and wrong-direction MCU ingress before any safety-state side effect.
- Routes STOP before ordinary command handling and keeps STOP independent from a closed, missing, corrupt, or full dedup/session state.
- Confirms accepted STOP_ACK state only after HAL transport handoff; failed handoff remains pending under the existing retry/timeout policy.
- Added a fixed-capacity Host fake HAL plus shared Host/QEMU and Host-only transport regressions.

## Interfaces affected

- Changes the internal firmware `hal_can_frame` shape and adds `mcu_can_bridge_*` APIs.
- Does not change frozen Wire V1 arbitration IDs, payload bytes, JSON Schema, Pydantic models, or logical protocol semantics.
- Documents that current Wire V1 represents one logical endpoint and cannot silently encode the BSP six-domain node allocation.

## Tests and commands

```sh
python3 tools/scripts/check_task_packet.py docs/task_packets/issue-180-mcu-can-hal-boundary.json --base origin/main
make -C firmware/mcu host-test
make -C firmware/mcu codec-sanitize
make -C firmware/mcu qemu-test
make -C firmware/mcu verify-no-fp
make -C firmware/mcu size-check
make test
make contract
make scenario-check
make context-check
make golden-check
make lint
make docs
make demo-scripted
make demo-offline
```

Cppcheck, GCC `-fanalyzer`, and strict `-Wconversion/-Wsign-conversion` builds also passed.

## Evidence

- Host and ASan/UBSan MCU assertions passed: `436 + 20,637 + 184 + 65,778 + 1,192 + 106`.
- QEMU ran the same bridge corpus with `1,192` passing assertions and an explicit `CAN transport NOT_EXECUTED` marker.
- The bridge corpus exhaustively rejects all 255 nonzero raw CAN flag combinations and all 255 non-eight DLC values.
- Full repository suite passed with `879 passed, 1 skipped` using the repository environment.
- Contract, 12 frozen and 24 expanded scenarios, context, golden set, Ruff, strict MkDocs, and scripted/offline demos passed.
- Firmware remains within budget: `.text=26,007`, `.bss=196`; no floating-point instructions or allocator symbols are linked.

## Risks and rollback

- This is the platform-independent and Host-fake slice only. QEMU CAN, legacy CH32V307, BSP STM32H563/STM32G0B1, physical CAN, controller FIFO/IRQ, and bus-off evidence remain `NOT_EXECUTED`.
- BSP six-domain arbitration remains blocked on an owner-approved versioned node/addressing decision; this PR deliberately does not invent one.
- This PR must not close #180 by itself. Real target HAL and physical/multi-domain evidence remain follow-up work.
- Rollback is a revert of commit `ed41bac`.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.
