### PR TITLE
feat(perception): add observation ingestion boundary (#72)

### DIFF
--- a/docs/task_packets/issue-72-observation-ingestion.json
+++ b/docs/task_packets/issue-72-observation-ingestion.json
@@ -1,0 +1,75 @@
+{
+  "issue": 72,
+  "human_owner": "zhangjia-1111",
+  "objective": "Add a fail-closed perception-to-World-Model adapter that validates, calibrates and freshness-gates Observation records before emitting WorldEvents.",
+  "decision_supported": "Whether a raw camera observation is trustworthy enough to enter the canonical World Model event stream.",
+  "allowed_paths": [
+    "services/perception/README.md",
+    "services/perception/workbench_perception/__init__.py",
+    "services/perception/workbench_perception/ingestion.py",
+    "tests/unit/test_observation_ingestion.py",
+    "tests/integration/test_observation_ingestion.py",
+    "docs/task_packets/issue-72-observation-ingestion.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/world_model/**"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "sim/**"
+  ],
+  "input_refs": [
+    "interfaces/json_schema/observation.schema.json",
+    "interfaces/json_schema/pose.schema.json",
+    "interfaces/json_schema/world_event.schema.json",
+    "interfaces/examples/observation-red-block.json"
+  ],
+  "outputs": [
+    "fail-closed Observation ingestion adapter",
+    "deterministic calibration and freshness fixtures",
+    "accepted Observation WorldEvents consumable by the World Model reducer"
+  ],
+  "acceptance": [
+    "only contract-valid Observation records are accepted",
+    "camera ID calibration revision frame pose units confidence timestamp clock and evidence references are validated",
+    "stale future-skewed duplicate and coordinate-frame-mismatched observations are rejected",
+    "frame conversion requires a declared calibration revision",
+    "raw observation provenance is preserved without caller mutation",
+    "deterministic tests cover dropout malformed pose low confidence stale frames and calibration mismatch",
+    "the World Model sink receives only accepted observations"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-72-observation-ingestion.json",
+    "python -m pytest tests/unit tests/integration -k observation -v",
+    "python -m ruff check services/perception/workbench_perception tests/unit/test_observation_ingestion.py tests/integration/test_observation_ingestion.py",
+    "python -m ruff format --check services/perception/workbench_perception tests/unit/test_observation_ingestion.py tests/integration/test_observation_ingestion.py",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "Task Packet validation output",
+    "focused observation unit and integration test output",
+    "full repository test output",
+    "contract scenario and context validation output"
+  ],
+  "stop_conditions": [
+    "an interface or Pydantic contract change is required",
+    "a write outside the allowed paths is required",
+    "a simulator oracle or raw image payload is required",
+    "a calibration cannot identify source and target frames",
+    "physical sensor evidence is requested without a connected bench"
+  ],
+  "max_iterations": 5,
+  "data_classification": "local synthetic observation fixtures only; no raw images or personal data",
+  "model_policy": "deterministic typed validation and rigid transforms only; no model inference",
+  "risks_and_fallbacks": [
+    "reject observations when their clock domain cannot be compared to an injected deterministic clock",
+    "reject unknown calibration revisions or frames instead of guessing a transform",
+    "preserve the current interfaces and open a separately approved contract issue if new fields are required"
+  ]
+}

--- a/services/perception/README.md
+++ b/services/perception/README.md
@@ -3,3 +3,12 @@
 P0 emits `Observation` from a controlled Gazebo camera using OpenCV plus AprilTag or color recognition. Required fields are documented in `interfaces/json_schema/observation.schema.json`.
 
 Do not use simulator Oracle values in sensor-mode metrics.
+
+`workbench_perception.ObservationIngestionAdapter` is the fail-closed boundary
+between an Observation producer and the World Model event stream. Callers must
+name an approved camera calibration revision and pose unit, and inject a clock
+from the same domain as the Observation. The adapter rejects malformed, stale,
+future-skewed, low-confidence, duplicate, uncalibrated, and frame-mismatched
+records before invoking its World Model sink. It preserves the unmodified JSON
+Observation under `payload.raw_observation` and emits the calibrated pose at
+`payload.pose`; it never writes `WorldState` facts directly.

--- a/services/perception/workbench_perception/__init__.py
+++ b/services/perception/workbench_perception/__init__.py
@@ -1,0 +1,5 @@
+"""Fail-closed perception boundaries for Workbench-1."""
+
+from .ingestion import CalibrationRecord, ObservationIngestionAdapter, ObservationRejected
+
+__all__ = ["CalibrationRecord", "ObservationIngestionAdapter", "ObservationRejected"]

--- a/services/perception/workbench_perception/ingestion.py
+++ b/services/perception/workbench_perception/ingestion.py
@@ -1,0 +1,352 @@
+"""Validate and calibrate observations before they enter the World Model.
+
+The adapter deliberately owns no detector and writes no ``WorldState`` facts.
+It turns one untrusted Observation mapping into a contract-shaped observation
+``WorldEvent`` only after every boundary check succeeds.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import OrderedDict
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from threading import Lock
+from typing import Any, Literal
+
+from pydantic import ValidationError
+from workbench_contracts import ClockId, Observation, WorldEvent, WorldEventType
+
+_REQUIRED_OBSERVATION_KEYS = frozenset(
+    {
+        "observation_id",
+        "run_id",
+        "entity_id",
+        "entity_type",
+        "pose",
+        "confidence",
+        "observed_at",
+        "source",
+        "evidence_refs",
+    }
+)
+_QUATERNION_TOLERANCE = 1e-6
+
+
+class ObservationRejected(ValueError):
+    """An observation failed a fail-closed ingestion boundary check."""
+
+
+@dataclass(frozen=True)
+class CalibrationRecord:
+    """One approved rigid transform for a camera calibration revision."""
+
+    camera_id: str
+    revision: str
+    source_frame: str
+    target_frame: str
+    clock_id: ClockId
+    translation_m: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    rotation_xyzw: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0)
+    pose_units: Literal["m"] = "m"
+
+    def __post_init__(self) -> None:
+        for name in ("camera_id", "revision", "source_frame", "target_frame"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"calibration {name} must be non-empty")
+        if not isinstance(self.clock_id, ClockId):
+            raise ValueError("calibration clock_id must be a ClockId")
+        if self.pose_units != "m":
+            raise ValueError("calibration pose_units must be 'm'")
+        if (
+            not isinstance(self.translation_m, tuple)
+            or len(self.translation_m) != 3
+            or not all(_is_finite_number(value) for value in self.translation_m)
+        ):
+            raise ValueError("calibration translation_m must contain three finite numbers")
+        if not isinstance(self.rotation_xyzw, tuple):
+            raise ValueError("calibration rotation_xyzw must be a tuple")
+        _require_unit_quaternion(self.rotation_xyzw, "calibration rotation_xyzw")
+
+
+class ObservationIngestionAdapter:
+    """Emit only validated, fresh and calibrated observation events."""
+
+    def __init__(
+        self,
+        calibrations: Iterable[CalibrationRecord],
+        *,
+        now: Callable[[ClockId], datetime],
+        sink: Callable[[WorldEvent], None] | None = None,
+        minimum_confidence: float = 0.5,
+        maximum_age: timedelta = timedelta(seconds=1),
+        maximum_future_skew: timedelta = timedelta(milliseconds=50),
+        duplicate_window_size: int = 1024,
+    ) -> None:
+        if not callable(now):
+            raise ValueError("now must be callable")
+        if sink is not None and not callable(sink):
+            raise ValueError("sink must be callable or None")
+        if isinstance(minimum_confidence, bool) or not _is_finite_number(minimum_confidence):
+            raise ValueError("minimum_confidence must be a finite number")
+        if not 0.0 <= float(minimum_confidence) <= 1.0:
+            raise ValueError("minimum_confidence must be between 0 and 1")
+        if not isinstance(maximum_age, timedelta) or not isinstance(maximum_future_skew, timedelta):
+            raise ValueError("freshness durations must be timedeltas")
+        if maximum_age < timedelta(0) or maximum_future_skew < timedelta(0):
+            raise ValueError("freshness durations must be non-negative")
+        if (
+            isinstance(duplicate_window_size, bool)
+            or not isinstance(duplicate_window_size, int)
+            or duplicate_window_size < 1
+        ):
+            raise ValueError("duplicate_window_size must be a positive integer")
+
+        calibration_by_key: dict[tuple[str, str], CalibrationRecord] = {}
+        for calibration in calibrations:
+            if not isinstance(calibration, CalibrationRecord):
+                raise ValueError("calibrations must contain CalibrationRecord values")
+            key = (calibration.camera_id, calibration.revision)
+            if key in calibration_by_key:
+                raise ValueError(f"duplicate calibration {key!r}")
+            calibration_by_key[key] = calibration
+        if not calibration_by_key:
+            raise ValueError("at least one calibration is required")
+
+        self._calibrations = calibration_by_key
+        self._now = now
+        self._sink = sink
+        self._minimum_confidence = float(minimum_confidence)
+        self._maximum_age = maximum_age
+        self._maximum_future_skew = maximum_future_skew
+        self._duplicate_window_size = duplicate_window_size
+        self._seen_ids: OrderedDict[tuple[str, str], None] = OrderedDict()
+        self._seen_frames: OrderedDict[tuple[str, str, str, tuple[str, ...]], None] = OrderedDict()
+        self._lock = Lock()
+
+    def ingest(
+        self,
+        record: Mapping[str, object] | None,
+        *,
+        camera_id: str,
+        calibration_revision: str,
+        pose_units: str,
+        sequence_no: int,
+    ) -> WorldEvent:
+        """Validate one record, optionally deliver it, and return its WorldEvent.
+
+        The injected sink is called only after the complete record has passed
+        structural, calibration, freshness and duplicate checks.
+        """
+        raw_record, observation = _parse_contract_observation(record)
+        _require_non_empty(camera_id, "camera_id")
+        _require_non_empty(calibration_revision, "calibration_revision")
+        if isinstance(sequence_no, bool) or not isinstance(sequence_no, int) or sequence_no < 0:
+            raise ObservationRejected("sequence_no must be a non-negative integer")
+
+        calibration = self._calibrations.get((camera_id, calibration_revision))
+        if calibration is None:
+            raise ObservationRejected(f"unknown calibration revision {calibration_revision!r} for camera {camera_id!r}")
+        if pose_units != "m" or pose_units != calibration.pose_units:
+            raise ObservationRejected("pose_units must match the declared calibration unit 'm'")
+        if observation.source != camera_id:
+            raise ObservationRejected(
+                f"Observation source {observation.source!r} does not match camera_id {camera_id!r}"
+            )
+        if observation.clock_id is not calibration.clock_id:
+            raise ObservationRejected(
+                f"Observation clock {observation.clock_id.value!r} does not match calibration clock "
+                f"{calibration.clock_id.value!r}"
+            )
+
+        observed_at = _parse_timestamp(observation.observed_at)
+        now = self._now(observation.clock_id)
+        if not isinstance(now, datetime) or now.tzinfo is None:
+            raise ObservationRejected("injected clock must return a timezone-aware datetime")
+        now = now.astimezone(UTC)
+        age = now - observed_at
+        if age > self._maximum_age:
+            raise ObservationRejected(f"Observation is stale by {age.total_seconds():.6f} seconds")
+        if age < -self._maximum_future_skew:
+            raise ObservationRejected(f"Observation is future-skewed by {-age.total_seconds():.6f} seconds")
+
+        if observation.confidence < self._minimum_confidence:
+            raise ObservationRejected(
+                f"Observation confidence {observation.confidence} is below {self._minimum_confidence}"
+            )
+        _validate_observation_values(observation)
+        transformed_pose = _transform_pose(observation, calibration)
+
+        event = WorldEvent(
+            event_id=f"observation:{observation.observation_id}",
+            run_id=observation.run_id,
+            sequence_no=sequence_no,
+            event_type=WorldEventType.OBSERVATION,
+            occurred_at=observation.observed_at,
+            payload={
+                "entity_id": observation.entity_id,
+                "entity_type": observation.entity_type,
+                "pose": transformed_pose,
+                "confidence": observation.confidence,
+                "detector": observation.detector.value,
+                "camera_id": camera_id,
+                "calibration_revision": calibration_revision,
+                "pose_units": pose_units,
+                "clock_id": observation.clock_id.value,
+                "raw_observation": raw_record,
+            },
+            evidence_refs=list(observation.evidence_refs),
+        )
+
+        observation_key = (observation.run_id, observation.observation_id)
+        frame_key = (observation.run_id, camera_id, observation.entity_id, tuple(observation.evidence_refs))
+        with self._lock:
+            if observation_key in self._seen_ids:
+                raise ObservationRejected(f"duplicate observation_id {observation.observation_id!r}")
+            if frame_key in self._seen_frames:
+                raise ObservationRejected("duplicate camera-frame observation for entity")
+            if self._sink is not None:
+                self._sink(event)
+            _remember(self._seen_ids, observation_key, self._duplicate_window_size)
+            _remember(self._seen_frames, frame_key, self._duplicate_window_size)
+        return event
+
+
+def _parse_contract_observation(record: Mapping[str, object] | None) -> tuple[dict[str, Any], Observation]:
+    if not isinstance(record, Mapping):
+        raise ObservationRejected("Observation record must be a mapping")
+    missing = _REQUIRED_OBSERVATION_KEYS - set(record)
+    if missing:
+        raise ObservationRejected(f"Observation is missing contract fields: {sorted(missing)}")
+    try:
+        serialized = json.dumps(dict(record), allow_nan=False, ensure_ascii=False)
+        raw_record = json.loads(serialized)
+        observation = Observation.model_validate_json(serialized, strict=True)
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise ObservationRejected(f"Observation is not contract-valid: {exc}") from exc
+    return raw_record, observation
+
+
+def _validate_observation_values(observation: Observation) -> None:
+    for name in ("observation_id", "run_id", "entity_id", "entity_type", "source"):
+        _require_non_empty(getattr(observation, name), name)
+    _require_non_empty(observation.pose.frame_id, "pose.frame_id")
+    if observation.hamming is not None and (isinstance(observation.hamming, bool) or observation.hamming < 0):
+        raise ObservationRejected("hamming must be a non-negative integer or null")
+    if observation.decision_margin is not None and not _is_finite_number(observation.decision_margin):
+        raise ObservationRejected("decision_margin must be finite or null")
+
+    position = observation.pose.position
+    if not all(_is_finite_number(value) for value in (position.x, position.y, position.z)):
+        raise ObservationRejected("pose position must contain finite numbers")
+    orientation = observation.pose.orientation
+    _require_unit_quaternion(
+        (orientation.x, orientation.y, orientation.z, orientation.w),
+        "pose orientation",
+        rejection=True,
+    )
+    if len(set(observation.evidence_refs)) != len(observation.evidence_refs):
+        raise ObservationRejected("evidence_refs must not contain duplicates")
+    for reference in observation.evidence_refs:
+        _require_non_empty(reference, "evidence_refs item")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ObservationRejected("observed_at must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ObservationRejected("observed_at must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _transform_pose(observation: Observation, calibration: CalibrationRecord) -> dict[str, object]:
+    pose = observation.pose
+    if pose.frame_id == calibration.target_frame:
+        return pose.model_dump(mode="json")
+    if pose.frame_id != calibration.source_frame:
+        raise ObservationRejected(
+            f"pose frame {pose.frame_id!r} matches neither calibration source "
+            f"{calibration.source_frame!r} nor target {calibration.target_frame!r}"
+        )
+
+    source_position = (pose.position.x, pose.position.y, pose.position.z)
+    rotated = _rotate_vector(calibration.rotation_xyzw, source_position)
+    translated = tuple(rotated[index] + calibration.translation_m[index] for index in range(3))
+    source_orientation = (pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w)
+    target_orientation = _multiply_quaternions(calibration.rotation_xyzw, source_orientation)
+    return {
+        "frame_id": calibration.target_frame,
+        "position": {"x": translated[0], "y": translated[1], "z": translated[2]},
+        "orientation": {
+            "x": target_orientation[0],
+            "y": target_orientation[1],
+            "z": target_orientation[2],
+            "w": target_orientation[3],
+        },
+    }
+
+
+def _multiply_quaternions(
+    left: tuple[float, float, float, float], right: tuple[float, float, float, float]
+) -> tuple[float, float, float, float]:
+    lx, ly, lz, lw = left
+    rx, ry, rz, rw = right
+    product = (
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+        lw * rw - lx * rx - ly * ry - lz * rz,
+    )
+    norm = math.sqrt(sum(component * component for component in product))
+    return tuple(component / norm for component in product)  # type: ignore[return-value]
+
+
+def _rotate_vector(
+    rotation: tuple[float, float, float, float], vector: tuple[float, float, float]
+) -> tuple[float, float, float]:
+    vector_quaternion = (vector[0], vector[1], vector[2], 0.0)
+    conjugate = (-rotation[0], -rotation[1], -rotation[2], rotation[3])
+    rotated = _multiply_raw(_multiply_raw(rotation, vector_quaternion), conjugate)
+    return rotated[0], rotated[1], rotated[2]
+
+
+def _multiply_raw(
+    left: tuple[float, float, float, float], right: tuple[float, float, float, float]
+) -> tuple[float, float, float, float]:
+    lx, ly, lz, lw = left
+    rx, ry, rz, rw = right
+    return (
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+        lw * rw - lx * rx - ly * ry - lz * rz,
+    )
+
+
+def _require_unit_quaternion(value: tuple[float, float, float, float], name: str, *, rejection: bool = False) -> None:
+    error_type = ObservationRejected if rejection else ValueError
+    if len(value) != 4 or not all(_is_finite_number(component) for component in value):
+        raise error_type(f"{name} must contain four finite numbers")
+    norm = math.sqrt(sum(float(component) * float(component) for component in value))
+    if not math.isclose(norm, 1.0, rel_tol=_QUATERNION_TOLERANCE, abs_tol=_QUATERNION_TOLERANCE):
+        raise error_type(f"{name} must be a unit quaternion")
+
+
+def _is_finite_number(value: object) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int | float) and math.isfinite(float(value))
+
+
+def _require_non_empty(value: object, name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ObservationRejected(f"{name} must be a non-empty string")
+
+
+def _remember(cache: OrderedDict[Any, None], key: Any, maximum_size: int) -> None:
+    cache[key] = None
+    while len(cache) > maximum_size:
+        cache.popitem(last=False)

--- a/tests/integration/test_observation_ingestion.py
+++ b/tests/integration/test_observation_ingestion.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [
+    str(ROOT / "libs/contracts"),
+    str(ROOT / "services/perception"),
+    str(ROOT / "services/world_model"),
+]
+
+from workbench_contracts import ClockId
+from workbench_perception import CalibrationRecord, ObservationIngestionAdapter, ObservationRejected
+from workbench_world_model import reduce_events
+
+
+def test_world_model_receives_only_accepted_observations() -> None:
+    accepted_events = []
+    adapter = ObservationIngestionAdapter(
+        [
+            CalibrationRecord(
+                camera_id="camera-01",
+                revision="cal-v1",
+                source_frame="camera_optical",
+                target_frame="workbench",
+                clock_id=ClockId.WALL,
+            )
+        ],
+        now=lambda _clock_id: datetime(2026, 8, 28, 4, 0, 1, tzinfo=UTC),
+        sink=accepted_events.append,
+        minimum_confidence=0.8,
+        maximum_age=timedelta(seconds=2),
+    )
+    valid_record = {
+        "observation_id": "obs-valid",
+        "run_id": "run-observation",
+        "entity_id": "red_block",
+        "entity_type": "block",
+        "pose": {
+            "frame_id": "camera_optical",
+            "position": {"x": 0.2, "y": 0.1, "z": 0.02},
+            "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        },
+        "confidence": 0.95,
+        "detector": "apriltag",
+        "observed_at": "2026-08-28T04:00:00Z",
+        "clock_id": "wall",
+        "source": "camera-01",
+        "evidence_refs": ["frame://camera-01/valid"],
+    }
+
+    adapter.ingest(
+        valid_record,
+        camera_id="camera-01",
+        calibration_revision="cal-v1",
+        pose_units="m",
+        sequence_no=0,
+    )
+    with pytest.raises(ObservationRejected):
+        adapter.ingest(
+            {**valid_record, "observation_id": "obs-low", "confidence": 0.2},
+            camera_id="camera-01",
+            calibration_revision="cal-v1",
+            pose_units="m",
+            sequence_no=1,
+        )
+
+    state = reduce_events("run-observation", accepted_events)
+
+    assert len(accepted_events) == 1
+    assert state.applied_event_ids == ["observation:obs-valid"]
+    assert state.entity_confidence == {"red_block": 0.95}
+    assert state.entity_evidence_refs == {"red_block": ["frame://camera-01/valid"]}

--- a/tests/unit/test_observation_ingestion.py
+++ b/tests/unit/test_observation_ingestion.py
@@ -119,10 +119,11 @@ class ObservationIngestionTests(unittest.TestCase):
         Draft202012Validator(schema).validate(event)
 
     def test_raw_provenance_is_preserved_and_detached(self) -> None:
-        record = observation_record(vendor_metadata={"exposure_us": 5000})
+        record = observation_record()
         original = deepcopy(record)
         event = ingest(adapter(), record)
         record["entity_id"] = "mutated"
+        record["pose"]["position"]["x"] = 99.0  # type: ignore[index]
         record["evidence_refs"].append("frame://mutated")  # type: ignore[union-attr]
 
         self.assertEqual(event.payload["raw_observation"], original)

--- a/tests/unit/test_observation_ingestion.py
+++ b/tests/unit/test_observation_ingestion.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import math
+import sys
+import unittest
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "libs/contracts"), str(ROOT / "services/perception")]
+
+from workbench_contracts import ClockId, WorldEventType
+from workbench_perception import CalibrationRecord, ObservationIngestionAdapter, ObservationRejected
+
+NOW = datetime(2026, 8, 28, 4, 0, 1, tzinfo=UTC)
+
+
+def observation_record(**updates: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "observation_id": "obs-001",
+        "run_id": "run-001",
+        "entity_id": "red_block",
+        "entity_type": "block",
+        "pose": {
+            "frame_id": "camera_optical",
+            "position": {"x": 0.2, "y": 0.1, "z": 0.02},
+            "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        },
+        "confidence": 0.98,
+        "detector": "apriltag",
+        "hamming": 0,
+        "decision_margin": 72.5,
+        "observed_at": "2026-08-28T04:00:00Z",
+        "clock_id": "wall",
+        "source": "camera-01",
+        "evidence_refs": ["frame://camera-01/001"],
+    }
+    record.update(updates)
+    return record
+
+
+def calibration(**updates: object) -> CalibrationRecord:
+    values: dict[str, object] = {
+        "camera_id": "camera-01",
+        "revision": "cal-v1",
+        "source_frame": "camera_optical",
+        "target_frame": "workbench",
+        "clock_id": ClockId.WALL,
+        "translation_m": (1.0, 2.0, 3.0),
+    }
+    values.update(updates)
+    return CalibrationRecord(**values)  # type: ignore[arg-type]
+
+
+def adapter(*, sink=None, **updates: object) -> ObservationIngestionAdapter:
+    values: dict[str, object] = {
+        "now": lambda _clock_id: NOW,
+        "sink": sink,
+        "minimum_confidence": 0.7,
+        "maximum_age": timedelta(seconds=2),
+        "maximum_future_skew": timedelta(milliseconds=100),
+    }
+    values.update(updates)
+    return ObservationIngestionAdapter([calibration()], **values)  # type: ignore[arg-type]
+
+
+def ingest(target: ObservationIngestionAdapter, record: dict[str, object] | None = None, **updates: object):
+    context: dict[str, object] = {
+        "camera_id": "camera-01",
+        "calibration_revision": "cal-v1",
+        "pose_units": "m",
+        "sequence_no": 0,
+    }
+    context.update(updates)
+    return target.ingest(observation_record() if record is None else record, **context)  # type: ignore[arg-type]
+
+
+class CalibrationRecordTests(unittest.TestCase):
+    def test_calibration_requires_bounded_rigid_transform(self) -> None:
+        invalid_updates = (
+            {"camera_id": ""},
+            {"camera_id": 1},
+            {"clock_id": "wall"},
+            {"translation_m": 1.0},
+            {"translation_m": (0.0, math.nan, 0.0)},
+            {"rotation_xyzw": [0.0, 0.0, 0.0, 1.0]},
+            {"rotation_xyzw": (0.0, 0.0, 0.0, 0.0)},
+            {"pose_units": "cm"},
+        )
+
+        for updates in invalid_updates:
+            with self.subTest(updates=updates), self.assertRaises(ValueError):
+                calibration(**updates)
+
+
+class ObservationIngestionTests(unittest.TestCase):
+    def test_valid_observation_is_calibrated_and_delivered(self) -> None:
+        delivered = []
+        target = adapter(sink=delivered.append)
+
+        event = ingest(target)
+
+        self.assertEqual(delivered, [event])
+        self.assertEqual(event.event_type, WorldEventType.OBSERVATION)
+        self.assertEqual(event.event_id, "observation:obs-001")
+        self.assertEqual(event.payload["pose"]["frame_id"], "workbench")
+        self.assertEqual(event.payload["pose"]["position"], {"x": 1.2, "y": 2.1, "z": 3.02})
+        self.assertEqual(event.payload["calibration_revision"], "cal-v1")
+        self.assertEqual(event.evidence_refs, ["frame://camera-01/001"])
+
+    def test_world_event_satisfies_current_contract(self) -> None:
+        event = ingest(adapter()).model_dump(mode="json")
+        schema_path = ROOT / "interfaces/json_schema/world_event.schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        Draft202012Validator(schema).validate(event)
+
+    def test_raw_provenance_is_preserved_and_detached(self) -> None:
+        record = observation_record(vendor_metadata={"exposure_us": 5000})
+        original = deepcopy(record)
+        event = ingest(adapter(), record)
+        record["entity_id"] = "mutated"
+        record["evidence_refs"].append("frame://mutated")  # type: ignore[union-attr]
+
+        self.assertEqual(event.payload["raw_observation"], original)
+
+    def test_dropout_and_contract_invalid_records_fail_closed(self) -> None:
+        target = adapter()
+        with self.assertRaises(ObservationRejected):
+            target.ingest(
+                None,
+                camera_id="camera-01",
+                calibration_revision="cal-v1",
+                pose_units="m",
+                sequence_no=0,
+            )
+
+        invalid_records = [
+            {},
+            {key: value for key, value in observation_record().items() if key != "source"},
+            observation_record(confidence="0.98"),
+            observation_record(hamming=-1),
+            observation_record(decision_margin=float("nan")),
+        ]
+
+        for record in invalid_records:
+            with self.subTest(record=record), self.assertRaises(ObservationRejected):
+                ingest(adapter(), record)  # type: ignore[arg-type]
+
+    def test_malformed_pose_is_rejected(self) -> None:
+        invalid_poses = [
+            {
+                "frame_id": "camera_optical",
+                "position": {"x": float("nan"), "y": 0.0, "z": 0.0},
+                "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+            },
+            {
+                "frame_id": "camera_optical",
+                "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+                "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0},
+            },
+        ]
+
+        for pose in invalid_poses:
+            with self.subTest(pose=pose), self.assertRaises(ObservationRejected):
+                ingest(adapter(), observation_record(pose=pose))
+
+    def test_confidence_and_freshness_gates_fail_closed(self) -> None:
+        invalid_records = (
+            observation_record(confidence=0.69),
+            observation_record(observed_at="2026-08-28T03:59:58Z"),
+            observation_record(observed_at="2026-08-28T04:00:01.101Z"),
+            observation_record(observed_at="not-a-timestamp"),
+            observation_record(observed_at="2026-08-28T04:00:00"),
+        )
+
+        for record in invalid_records:
+            with self.subTest(record=record), self.assertRaises(ObservationRejected):
+                ingest(adapter(), record)
+
+    def test_camera_calibration_units_clock_and_frames_are_validated(self) -> None:
+        cases = (
+            (observation_record(), {"camera_id": "camera-02"}),
+            (observation_record(), {"calibration_revision": "missing"}),
+            (observation_record(), {"pose_units": "cm"}),
+            (observation_record(clock_id="monotonic"), {}),
+            (
+                observation_record(
+                    pose={
+                        "frame_id": "unknown_frame",
+                        "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+                        "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                    }
+                ),
+                {},
+            ),
+        )
+
+        for record, context in cases:
+            with self.subTest(context=context), self.assertRaises(ObservationRejected):
+                ingest(adapter(), record, **context)
+
+    def test_target_frame_pose_is_not_transformed_again(self) -> None:
+        pose = {
+            "frame_id": "workbench",
+            "position": {"x": 0.2, "y": 0.1, "z": 0.02},
+            "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        }
+
+        event = ingest(adapter(), observation_record(pose=pose))
+
+        self.assertEqual(event.payload["pose"], pose)
+
+    def test_duplicate_ids_and_entity_frames_are_rejected(self) -> None:
+        target = adapter()
+        ingest(target)
+
+        with self.assertRaisesRegex(ObservationRejected, "observation_id"):
+            ingest(target)
+        with self.assertRaisesRegex(ObservationRejected, "camera-frame"):
+            ingest(target, observation_record(observation_id="obs-002"), sequence_no=1)
+
+    def test_invalid_observations_never_reach_world_model_sink(self) -> None:
+        delivered = []
+        target = adapter(sink=delivered.append)
+
+        with self.assertRaises(ObservationRejected):
+            ingest(target, observation_record(confidence=0.1))
+
+        self.assertEqual(delivered, [])
+
+    def test_duplicate_tracking_is_bounded(self) -> None:
+        target = adapter(duplicate_window_size=1)
+        ingest(target)
+        ingest(
+            target,
+            observation_record(
+                observation_id="obs-002",
+                entity_id="blue_block",
+                evidence_refs=["frame://camera-01/002"],
+            ),
+            sequence_no=1,
+        )
+
+        event = ingest(target, sequence_no=2)
+
+        self.assertEqual(event.event_id, "observation:obs-001")
+
+    def test_adapter_configuration_rejects_unsafe_values(self) -> None:
+        with self.assertRaises(ValueError):
+            ObservationIngestionAdapter([], now=lambda _clock: NOW)
+        with self.assertRaises(ValueError):
+            adapter(minimum_confidence=float("nan"))
+        with self.assertRaises(ValueError):
+            adapter(maximum_age=timedelta(seconds=-1))
+        with self.assertRaises(ValueError):
+            adapter(duplicate_window_size=0)
+        with self.assertRaises(ValueError):
+            adapter(duplicate_window_size=1.5)
+        with self.assertRaises(ValueError):
+            ObservationIngestionAdapter([object()], now=lambda _clock: NOW)  # type: ignore[list-item]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Related Issue

Closes #72

## What changed

- add a fail-closed `ObservationIngestionAdapter` between perception producers and the World Model event stream;
- validate contract-required Observation fields using the existing Pydantic contract;
- validate camera ID, calibration revision, pose units, confidence, clock domain, timestamp and evidence references;
- reject malformed, stale, future-skewed, low-confidence, duplicate, uncalibrated and frame-mismatched observations;
- apply declared rigid calibration transforms to positions and orientations;
- preserve a detached copy of the raw Observation under `payload.raw_observation`;
- emit a contract-shaped Observation `WorldEvent` only after every boundary check succeeds;
- invoke the World Model sink only for accepted observations;
- keep duplicate tracking bounded by a configurable fixed-size window;
- document the new perception ingestion boundary;
- add an Issue #72 Task Packet plus deterministic unit and integration coverage.

## Interfaces affected
None.

- no changes to `interfaces/`;
- no changes to `libs/contracts/`;
- the adapter consumes the existing `Observation`, `Pose` and `WorldEvent` contracts;
- the adapter does not write `WorldState` facts directly.

## Tests and commands

```text
python tools/scripts/check_task_packet.py docs/task_packets/issue-72-observation-ingestion.json
PASS

python -m pytest tests/unit tests/integration -k observation -v
16 passed, 378 deselected

python -m pytest -q
460 passed

python -m ruff check services/perception/workbench_perception tests/unit/test_observation_ingestion.py tests/integration/test_observation_ingestion.py
PASS

python -m ruff format --check services/perception/workbench_perception tests/unit/test_observation_ingestion.py tests/integration/test_observation_ingestion.py
PASS

python tools/scripts/validate_contracts.py
PASS

python tools/scripts/validate_scenarios.py
PASS — 12 frozen and 24 expanded manifests

python tools/scripts/check_context.py
PASS

git diff --check
PASS
```

The Windows development environment did not provide make. The corresponding Python commands defined by the Makefile were executed directly. Repository CI should run the canonical make targets.

## Evidence

deterministic fixtures cover:- missing/dropout observations;
- contract-invalid records;
- malformed and non-finite poses;
- non-unit quaternions;
- low confidence;
- stale and future-skewed timestamps;
- clock-domain mismatch;
- unknown calibration revisions;
- pose-unit and coordinate-frame mismatch;
- duplicate IDs and duplicate entity/frame evidence;
- caller mutation after ingestion;

integration coverage proves rejected observations never reach the World Model sink;
accepted events satisfy the current WorldEvent JSON Schema;
accepted events replay through the canonical World Model reducer;
Task Packet, contract, scenario and context validation all pass.

## Risks and rollback

freshness decisions depend on the caller injecting a clock from the same declared domain as the Observation;
unknown calibration revisions and frames fail closed rather than guessing a transform;
duplicate detection uses a bounded window, so records older than the configured window may be accepted again;
no physical camera evidence is claimed by this PR;
deployment/launch packaging is outside this bounded Issue and remains Integration-owned;
rollback by reverting commit 3deda38; no schema or persistent-data migration is required.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.
