### PR TITLE
feat(linux): expose wbcan ethtool statistics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             "linux-headers-$(uname -r)" \
             linux-headers-generic \
             "linux-modules-extra-$(uname -r)" \
-            can-utils build-essential
+            can-utils ethtool build-essential
       - name: Build and check wbcan.ko
         run: |
           for headers in /usr/src/linux-headers-*-generic; do

--- a/docs/task_packets/linux-wbcan-ethtool-stats.json
+++ b/docs/task_packets/linux-wbcan-ethtool-stats.json
@@ -1,0 +1,52 @@
+{
+  "issue": "LINUX7",
+  "human_owner": "Quchaosheng",
+  "objective": "Expose the wbcan driver's software-owned CAN counters through the standard ethtool statistics interface and verify their presence and movement in the privileged test suite.",
+  "allowed_paths": [
+    "kernel/wbcan/wbcan.c",
+    "kernel/wbcan/test_wbcan.sh",
+    ".github/workflows/ci.yml",
+    "tests/unit/test_release_workflow.py",
+    "docs/task_packets/linux-wbcan-ethtool-stats.json"
+  ],
+  "read_only_paths": [
+    "firmware/**",
+    "interfaces/**",
+    "robot/control/**",
+    "hardware/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "firmware/**",
+    "interfaces/**",
+    "robot/control/**",
+    "hardware/**"
+  ],
+  "acceptance": [
+    "ethtool -S wbcan0 exposes stable tx, rx, fault and CAN error counters",
+    "ethtool counters are read under the driver's existing lock and do not invent physical hardware metrics",
+    "the privileged suite verifies all advertised fields and proves tx_frames advances after a frame",
+    "CI installs ethtool and keeps module build, checkpatch and runtime failures fail-closed",
+    "the PR is explicitly software-only and does not claim CAN FD throughput or physical latency evidence"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/linux-wbcan-ethtool-stats.json",
+    "python3 -m pytest tests/unit/test_release_workflow.py -v",
+    "make -C kernel/wbcan",
+    "make -C kernel/wbcan checkpatch",
+    "sudo make -C kernel/wbcan reload",
+    "sudo make -C kernel/wbcan test",
+    "git diff --check"
+  ],
+  "evidence": [
+    "module build and checkpatch output",
+    "ethtool -S field and counter-change assertions",
+    "privileged wbcan test report",
+    "release workflow regression output"
+  ],
+  "stop_conditions": [
+    "the target kernel lacks the documented ethtool statistics API",
+    "a physical controller, CAN FD data path or hardware performance measurement is required",
+    "firmware, interface, robot-control or hardware changes are required"
+  ]
+}

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -43,10 +43,11 @@ report_check() {
 
 need() {
 	command -v "$1" >/dev/null 2>&1 || {
-		red "missing $1 (apt-get install can-utils)"; exit 1; }
+		red "missing $1 (apt-get install can-utils ethtool)"; exit 1; }
 }
 need cansend
 need candump
+need ethtool
 need python3
 
 if ! dmesg >/dev/null 2>&1; then
@@ -168,6 +169,28 @@ check() {
 	fi
 }
 
+ethtool_stat() {
+	ethtool -S "$IFACE" 2>/dev/null |
+		awk -v key="$1" '$1 == key ":" { print $2; found = 1; exit }
+		     END { if (!found) exit 1 }'
+}
+
+ethtool_stats=$(ethtool -S "$IFACE" 2>/dev/null || true)
+if [ -n "$ethtool_stats" ]; then
+	ethtool_ready=1
+else
+	ethtool_ready=0
+fi
+check "ethtool statistics are available" "1" "$ethtool_ready"
+for ethtool_key in tx_frames rx_frames fault_candidates fault_injected bus_errors arbitration_lost restart_attempts stop_attempts; do
+	if grep -Eq "^[[:space:]]*$ethtool_key:[[:space:]]*[0-9]+$" <<<"$ethtool_stats"; then
+		stat_present=1
+	else
+		stat_present=0
+	fi
+	check "ethtool exposes $ethtool_key" "1" "$stat_present"
+done
+
 # wbcan is a module-load singleton, not an RTNL-created link kind.
 if ip link add dev wbcan-test type wbcan 2>/dev/null; then
 	check "RTNL creation is rejected for singleton wbcan" "rejected" "accepted"
@@ -199,6 +222,10 @@ clear_fault
 out=$(capture 300 & sleep 0.1; cansend "$IFACE" 123#DEADBEEF; wait)
 check "baseline delivers frame" \
       "1" "$(grep -c 'DEADBEEF' <<<"$out")"
+before_ethtool_tx=$(ethtool_stat tx_frames)
+cansend "$IFACE" 124#0102
+after_ethtool_tx=$(ethtool_stat tx_frames)
+check "ethtool tx_frames advances" "1" "$((after_ethtool_tx - before_ethtool_tx))"
 
 # SocketCAN own-message and local-loopback options must keep their standard
 # meaning even though this driver performs the echo itself.

--- a/kernel/wbcan/test_wbcan.sh
+++ b/kernel/wbcan/test_wbcan.sh
@@ -182,14 +182,18 @@ else
 	ethtool_ready=0
 fi
 check "ethtool statistics are available" "1" "$ethtool_ready"
+ethtool_fields_complete=1
+missing_ethtool_fields=""
 for ethtool_key in tx_frames rx_frames fault_candidates fault_injected bus_errors arbitration_lost restart_attempts stop_attempts; do
-	if grep -Eq "^[[:space:]]*$ethtool_key:[[:space:]]*[0-9]+$" <<<"$ethtool_stats"; then
-		stat_present=1
-	else
-		stat_present=0
+	if ! grep -Eq "^[[:space:]]*$ethtool_key:[[:space:]]*[0-9]+$" <<<"$ethtool_stats"; then
+		ethtool_fields_complete=0
+		missing_ethtool_fields="${missing_ethtool_fields}${missing_ethtool_fields:+,}$ethtool_key"
 	fi
-	check "ethtool exposes $ethtool_key" "1" "$stat_present"
 done
+check "ethtool exposes ethtool key" "1" "$ethtool_fields_complete"
+if [ "$ethtool_fields_complete" -eq 0 ]; then
+	red "missing ethtool fields: $missing_ethtool_fields"
+fi
 
 # wbcan is a module-load singleton, not an RTNL-created link kind.
 if ip link add dev wbcan-test type wbcan 2>/dev/null; then

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -635,7 +635,7 @@ static void wbcan_get_ethtool_stats(struct net_device *dev,
 static const struct ethtool_ops wbcan_ethtool_ops = {
 	.get_ts_info		= ethtool_op_get_ts_info,
 	.get_strings		= wbcan_get_strings,
-	.get_ethtool_stats = wbcan_get_ethtool_stats,
+	.get_ethtool_stats	= wbcan_get_ethtool_stats,
 	.get_sset_count		= wbcan_get_sset_count,
 };
 

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -614,7 +614,7 @@ static void wbcan_get_strings(struct net_device *dev, u32 stringset, u8 *data)
 }
 
 static void wbcan_get_ethtool_stats(struct net_device *dev,
-					struct ethtool_stats *stats, u64 *data)
+				    struct ethtool_stats *stats, u64 *data)
 {
 	struct wbcan_priv *priv = netdev_priv(dev);
 	unsigned long flags;

--- a/kernel/wbcan/wbcan.c
+++ b/kernel/wbcan/wbcan.c
@@ -44,6 +44,29 @@
 
 #define WBCAN_ECHO_SKB_MAX	4
 
+enum wbcan_ethtool_stat_index {
+	WBCAN_ETHTOOL_TX_FRAMES,
+	WBCAN_ETHTOOL_RX_FRAMES,
+	WBCAN_ETHTOOL_FAULT_CANDIDATES,
+	WBCAN_ETHTOOL_FAULT_INJECTED,
+	WBCAN_ETHTOOL_BUS_ERRORS,
+	WBCAN_ETHTOOL_ARBITRATION_LOST,
+	WBCAN_ETHTOOL_RESTART_ATTEMPTS,
+	WBCAN_ETHTOOL_STOP_ATTEMPTS,
+	WBCAN_ETHTOOL_STAT_COUNT,
+};
+
+static const char *const wbcan_ethtool_stat_names[WBCAN_ETHTOOL_STAT_COUNT] = {
+	[WBCAN_ETHTOOL_TX_FRAMES]		= "tx_frames",
+	[WBCAN_ETHTOOL_RX_FRAMES]		= "rx_frames",
+	[WBCAN_ETHTOOL_FAULT_CANDIDATES]	= "fault_candidates",
+	[WBCAN_ETHTOOL_FAULT_INJECTED]	= "fault_injected",
+	[WBCAN_ETHTOOL_BUS_ERRORS]		= "bus_errors",
+	[WBCAN_ETHTOOL_ARBITRATION_LOST]	= "arbitration_lost",
+	[WBCAN_ETHTOOL_RESTART_ATTEMPTS]	= "restart_attempts",
+	[WBCAN_ETHTOOL_STOP_ATTEMPTS]	= "stop_attempts",
+};
+
 /* Fault modes. Values are the debugfs ABI; do not renumber. */
 enum wbcan_fault {
 	WBCAN_FAULT_NONE	= 0,
@@ -572,8 +595,48 @@ static const struct net_device_ops wbcan_netdev_ops = {
 	.ndo_get_stats64	= wbcan_get_stats64,
 };
 
+static int wbcan_get_sset_count(struct net_device *dev, int stringset)
+{
+	if (stringset == ETH_SS_STATS)
+		return WBCAN_ETHTOOL_STAT_COUNT;
+	return -EOPNOTSUPP;
+}
+
+static void wbcan_get_strings(struct net_device *dev, u32 stringset, u8 *data)
+{
+	unsigned int index;
+
+	if (stringset != ETH_SS_STATS)
+		return;
+	for (index = 0; index < WBCAN_ETHTOOL_STAT_COUNT; index++)
+		strscpy(data + index * ETH_GSTRING_LEN,
+			wbcan_ethtool_stat_names[index], ETH_GSTRING_LEN);
+}
+
+static void wbcan_get_ethtool_stats(struct net_device *dev,
+					struct ethtool_stats *stats, u64 *data)
+{
+	struct wbcan_priv *priv = netdev_priv(dev);
+	unsigned long flags;
+
+	spin_lock_irqsave(&priv->lock, flags);
+	data[WBCAN_ETHTOOL_TX_FRAMES] = priv->stat_tx;
+	data[WBCAN_ETHTOOL_RX_FRAMES] = priv->stat_rx;
+	data[WBCAN_ETHTOOL_FAULT_CANDIDATES] = priv->stat_seen;
+	data[WBCAN_ETHTOOL_FAULT_INJECTED] = priv->stat_injected;
+	data[WBCAN_ETHTOOL_BUS_ERRORS] = priv->can.can_stats.bus_error;
+	data[WBCAN_ETHTOOL_ARBITRATION_LOST] =
+		priv->can.can_stats.arbitration_lost;
+	data[WBCAN_ETHTOOL_RESTART_ATTEMPTS] = priv->stat_restart_attempts;
+	data[WBCAN_ETHTOOL_STOP_ATTEMPTS] = priv->stat_stop_attempts;
+	spin_unlock_irqrestore(&priv->lock, flags);
+}
+
 static const struct ethtool_ops wbcan_ethtool_ops = {
-	.get_ts_info	= ethtool_op_get_ts_info,
+	.get_ts_info		= ethtool_op_get_ts_info,
+	.get_strings		= wbcan_get_strings,
+	.get_ethtool_stats = wbcan_get_ethtool_stats,
+	.get_sset_count		= wbcan_get_sset_count,
 };
 
 /* --------------------------------------------------------------- debugfs ABI

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -79,6 +79,29 @@ def test_kernel_module_builds_against_lts_and_runner_headers() -> None:
     assert "make -C kernel/wbcan checkpatch" in build_step
 
 
+def test_kernel_fault_suite_covers_ethtool_statistics() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    kernel_source = (ROOT / "kernel" / "wbcan" / "wbcan.c").read_text(encoding="utf-8")
+    fault_suite = (ROOT / "kernel" / "wbcan" / "test_wbcan.sh").read_text(encoding="utf-8")
+    kernel_job = workflow.split("  kernel-module:", maxsplit=1)[1].split("\n  mcu-qemu:", maxsplit=1)[0]
+
+    assert "can-utils ethtool build-essential" in kernel_job
+    assert "get_ethtool_stats" in kernel_source
+    assert "get_sset_count" in kernel_source
+    for name in (
+        "tx_frames",
+        "rx_frames",
+        "fault_candidates",
+        "fault_injected",
+        "bus_errors",
+        "arbitration_lost",
+        "restart_attempts",
+        "stop_attempts",
+    ):
+        assert f'"{name}"' in kernel_source
+    assert "ethtool tx_frames advances" in fault_suite
+
+
 def test_kernel_module_unload_verifies_singleton_cleanup() -> None:
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     load_step = _step_block(workflow, "name: Load the module and bring the interface up")


### PR DESCRIPTION
## Summary

Expose software-owned wbcan driver counters through the standard ethtool statistics interface.

## Changes

- Add `ethtool -S wbcan0` support to the wbcan SocketCAN test device.
- Expose TX/RX, fault, CAN error, restart and stop counters.
- Read counters under the driver's existing synchronization boundary.
- Extend the privileged wbcan test suite to verify all statistic fields and confirm that `tx_frames` advances after transmission.
- Install `ethtool` in the kernel-module CI job.
- Add workflow regression coverage and the LINUX7 Task Packet.

## Evidence Boundary

These counters describe the software test device only. This PR does not claim physical CAN FD throughput, bus timing, hardware latency or real-board performance validation.

## Validation

- 6 release workflow tests passed
- Bash syntax check passed
- Python syntax check passed
- Task Packet JSON syntax passed
- `git diff --check` passed

Kernel module build, checkpatch and privileged runtime tests are delegated to the Ubuntu GitHub Actions runner.

## Related Issue

## What changed

## Interfaces affected

## Tests and commands

## Evidence

## Risks and rollback

## Checklist

- [ ] I changed only approved paths.
- [ ] Tests and contract checks pass.
- [ ] I covered normal and failure behavior.
- [ ] I updated examples/docs when an interface changed.
- [ ] I did not add secrets, private data or unreviewed assets.
