### PR TITLE
feat(agent): implement the A5 policy validator from the immutable tool registry

### DIFF
--- a/docs/task_packets/issue-58-a5-policy-validator.json
+++ b/docs/task_packets/issue-58-a5-policy-validator.json
@@ -1,0 +1,86 @@
+{
+  "issue": 58,
+  "human_owner": "kukuboring",
+  "objective": "Complete the remaining A5 policy-validator scope after Issue #118/#119: fail closed on missing or invalid policy configuration, reject disguised raw-control parameters, require per-action confirmation for configured high-impact semantic actions, and emit immutable structured decisions carrying an auditable policy version while continuing to use ToolRegistry as the only action and parameter allow-list.",
+  "allowed_paths": [
+    "docs/task_packets/issue-58-a5-policy-validator.json",
+    "services/agent_runtime/workbench_agent_runtime/policy_validator.py",
+    "tests/unit/test_policy_validator.py"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "docs/architecture/system.md",
+    "docs/task_packets/example-001-world-reducer.json",
+    "docs/task_packets/agent-a5-policy-validator.json",
+    "interfaces/json_schema/semantic_action.schema.json",
+    "interfaces/json_schema/task_graph.schema.json",
+    "interfaces/examples/semantic-action-place.json",
+    "interfaces/examples/task-graph-place.json",
+    "libs/contracts/**",
+    "services/agent_runtime/workbench_agent_runtime/__init__.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_registry.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_schemas.py",
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "services/agent_runtime/workbench_agent_runtime/local_model.py",
+    "tests/unit/test_tool_registry.py",
+    "tools/scripts/check_task_packet.py",
+    "Makefile",
+    "pyproject.toml"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "services/world_model/**",
+    "services/backend/**",
+    "services/perception/**",
+    "sim/**",
+    "hardware/**",
+    "deploy/**",
+    ".github/**"
+  ],
+  "acceptance": [
+    "A valid explicit in-memory policy configuration contains a non-blank policy version and a bounded set of high-impact ActionType values; PolicyValidator with missing, malformed, or unknown-action configuration fails closed with stable structured reason codes. Tests: test_missing_policy_config_fails_closed, test_blank_policy_version_fails_closed, test_unknown_high_impact_action_fails_closed, and test_malformed_policy_config_fails_closed.",
+    "For a registry-valid non-high-impact action, check returns an immutable structured allow decision containing step_id, action_id, outcome, stable reason code, and the configured policy_version. The SemanticAction and TaskGraph model dumps are byte-for-byte equal before and after checking. Test: test_safe_action_is_allowed_with_versioned_structured_reason_without_mutation.",
+    "ToolRegistry remains the only action and parameter field allow-list: registry validation errors become structured deny decisions, an unregistered action is denied, and a custom injected registry schema change is immediately honored without editing policy-validator field lists. Tests: test_unknown_action_is_denied_structurally and test_injected_registry_change_propagates_without_second_allowlist.",
+    "The policy recursively rejects raw joint, velocity, torque, or firmware parameter identifiers found in nested mappings/lists or serialized key-value strings, including spaced or slash-delimited keys, compact uppercase identifiers, and JSON-escaped keys otherwise accepted by an injected ToolRegistry. Non-string mapping keys and bounded traversal-limit violations fail closed with policy_input_malformed rather than raising. Matching remains limited to parameter-like identifiers or key-value syntax so ordinary explanatory prose, including colon headings, is not rejected merely for mentioning a word. Tests: test_nested_raw_control_identifiers_are_denied, test_disguised_raw_control_identifiers_are_denied, test_non_string_mapping_key_fails_closed, test_excessive_payload_nesting_fails_closed_structurally, and test_plain_prose_is_not_misclassified_as_a_raw_parameter.",
+    "Each configured high-impact semantic action requires confirmation for that exact action_id. Missing confirmation returns confirmation_required, confirmation for a different action_id does not authorize it, malformed confirmation collections fail closed with confirmation_input_malformed, and confirmation for the matching action_id allows it only if ToolRegistry and raw-control checks also pass. Tests: test_high_impact_action_requires_confirmation, test_confirmation_is_scoped_to_exact_action_id, test_malformed_confirmation_ids_fail_closed_without_substring_matching, and test_matching_confirmation_allows_registry_valid_high_impact_action.",
+    "PolicyReport is valid only when every per-step outcome is allow; enforce raises PolicyViolation for both deny and confirmation_required outcomes and preserves structured location and reason information. Existing aggregation and fail-closed tests remain green after being migrated to explicit valid configuration. Tests: test_enforce_rejects_deny_and_confirmation_required and the existing policy-validator suite.",
+    "A policy allow decision is authorization evidence only. The module does not dispatch actions, obtain or persist operator confirmation, emit ActionResult or VerificationResult, write WorldState, or claim execution/completion. Test: test_policy_output_is_authorization_only.",
+    "All focused and repository-required checks pass, and the Git-visible diff relative to fixed base 19a24dc45293deb34425b8508afe7b3342c84e27 contains only the three allowed paths."
+  ],
+  "commands": [
+    "python3 -m pytest tests/unit/test_policy_validator.py -v",
+    "python3 -m pytest tests/unit -k policy_validator -v",
+    "python3 -m pytest tests/unit/test_tool_registry.py -v",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "make check",
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-58-a5-policy-validator.json --base 19a24dc45293deb34425b8508afe7b3342c84e27"
+  ],
+  "evidence": [
+    "Pre-implementation baseline output showing 92 existing policy-validator and ToolRegistry tests pass while a serialized joint_velocity payload and an unconfirmed PLACE both produce is_valid=True, PolicyReport exposes only findings, and PolicyValidator accepts no policy configuration.",
+    "Focused red-test output proving the new tests fail before implementation because versioned decisions, explicit configuration, nested raw-control scanning, and per-action confirmation are absent.",
+    "Focused green-test output for every allow, deny, confirmation-required, malformed-config, unknown-action, non-mutation, and registry-propagation behavior named in acceptance.",
+    "Review-remediation red evidence: the focused five-test command produced 12 failures against the pre-fix implementation, reproducing confirmation substring/list acceptance, four disguised raw-control bypasses, non-string-key fail-open, RecursionError, and two colon-prose false positives.",
+    "Review-remediation green evidence: the same focused five-test command passed with 5 passed, 44 deselected, and 11 subtests passed after the bounded fixes.",
+    "Captured structured PolicyReport examples for allow, deny, and confirmation_required outcomes showing stable reason codes and the configured policy_version.",
+    "Before-and-after TaskGraph and SemanticAction model_dump equality from the non-mutation regression.",
+    "Injected-registry regression showing the policy follows a registry schema change while the nested raw-control guard remains non-bypassable.",
+    "Review-remediation full-gate evidence: make test and make check each completed with 897 passed, 1 skipped, and 280 subtests passed; Ruff check/format, contract validation, scenario validation for 12 frozen and 24 expanded manifests, golden-set validation, context validation, demo_scripted, and local_runner all passed.",
+    "Review-remediation boundary evidence: Task Packet validation passed against fixed base 19a24dc45293deb34425b8508afe7b3342c84e27; git diff --check passed; the final Git-visible paths are only policy_validator.py, test_policy_validator.py, and this Task Packet."
+  ],
+  "stop_conditions": [
+    "Implementation requires changing interfaces, libs/contracts, ToolRegistry, tool_schemas, planner, local_model, package exports, another Agent Runtime module, or any path outside allowed_paths.",
+    "Implementation requires adding a second action or parameter field allow-list instead of consuming the injected ToolRegistry.",
+    "Implementing confirmation requires asking the operator, persisting confirmation, changing TaskGraph or SemanticAction contracts, or wiring the execution controller; those responsibilities belong to Issue #59 or require a separately approved cross-module Task Packet.",
+    "The confirmation design would authorize all actions of a type instead of an explicitly confirmed action_id, or would treat the mere presence of ASK_CONFIRM as proof that confirmation was granted.",
+    "The raw-control guard cannot reject nested parameter-like joint, velocity, torque, and firmware identifiers without broadly rejecting ordinary prose or mutating input payloads.",
+    "The policy layer would dispatch Motion, emit ActionResult or VerificationResult, write WorldState, or claim execution or completion evidence.",
+    "Any interfaces, multiple-module, robot/control, firmware, safety-configuration, deployment, CI, simulation, hardware, Backend, Perception, or World Model change becomes necessary.",
+    "The fixed base 19a24dc45293deb34425b8508afe7b3342c84e27 is no longer the intended branch boundary, the worktree contains overlapping user changes, or the ownership delegation is withdrawn or disputed.",
+    "A required command fails for a reason that cannot be fixed within allowed_paths without changing the approved behavior."
+  ]
+}

--- a/services/agent_runtime/workbench_agent_runtime/policy_validator.py
+++ b/services/agent_runtime/workbench_agent_runtime/policy_validator.py
@@ -1,46 +1,65 @@
-"""Language-layer policy validator: exact field-set whitelist, fail-closed.
+"""Fail-closed authorization policy for typed semantic actions.
 
-A5 validates the ``TaskGraph`` produced from a natural-language goal against the
-tool whitelist before anything reaches Motion / the MCU.  It reads
-``required_params`` / ``optional_params`` / ``param_types`` from
-:class:`~workbench_agent_runtime.tool_registry.ToolRegistry` — the single source
-of truth — and enforces **exact field-set equality**: every required key must be
-present, and no key outside the allow-list may appear.
+``ToolRegistry`` is the only action and parameter-field allow-list.  This
+module consumes its validation result, then applies two independent policy
+rules: raw-control identifiers are forbidden even inside registry-accepted
+nested payloads, and configured high-impact actions require confirmation for
+the exact ``action_id``.
 
-``bool`` is checked *before* ``int`` / ``float`` because ``isinstance(True, int)``
-is ``True`` in Python; without that ordering a ``duration_ms=True`` would pass
-an integer slot as ``1``.
-
-Three rules this module obeys and never crosses:
-
-1. **The model never touches joints.**  Only the six semantic actions
-   (``observe``/``grasp``/``place``/``ask_confirm``/``express``/``stop``) are
-   valid; any joint/firmware field is an allow-list violation and is rejected.
-2. **Completion is judged only by the world-model verifier.**  This module never
-   constructs a ``VerificationResult`` and never declares a task done.
-3. **Success claims carry evidence.**  Out of scope here.
+The output is immutable authorization evidence.  It never dispatches an
+action, obtains or stores confirmation, emits execution or verification
+results, writes WorldState, or claims completion.
 """
 
 from __future__ import annotations
 
+import json
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
 
-from workbench_contracts import TaskGraph, TaskStep
+from workbench_contracts import ActionType, TaskGraph, TaskStep
 
 from .tool_registry import ToolRegistry
 
-# ---------------------------------------------------------------------------
-# public types
-# ---------------------------------------------------------------------------
+_POLICY_CONFIG_KEYS = frozenset({"policy_version", "high_impact_actions"})
+_RAW_CONTROL_TOKENS = frozenset({"joint", "velocity", "torque", "firmware"})
+_PARAMETER_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_.\-\[\]]*$")
+_SERIALIZED_KEY = re.compile(r"(?<![A-Za-z0-9_.\-\]])([A-Za-z_][A-Za-z0-9_.\-\[\]]*)(?:(?:\s*=\s*)|:)(?=\S)")
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_MAX_SCAN_DEPTH = 64
+_MAX_SCAN_NODES = 10_000
+_CONFIG_SNAPSHOT_FAILED = object()
 
 
-class PolicyViolation(RuntimeError):
-    """A TaskGraph or action violates the tool whitelist (fail-closed)."""
+class PolicyOutcome(StrEnum):
+    """Authorization outcome for one TaskGraph step."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    CONFIRMATION_REQUIRED = "confirmation_required"
+
+
+class PolicyReasonCode(StrEnum):
+    """Stable, machine-readable reasons for policy outcomes."""
+
+    POLICY_ALLOWED = "policy_allowed"
+    POLICY_CONFIG_MISSING = "policy_config_missing"
+    POLICY_VERSION_BLANK = "policy_version_blank"
+    POLICY_CONFIG_UNKNOWN_ACTION = "policy_config_unknown_action"
+    POLICY_CONFIG_MALFORMED = "policy_config_malformed"
+    CONFIRMATION_INPUT_MALFORMED = "confirmation_input_malformed"
+    TOOL_REGISTRY_DENIED = "tool_registry_denied"
+    RAW_CONTROL_PARAMETER = "raw_control_parameter"
+    POLICY_INPUT_MALFORMED = "policy_input_malformed"
+    ACTION_CONFIRMATION_REQUIRED = "action_confirmation_required"
 
 
 @dataclass(frozen=True)
 class PolicyFinding:
-    """One whitelist violation, located to a step and field."""
+    """One policy detail, located to a step and field."""
 
     step_id: str
     action_id: str
@@ -49,65 +68,417 @@ class PolicyFinding:
 
 
 @dataclass(frozen=True)
-class PolicyReport:
-    """Aggregated whitelist result for a TaskGraph."""
+class PolicyDecision:
+    """Immutable authorization decision for exactly one TaskGraph step."""
 
-    findings: tuple[PolicyFinding, ...]
+    step_id: str
+    action_id: str
+    outcome: PolicyOutcome
+    reason_code: PolicyReasonCode
+    policy_version: str | None
+    findings: tuple[PolicyFinding, ...] = ()
+
+
+@dataclass(frozen=True)
+class PolicyReport:
+    """Immutable collection of per-step authorization decisions."""
+
+    decisions: tuple[PolicyDecision, ...]
+
+    @property
+    def findings(self) -> tuple[PolicyFinding, ...]:
+        """Flattened compatibility view of details from denied decisions."""
+        return tuple(finding for decision in self.decisions for finding in decision.findings)
 
     @property
     def is_valid(self) -> bool:
-        return not self.findings
+        return all(decision.outcome is PolicyOutcome.ALLOW for decision in self.decisions)
 
 
-# ---------------------------------------------------------------------------
-# validator
-# ---------------------------------------------------------------------------
+class PolicyViolation(RuntimeError):
+    """Raised when a TaskGraph contains a non-allow policy decision."""
+
+    def __init__(self, report: PolicyReport) -> None:
+        self.report = report
+        super().__init__(_format_decisions(report.decisions))
+
+
+@dataclass(frozen=True)
+class _PolicyConfigState:
+    policy_version: str | None
+    high_impact_actions: frozenset[ActionType]
+    error_code: PolicyReasonCode | None = None
+    error_field: str = ""
+    error_message: str = ""
+
+
+class _PolicyInputMalformed(ValueError):
+    """Internal signal converted into a structured fail-closed decision."""
+
+    def __init__(self, field: str, message: str) -> None:
+        self.field = field
+        self.message = message
+        super().__init__(message)
 
 
 class PolicyValidator:
-    """Validate TaskGraphs against the tool whitelist with fail-closed semantics.
+    """Authorize TaskGraphs against explicit policy and an injected registry.
 
-    The whitelist data lives in :class:`ToolRegistry`; this module holds no
-    second copy of the field list.  Two entry points:
+    ``policy_config`` must be an in-memory mapping with exactly two keys:
+    ``policy_version`` is a non-blank string and ``high_impact_actions`` is a
+    ``frozenset`` of ActionType values registered in the injected registry.
 
-    * :meth:`check` returns a :class:`PolicyReport` (inspection, never raises).
-    * :meth:`enforce` raises :class:`PolicyViolation` on the first invalid graph.
+    Confirmation is supplied per call as a set of confirmed action IDs.  It is
+    consumed only for the current check and is never obtained or persisted here.
     """
 
-    def __init__(self, registry: ToolRegistry | None = None) -> None:
+    def __init__(self, registry: ToolRegistry | None = None, *, policy_config: object = None) -> None:
         self._registry = registry if registry is not None else ToolRegistry()
+        self._policy_config = _snapshot_policy_config(policy_config)
 
-    # -- public API ----------------------------------------------------------
+    def check(
+        self,
+        graph: TaskGraph,
+        *,
+        confirmed_action_ids: frozenset[str] = frozenset(),
+    ) -> PolicyReport:
+        """Return one immutable structured authorization decision per step."""
+        config = _validate_policy_config(self._policy_config, self._registry)
+        if config.error_code is not None:
+            return PolicyReport(tuple(_config_error_decision(step, config) for step in graph.steps))
 
-    def check(self, graph: TaskGraph) -> PolicyReport:
-        """Return every whitelist violation across all steps (never raises)."""
-        findings: list[PolicyFinding] = []
-        for step in graph.steps:
-            findings.extend(self._check_step(step))
-        return PolicyReport(tuple(findings))
+        confirmed_ids = _snapshot_confirmed_action_ids(confirmed_action_ids)
+        if confirmed_ids is None:
+            return PolicyReport(tuple(_malformed_confirmation_decision(step, config) for step in graph.steps))
 
-    def enforce(self, graph: TaskGraph) -> None:
-        """Fail-closed: raise :class:`PolicyViolation` if any step is invalid."""
-        report = self.check(graph)
+        decisions = tuple(self._check_step(step, config, confirmed_ids) for step in graph.steps)
+        return PolicyReport(decisions)
+
+    def enforce(
+        self,
+        graph: TaskGraph,
+        *,
+        confirmed_action_ids: frozenset[str] = frozenset(),
+    ) -> None:
+        """Raise PolicyViolation for deny and confirmation-required outcomes."""
+        report = self.check(graph, confirmed_action_ids=confirmed_action_ids)
         if not report.is_valid:
-            raise PolicyViolation(_format_findings(report.findings))
+            raise PolicyViolation(report)
 
-    # -- internals -----------------------------------------------------------
-
-    def _check_step(self, step: TaskStep) -> list[PolicyFinding]:
+    def _check_step(
+        self,
+        step: TaskStep,
+        config: _PolicyConfigState,
+        confirmed_action_ids: frozenset[str],
+    ) -> PolicyDecision:
         action = step.action
-        result = self._registry.validate(action)
-        return [PolicyFinding(step.step_id, action.action_id, error.field, error.message) for error in result.errors]
+        registry_result = self._registry.validate(action)
+        if not registry_result.is_valid:
+            findings = tuple(
+                PolicyFinding(step.step_id, action.action_id, error.field, error.message)
+                for error in registry_result.errors
+            )
+            return PolicyDecision(
+                step_id=step.step_id,
+                action_id=action.action_id,
+                outcome=PolicyOutcome.DENY,
+                reason_code=PolicyReasonCode.TOOL_REGISTRY_DENIED,
+                policy_version=config.policy_version,
+                findings=findings,
+            )
+
+        try:
+            raw_identifiers = _find_raw_control_identifiers(action.parameters)
+        except _PolicyInputMalformed as error:
+            finding = PolicyFinding(
+                step.step_id,
+                action.action_id,
+                error.field,
+                error.message,
+            )
+            return PolicyDecision(
+                step_id=step.step_id,
+                action_id=action.action_id,
+                outcome=PolicyOutcome.DENY,
+                reason_code=PolicyReasonCode.POLICY_INPUT_MALFORMED,
+                policy_version=config.policy_version,
+                findings=(finding,),
+            )
+        if raw_identifiers:
+            findings = tuple(
+                PolicyFinding(
+                    step.step_id,
+                    action.action_id,
+                    field,
+                    f"raw-control parameter identifier '{identifier}' is forbidden",
+                )
+                for field, identifier in raw_identifiers
+            )
+            return PolicyDecision(
+                step_id=step.step_id,
+                action_id=action.action_id,
+                outcome=PolicyOutcome.DENY,
+                reason_code=PolicyReasonCode.RAW_CONTROL_PARAMETER,
+                policy_version=config.policy_version,
+                findings=findings,
+            )
+
+        if action.action_type in config.high_impact_actions and action.action_id not in confirmed_action_ids:
+            finding = PolicyFinding(
+                step.step_id,
+                action.action_id,
+                "confirmation",
+                f"high-impact action '{action.action_id}' requires confirmation for this exact action_id",
+            )
+            return PolicyDecision(
+                step_id=step.step_id,
+                action_id=action.action_id,
+                outcome=PolicyOutcome.CONFIRMATION_REQUIRED,
+                reason_code=PolicyReasonCode.ACTION_CONFIRMATION_REQUIRED,
+                policy_version=config.policy_version,
+                findings=(finding,),
+            )
+
+        return PolicyDecision(
+            step_id=step.step_id,
+            action_id=action.action_id,
+            outcome=PolicyOutcome.ALLOW,
+            reason_code=PolicyReasonCode.POLICY_ALLOWED,
+            policy_version=config.policy_version,
+        )
 
 
-# ---------------------------------------------------------------------------
-# helpers
-# ---------------------------------------------------------------------------
+def _snapshot_confirmed_action_ids(value: object) -> frozenset[str] | None:
+    if not isinstance(value, set | frozenset):
+        return None
+    try:
+        snapshot = frozenset(value)
+    except Exception:  # noqa: BLE001 - malformed injected confirmation input must fail closed
+        return None
+    if any(not isinstance(action_id, str) or not action_id.strip() for action_id in snapshot):
+        return None
+    return snapshot
 
 
-def _format_findings(findings: tuple[PolicyFinding, ...]) -> str:
-    lines = []
-    for finding in findings:
-        loc = f"step '{finding.step_id}'" if finding.step_id else "step '(unknown)'"
-        lines.append(f"{loc} action '{finding.action_id}': {finding.field}: {finding.message}")
-    return "TaskGraph violates tool whitelist:\n" + "\n".join(lines)
+def _snapshot_policy_config(policy_config: object) -> object:
+    if not isinstance(policy_config, Mapping):
+        return policy_config
+    try:
+        return MappingProxyType(dict(policy_config))
+    except Exception:  # noqa: BLE001 - malformed injected mappings must fail closed during check
+        return _CONFIG_SNAPSHOT_FAILED
+
+
+def _validate_policy_config(policy_config: object, registry: ToolRegistry) -> _PolicyConfigState:
+    if policy_config is None:
+        return _config_error(
+            PolicyReasonCode.POLICY_CONFIG_MISSING,
+            "policy_config",
+            "explicit policy configuration is required",
+        )
+    if policy_config is _CONFIG_SNAPSHOT_FAILED or not isinstance(policy_config, Mapping):
+        return _config_error(
+            PolicyReasonCode.POLICY_CONFIG_MALFORMED,
+            "policy_config",
+            "policy configuration must be a mapping",
+        )
+
+    if set(policy_config) != _POLICY_CONFIG_KEYS:
+        return _config_error(
+            PolicyReasonCode.POLICY_CONFIG_MALFORMED,
+            "policy_config",
+            f"policy configuration keys must be exactly {sorted(_POLICY_CONFIG_KEYS)}",
+        )
+
+    policy_version = policy_config["policy_version"]
+    if not isinstance(policy_version, str):
+        return _config_error(
+            PolicyReasonCode.POLICY_CONFIG_MALFORMED,
+            "policy_config.policy_version",
+            "policy_version must be a string",
+        )
+    if not policy_version.strip():
+        return _config_error(
+            PolicyReasonCode.POLICY_VERSION_BLANK,
+            "policy_config.policy_version",
+            "policy_version must be non-blank",
+        )
+
+    high_impact_actions = policy_config["high_impact_actions"]
+    if not isinstance(high_impact_actions, frozenset):
+        return _config_error(
+            PolicyReasonCode.POLICY_CONFIG_MALFORMED,
+            "policy_config.high_impact_actions",
+            "high_impact_actions must be a frozenset",
+            policy_version=policy_version,
+        )
+
+    registered_actions = frozenset(registry.list_all())
+    unknown_actions = tuple(
+        action
+        for action in high_impact_actions
+        if not isinstance(action, ActionType) or action not in registered_actions
+    )
+    if unknown_actions:
+        labels = sorted(action.value if isinstance(action, ActionType) else repr(action) for action in unknown_actions)
+        return _config_error(
+            PolicyReasonCode.POLICY_CONFIG_UNKNOWN_ACTION,
+            "policy_config.high_impact_actions",
+            f"high_impact_actions contains unknown actions: {labels}",
+            policy_version=policy_version,
+        )
+
+    return _PolicyConfigState(
+        policy_version=policy_version,
+        high_impact_actions=high_impact_actions,
+    )
+
+
+def _config_error(
+    reason_code: PolicyReasonCode,
+    field: str,
+    message: str,
+    *,
+    policy_version: str | None = None,
+) -> _PolicyConfigState:
+    return _PolicyConfigState(
+        policy_version=policy_version,
+        high_impact_actions=frozenset(),
+        error_code=reason_code,
+        error_field=field,
+        error_message=message,
+    )
+
+
+def _config_error_decision(step: TaskStep, config: _PolicyConfigState) -> PolicyDecision:
+    finding = PolicyFinding(
+        step.step_id,
+        step.action.action_id,
+        config.error_field,
+        config.error_message,
+    )
+    return PolicyDecision(
+        step_id=step.step_id,
+        action_id=step.action.action_id,
+        outcome=PolicyOutcome.DENY,
+        reason_code=config.error_code,
+        policy_version=config.policy_version,
+        findings=(finding,),
+    )
+
+
+def _malformed_confirmation_decision(
+    step: TaskStep,
+    config: _PolicyConfigState,
+) -> PolicyDecision:
+    finding = PolicyFinding(
+        step.step_id,
+        step.action.action_id,
+        "confirmed_action_ids",
+        "confirmed_action_ids must be a set or frozenset of non-blank strings",
+    )
+    return PolicyDecision(
+        step_id=step.step_id,
+        action_id=step.action.action_id,
+        outcome=PolicyOutcome.DENY,
+        reason_code=PolicyReasonCode.CONFIRMATION_INPUT_MALFORMED,
+        policy_version=config.policy_version,
+        findings=(finding,),
+    )
+
+
+def _find_raw_control_identifiers(value: object) -> tuple[tuple[str, str], ...]:
+    findings: list[tuple[str, str]] = []
+    seen: set[int] = set()
+    stack: list[tuple[object, str, int]] = [(value, "parameters", 0)]
+    scanned_nodes = 0
+
+    while stack:
+        item, path, depth = stack.pop()
+        scanned_nodes += 1
+        if depth > _MAX_SCAN_DEPTH or scanned_nodes > _MAX_SCAN_NODES:
+            raise _PolicyInputMalformed(
+                path,
+                f"raw-control scan limit exceeded (max_depth={_MAX_SCAN_DEPTH}, max_nodes={_MAX_SCAN_NODES})",
+            )
+
+        if isinstance(item, str):
+            if _PARAMETER_IDENTIFIER.fullmatch(item) and _contains_raw_control_token(item):
+                findings.append((path, item))
+            for match in _SERIALIZED_KEY.finditer(item):
+                identifier = match.group(1)
+                if _contains_raw_control_token(identifier):
+                    findings.append((path, identifier))
+            decoded = _decode_serialized_container(item, path)
+            if decoded is not None:
+                stack.append((decoded, path, depth + 1))
+            continue
+
+        if isinstance(item, Mapping):
+            marker = id(item)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            try:
+                entries = tuple(item.items())
+            except Exception as error:
+                raise _PolicyInputMalformed(path, "policy input mapping could not be inspected") from error
+            for key, child in reversed(entries):
+                if not isinstance(key, str):
+                    raise _PolicyInputMalformed(
+                        path,
+                        "policy input mapping keys must be strings",
+                    )
+                child_path = f"{path}.{key}" if _PARAMETER_IDENTIFIER.fullmatch(key) else f"{path}[{key!r}]"
+                if _contains_raw_control_token(key):
+                    findings.append((child_path, key))
+                stack.append((child, child_path, depth + 1))
+            continue
+
+        if isinstance(item, list | tuple):
+            marker = id(item)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            for index in range(len(item) - 1, -1, -1):
+                stack.append((item[index], f"{path}[{index}]", depth + 1))
+
+    return tuple(findings)
+
+
+def _decode_serialized_container(value: str, path: str) -> object | None:
+    stripped = value.strip()
+    if not stripped.startswith(("{", "[")):
+        return None
+    try:
+        decoded = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    except (RecursionError, ValueError) as error:
+        raise _PolicyInputMalformed(path, "raw-control scan limit exceeded while decoding JSON") from error
+    if isinstance(decoded, Mapping | list | tuple):
+        return decoded
+    return None
+
+
+def _contains_raw_control_token(identifier: str) -> bool:
+    separated = _CAMEL_BOUNDARY.sub("_", identifier)
+    tokens = {token.casefold() for token in re.split(r"[^A-Za-z0-9]+", separated) if token}
+    if tokens & _RAW_CONTROL_TOKENS:
+        return True
+    compact = re.sub(r"[^A-Za-z0-9]+", "", separated).casefold()
+    return any(compact.startswith(token) or compact.endswith(token) for token in _RAW_CONTROL_TOKENS)
+
+
+def _format_decisions(decisions: tuple[PolicyDecision, ...]) -> str:
+    lines: list[str] = []
+    for decision in decisions:
+        if decision.outcome is PolicyOutcome.ALLOW:
+            continue
+        details = "; ".join(f"{finding.field}: {finding.message}" for finding in decision.findings)
+        lines.append(
+            f"step '{decision.step_id}' action '{decision.action_id}': "
+            f"outcome={decision.outcome.value} reason_code={decision.reason_code.value} "
+            f"policy_version={decision.policy_version!r}: {details}"
+        )
+    return "TaskGraph violates policy:\n" + "\n".join(lines)

--- a/tests/unit/test_policy_validator.py
+++ b/tests/unit/test_policy_validator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -27,6 +28,7 @@ from workbench_agent_runtime.policy_validator import (
     PolicyViolation,
 )
 from workbench_agent_runtime.tool_registry import ToolRegistry
+from workbench_agent_runtime.tool_schemas import TOOL_SCHEMAS
 from workbench_contracts import ActionType, SemanticAction, TaskGraph, TaskStep
 
 # ---------------------------------------------------------------------------
@@ -54,6 +56,36 @@ def _graph(*actions: SemanticAction) -> TaskGraph:
     return TaskGraph(task_id="task-test", goal="test", steps=steps, planner="test", model_route="template")
 
 
+POLICY_VERSION = "test-policy-v1"
+
+
+def _policy_config(*, high_impact_actions: frozenset[ActionType] = frozenset()) -> dict[str, object]:
+    return {
+        "policy_version": POLICY_VERSION,
+        "high_impact_actions": high_impact_actions,
+    }
+
+
+def _validator(
+    registry: ToolRegistry | None = None,
+    *,
+    high_impact_actions: frozenset[ActionType] = frozenset(),
+) -> PolicyValidator:
+    return PolicyValidator(
+        registry=registry,
+        policy_config=_policy_config(high_impact_actions=high_impact_actions),
+    )
+
+
+def _registry_with_stop_parameter(name: str, parameter_type: type) -> ToolRegistry:
+    schema = dict(TOOL_SCHEMAS[ActionType.STOP])
+    schema["optional_params"] = schema["optional_params"] | frozenset({name})
+    schema["param_types"] = {**schema["param_types"], name: parameter_type}
+    registry = ToolRegistry(load_defaults=False)
+    registry.register(ActionType.STOP, schema)
+    return registry
+
+
 # ---------------------------------------------------------------------------
 # tests
 # ---------------------------------------------------------------------------
@@ -61,7 +93,7 @@ def _graph(*actions: SemanticAction) -> TaskGraph:
 
 class PolicyValidatorValidActionTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_observe_with_no_params_is_valid(self) -> None:
         report = self.validator.check(_graph(_action(ActionType.OBSERVE)))
@@ -100,7 +132,7 @@ class PolicyValidatorFieldSetTests(unittest.TestCase):
     """Exact field-set equality: reject extra AND missing."""
 
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_extra_field_is_rejected(self) -> None:
         report = self.validator.check(_graph(_action(ActionType.OBSERVE, parameters={"joint_angle": 90})))
@@ -140,7 +172,7 @@ class PolicyValidatorBoolBeforeIntTests(unittest.TestCase):
     """bool must be rejected for integer slots, not coerced to 1/0."""
 
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_duration_ms_bool_is_rejected(self) -> None:
         report = self.validator.check(
@@ -195,7 +227,7 @@ class PolicyValidatorSchemaConstraintTests(unittest.TestCase):
     """A5 consumes value and relational constraints from ToolRegistry."""
 
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_non_finite_confidence_is_rejected(self) -> None:
         report = self.validator.check(
@@ -255,7 +287,7 @@ class PolicyValidatorSchemaConstraintTests(unittest.TestCase):
 
 class PolicyValidatorTypeMismatchTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_str_slot_with_int_is_rejected(self) -> None:
         report = self.validator.check(
@@ -285,7 +317,7 @@ class PolicyValidatorTypeMismatchTests(unittest.TestCase):
 
 class PolicyValidatorEnforcementTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_enforce_raises_on_invalid_graph(self) -> None:
         with self.assertRaises(PolicyViolation):
@@ -312,7 +344,7 @@ class PolicyValidatorEnforcementTests(unittest.TestCase):
 
 class PolicyValidatorAggregationTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_multiple_invalid_steps_aggregate_all_findings(self) -> None:
         graph = _graph(
@@ -345,7 +377,7 @@ class PolicyValidatorAggregationTests(unittest.TestCase):
 
 class PolicyValidatorBoundaryTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.validator = PolicyValidator()
+        self.validator = _validator()
 
     def test_non_action_type_input_is_rejected(self) -> None:
         action = SemanticAction.model_construct(
@@ -370,7 +402,7 @@ class PolicyValidatorBoundaryTests(unittest.TestCase):
         """The validator must read its whitelist from the injected registry,
         not a hardcoded second copy."""
         empty_registry = ToolRegistry(load_defaults=False)
-        validator = PolicyValidator(registry=empty_registry)
+        validator = _validator(registry=empty_registry)
         report = validator.check(_graph(_action(ActionType.OBSERVE)))
         self.assertFalse(report.is_valid)  # nothing registered -> reject
 
@@ -379,7 +411,7 @@ class PolicyValidatorRuleBoundaryTests(unittest.TestCase):
     def test_validator_does_not_emit_verification_result(self) -> None:
         """Rule 2: completion is judged only by the world-model verifier.
         The validator's output must be a PolicyReport, never a VerificationResult."""
-        validator = PolicyValidator()
+        validator = _validator()
         report = validator.check(_graph(_action(ActionType.OBSERVE)))
         self.assertIsInstance(report, PolicyReport)
         self.assertIsInstance(report.findings, tuple)
@@ -389,13 +421,334 @@ class PolicyValidatorRuleBoundaryTests(unittest.TestCase):
         self.assertNotIsInstance(report, VerificationResult)
 
     def test_report_findings_are_policy_findings(self) -> None:
-        validator = PolicyValidator()
+        validator = _validator()
         report = validator.check(_graph(_action(ActionType.GRASP)))
         for finding in report.findings:
             self.assertIsInstance(finding, PolicyFinding)
             self.assertIsInstance(finding.step_id, str)
             self.assertIsInstance(finding.field, str)
             self.assertIsInstance(finding.message, str)
+
+
+class PolicyValidatorConfigurationTests(unittest.TestCase):
+    def test_missing_policy_config_fails_closed(self) -> None:
+        report = PolicyValidator().check(_graph(_action(ActionType.OBSERVE)))
+
+        self.assertFalse(report.is_valid)
+        self.assertEqual(report.decisions[0].outcome, "deny")
+        self.assertEqual(report.decisions[0].reason_code, "policy_config_missing")
+        self.assertIsNone(report.decisions[0].policy_version)
+
+    def test_blank_policy_version_fails_closed(self) -> None:
+        validator = PolicyValidator(
+            policy_config={
+                "policy_version": "  ",
+                "high_impact_actions": frozenset(),
+            }
+        )
+
+        report = validator.check(_graph(_action(ActionType.OBSERVE)))
+
+        self.assertFalse(report.is_valid)
+        self.assertEqual(report.decisions[0].reason_code, "policy_version_blank")
+        self.assertIsNone(report.decisions[0].policy_version)
+
+    def test_unknown_high_impact_action_fails_closed(self) -> None:
+        validator = PolicyValidator(
+            policy_config={
+                "policy_version": POLICY_VERSION,
+                "high_impact_actions": frozenset({"joint_move"}),
+            }
+        )
+
+        report = validator.check(_graph(_action(ActionType.OBSERVE)))
+
+        self.assertFalse(report.is_valid)
+        self.assertEqual(report.decisions[0].reason_code, "policy_config_unknown_action")
+        self.assertEqual(report.decisions[0].policy_version, POLICY_VERSION)
+
+    def test_malformed_policy_config_fails_closed(self) -> None:
+        malformed_configs = (
+            object(),
+            {"policy_version": POLICY_VERSION},
+            {"policy_version": 1, "high_impact_actions": frozenset()},
+            {"policy_version": POLICY_VERSION, "high_impact_actions": [ActionType.PLACE]},
+            {
+                "policy_version": POLICY_VERSION,
+                "high_impact_actions": frozenset(),
+                "unexpected": True,
+            },
+        )
+        for config in malformed_configs:
+            with self.subTest(config=config):
+                report = PolicyValidator(policy_config=config).check(_graph(_action(ActionType.OBSERVE)))
+                self.assertFalse(report.is_valid)
+                self.assertEqual(report.decisions[0].reason_code, "policy_config_malformed")
+
+
+class PolicyValidatorStructuredDecisionTests(unittest.TestCase):
+    def test_safe_action_is_allowed_with_versioned_structured_reason_without_mutation(self) -> None:
+        action = _action(ActionType.OBSERVE, action_id="act-safe", parameters={"required_confidence": 0.9})
+        graph = _graph(action)
+        action_before = action.model_dump_json().encode()
+        graph_before = graph.model_dump_json().encode()
+
+        report = _validator().check(graph)
+
+        self.assertTrue(report.is_valid)
+        self.assertEqual(len(report.decisions), 1)
+        decision = report.decisions[0]
+        self.assertEqual(decision.step_id, "step-1")
+        self.assertEqual(decision.action_id, "act-safe")
+        self.assertEqual(decision.outcome, "allow")
+        self.assertEqual(decision.reason_code, "policy_allowed")
+        self.assertEqual(decision.policy_version, POLICY_VERSION)
+        self.assertEqual(action.model_dump_json().encode(), action_before)
+        self.assertEqual(graph.model_dump_json().encode(), graph_before)
+        self.assertIsInstance(report.decisions, tuple)
+        with self.assertRaises(FrozenInstanceError):
+            decision.outcome = "deny"
+
+    def test_unknown_action_is_denied_structurally(self) -> None:
+        registry = ToolRegistry(load_defaults=False)
+
+        report = _validator(registry=registry).check(_graph(_action(ActionType.OBSERVE, action_id="act-unknown")))
+
+        self.assertFalse(report.is_valid)
+        decision = report.decisions[0]
+        self.assertEqual(decision.step_id, "step-1")
+        self.assertEqual(decision.action_id, "act-unknown")
+        self.assertEqual(decision.outcome, "deny")
+        self.assertEqual(decision.reason_code, "tool_registry_denied")
+        self.assertEqual(decision.policy_version, POLICY_VERSION)
+        self.assertTrue(any(finding.field == "action_type" for finding in decision.findings))
+
+    def test_injected_registry_change_propagates_without_second_allowlist(self) -> None:
+        registry = _registry_with_stop_parameter("operator_note", str)
+        graph = _graph(
+            _action(
+                ActionType.STOP,
+                action_id="act-custom",
+                parameters={"operator_note": "approved semantic stop"},
+            )
+        )
+
+        report = _validator(registry=registry).check(graph)
+
+        self.assertTrue(report.is_valid, report.decisions)
+        self.assertEqual(report.decisions[0].outcome, "allow")
+        self.assertEqual(report.decisions[0].reason_code, "policy_allowed")
+
+
+class PolicyValidatorRawControlTests(unittest.TestCase):
+    def test_nested_raw_control_identifiers_are_denied(self) -> None:
+        registry = _registry_with_stop_parameter("payload", list)
+        payloads = (
+            [{"motion": {"joint_position": 0.25}}],
+            [{"profile": ["velocity_limit=0.25"]}],
+            [["torque=3.0"]],
+            [{"update": {"name": "firmware_mode"}}],
+        )
+        for index, payload in enumerate(payloads, start=1):
+            with self.subTest(payload=payload):
+                action_id = f"act-raw-{index}"
+                graph = _graph(_action(ActionType.STOP, action_id=action_id, parameters={"payload": payload}))
+                report = _validator(
+                    registry=registry,
+                    high_impact_actions=frozenset({ActionType.STOP}),
+                ).check(graph, confirmed_action_ids=frozenset({action_id}))
+                self.assertFalse(report.is_valid)
+                self.assertEqual(report.decisions[0].outcome, "deny")
+                self.assertEqual(report.decisions[0].reason_code, "raw_control_parameter")
+                self.assertTrue(report.decisions[0].findings)
+
+    def test_plain_prose_is_not_misclassified_as_a_raw_parameter(self) -> None:
+        registry = _registry_with_stop_parameter("note", str)
+        notes = (
+            (
+                "This explanation mentions joint behavior, velocity profiles, torque margins, "
+                "and firmware safety without encoding a control parameter."
+            ),
+            "Firmware: safety remains outside this policy.",
+            "Joint: a mechanical connection, not a command.",
+        )
+        for note in notes:
+            with self.subTest(note=note):
+                graph = _graph(_action(ActionType.STOP, parameters={"note": note}))
+                report = _validator(registry=registry).check(graph)
+
+                self.assertTrue(report.is_valid, report.decisions)
+
+    def test_disguised_raw_control_identifiers_are_denied(self) -> None:
+        registry = _registry_with_stop_parameter("payload", list)
+        payloads = (
+            [{"joint velocity": 1}],
+            [{"firmware/mode": "update"}],
+            [{"JOINTVELOCITY": 1}],
+            ['{"joint\\u005fvelocity":1}'],
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                report = _validator(registry=registry).check(
+                    _graph(_action(ActionType.STOP, parameters={"payload": payload}))
+                )
+
+                self.assertFalse(report.is_valid)
+                self.assertEqual(report.decisions[0].reason_code, "raw_control_parameter")
+
+    def test_non_string_mapping_key_fails_closed(self) -> None:
+        registry = _registry_with_stop_parameter("payload", list)
+        payload = [{("torque_limit",): 1}]
+
+        report = _validator(registry=registry).check(_graph(_action(ActionType.STOP, parameters={"payload": payload})))
+
+        self.assertFalse(report.is_valid)
+        self.assertEqual(report.decisions[0].reason_code, "policy_input_malformed")
+
+    def test_excessive_payload_nesting_fails_closed_structurally(self) -> None:
+        registry = _registry_with_stop_parameter("payload", list)
+        payload: object = "safe"
+        for _ in range(1200):
+            payload = [payload]
+
+        report = _validator(registry=registry).check(_graph(_action(ActionType.STOP, parameters={"payload": payload})))
+
+        self.assertFalse(report.is_valid)
+        self.assertEqual(report.decisions[0].reason_code, "policy_input_malformed")
+        self.assertTrue(any("scan limit" in finding.message for finding in report.findings))
+
+
+class PolicyValidatorConfirmationTests(unittest.TestCase):
+    def test_high_impact_action_requires_confirmation(self) -> None:
+        graph = _graph(
+            _action(ActionType.ASK_CONFIRM, parameters={"question": "place it?"}),
+            _action(
+                ActionType.PLACE,
+                action_id="act-place",
+                target_id="red_block",
+                parameters={"destination_id": "tray"},
+            ),
+        )
+
+        report = _validator(high_impact_actions=frozenset({ActionType.PLACE})).check(graph)
+
+        self.assertFalse(report.is_valid)
+        self.assertEqual(report.decisions[0].outcome, "allow")
+        self.assertEqual(report.decisions[1].outcome, "confirmation_required")
+        self.assertEqual(report.decisions[1].reason_code, "action_confirmation_required")
+        self.assertEqual(report.decisions[1].policy_version, POLICY_VERSION)
+
+    def test_confirmation_is_scoped_to_exact_action_id(self) -> None:
+        graph = _graph(
+            _action(
+                ActionType.PLACE,
+                action_id="act-place",
+                target_id="red_block",
+                parameters={"destination_id": "tray"},
+            )
+        )
+        validator = _validator(high_impact_actions=frozenset({ActionType.PLACE}))
+
+        report = validator.check(graph, confirmed_action_ids=frozenset({"act-other"}))
+
+        self.assertFalse(report.is_valid)
+        self.assertEqual(report.decisions[0].action_id, "act-place")
+        self.assertEqual(report.decisions[0].outcome, "confirmation_required")
+
+    def test_malformed_confirmation_ids_fail_closed_without_substring_matching(self) -> None:
+        graph = _graph(
+            _action(
+                ActionType.PLACE,
+                action_id="act-place",
+                target_id="red_block",
+                parameters={"destination_id": "tray"},
+            )
+        )
+        validator = _validator(high_impact_actions=frozenset({ActionType.PLACE}))
+        malformed_values = (
+            "act-place-other",
+            ["act-place"],
+            frozenset({" "}),
+            frozenset({1}),
+        )
+
+        for confirmed_action_ids in malformed_values:
+            with self.subTest(confirmed_action_ids=confirmed_action_ids):
+                report = validator.check(
+                    graph,
+                    confirmed_action_ids=confirmed_action_ids,  # type: ignore[arg-type]
+                )
+
+                self.assertFalse(report.is_valid)
+                self.assertEqual(report.decisions[0].outcome, "deny")
+                self.assertEqual(report.decisions[0].reason_code, "confirmation_input_malformed")
+
+    def test_matching_confirmation_allows_registry_valid_high_impact_action(self) -> None:
+        valid_graph = _graph(
+            _action(
+                ActionType.PLACE,
+                action_id="act-place",
+                target_id="red_block",
+                parameters={"destination_id": "tray"},
+            )
+        )
+        invalid_graph = _graph(
+            _action(ActionType.PLACE, action_id="act-place-invalid", target_id="red_block", parameters={})
+        )
+        validator = _validator(high_impact_actions=frozenset({ActionType.PLACE}))
+
+        valid_report = validator.check(valid_graph, confirmed_action_ids=frozenset({"act-place"}))
+        invalid_report = validator.check(
+            invalid_graph,
+            confirmed_action_ids=frozenset({"act-place-invalid"}),
+        )
+
+        self.assertTrue(valid_report.is_valid, valid_report.decisions)
+        self.assertEqual(valid_report.decisions[0].outcome, "allow")
+        self.assertEqual(invalid_report.decisions[0].outcome, "deny")
+        self.assertEqual(invalid_report.decisions[0].reason_code, "tool_registry_denied")
+
+
+class PolicyValidatorIssue58EnforcementTests(unittest.TestCase):
+    def test_enforce_rejects_deny_and_confirmation_required(self) -> None:
+        denied_graph = _graph(_action(ActionType.OBSERVE, action_id="act-denied"))
+        confirmation_graph = _graph(
+            _action(
+                ActionType.PLACE,
+                action_id="act-confirm",
+                target_id="red_block",
+                parameters={"destination_id": "tray"},
+            )
+        )
+
+        with self.assertRaises(PolicyViolation) as denied:
+            _validator(registry=ToolRegistry(load_defaults=False)).enforce(denied_graph)
+        with self.assertRaises(PolicyViolation) as confirmation:
+            _validator(high_impact_actions=frozenset({ActionType.PLACE})).enforce(confirmation_graph)
+
+        self.assertEqual(denied.exception.report.decisions[0].step_id, "step-1")
+        self.assertEqual(denied.exception.report.decisions[0].reason_code, "tool_registry_denied")
+        self.assertEqual(confirmation.exception.report.decisions[0].action_id, "act-confirm")
+        self.assertEqual(confirmation.exception.report.decisions[0].outcome, "confirmation_required")
+
+    def test_policy_output_is_authorization_only(self) -> None:
+        from workbench_contracts import ActionResult, VerificationResult
+
+        report = _validator().check(_graph(_action(ActionType.OBSERVE)))
+        decision = report.decisions[0]
+
+        self.assertIsInstance(report, PolicyReport)
+        self.assertNotIsInstance(report, (ActionResult, VerificationResult))
+        self.assertNotIsInstance(decision, (ActionResult, VerificationResult))
+        for forbidden_attribute in (
+            "dispatch_state",
+            "device_state",
+            "evidence_refs",
+            "verification_id",
+            "completed",
+        ):
+            self.assertFalse(hasattr(report, forbidden_attribute))
+            self.assertFalse(hasattr(decision, forbidden_attribute))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Related Issue

Closes #58

## What changed

- add an explicit fail-closed A5 policy configuration with a non-blank audit version and a bounded set of high-impact semantic actions;
- keep the injected `ToolRegistry` as the only action and parameter allow-list;
- return immutable per-step allow, deny, or confirmation-required decisions with stable reason codes;
- reject nested and serialized raw joint, velocity, torque, and firmware parameter identifiers with bounded traversal;
- require confirmation for the exact high-impact `action_id` rather than authorizing an action type globally;
- preserve the input `TaskGraph` and `SemanticAction` without mutation;
- add deterministic coverage for configuration failures, registry propagation, raw-control disguises, confirmation scoping, structured reports, and enforcement.

## Interfaces affected

None.

- no changes to `interfaces/` or `libs/contracts/`;
- no changes to ToolRegistry schemas;
- the policy layer returns authorization evidence only and does not dispatch actions, persist confirmation, emit execution results, or write WorldState.

## Tests and commands

```text
python -m pytest -q tests/unit/test_policy_validator.py tests/unit/test_tool_registry.py
110 passed

python -m pytest -q --ignore=tests/unit/test_multi_host_deployment.py
893 passed

python -m ruff check .
PASS

python -m ruff format --check .
341 files already formatted

python tools/scripts/validate_contracts.py
PASS

python tools/scripts/validate_scenarios.py
PASS — 12 frozen and 24 expanded manifests

python tools/scripts/check_context.py
PASS

python tools/scripts/validate_golden_set.py
PASS — 50 tasks across 5 families and 26 dangerous requests

python tools/scripts/check_task_packet.py --all --base 9a85bacb105f89c6954a53f2dcf1b9ca95327842 --head ed3aa21233040ef19239206d18721f13eb23d621
PASS

python -m mkdocs build --strict
PASS

python tools/scripts/demo_scripted.py
PASS

python tools/scripts/local_runner.py --goal "Place the red block in the tray"
PASS

git diff --check
PASS
```

The local Windows review excludes `tests/unit/test_multi_host_deployment.py` because Docker CLI is unavailable locally; GitHub CI covers the Linux/Docker deployment checks.

## Evidence

- focused policy and registry coverage proves the registry remains the only action/parameter allow-list;
- tests cover allow, deny, confirmation-required, malformed configuration, unknown actions, exact-action confirmation, non-mutation, bounded raw-control scanning, and injected registry changes;
- the Task Packet checker confirms the Git-visible diff contains only the three approved paths;
- validation against the latest `main` merge result completed without conflicts;
- commit `ed3aa21233040ef19239206d18721f13eb23d621` retains the original contributor's DCO sign-off.

## Risks and rollback

- missing or malformed policy configuration now fails closed, so callers must provide an explicit valid configuration before authorization;
- high-impact actions remain blocked until their exact `action_id` is confirmed;
- raw-control scanning is intentionally bounded and fails closed when traversal limits are exceeded;
- rollback by reverting commit `ed3aa21233040ef19239206d18721f13eb23d621`; no schema or persistent-data migration is required.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.