### PR TITLE
feat(perception): add known-target RGB-D producer

### DIFF
--- a/docs/task_packets/issue-158-real-rgbd-observations.json
+++ b/docs/task_packets/issue-158-real-rgbd-observations.json
@@ -1,0 +1,96 @@
+{
+  "issue": 158,
+  "human_owner": "zhangjia-1111",
+  "objective": "Implement only the deterministic software portion of the known-target RGB-D producer on the Issue #72 branch, while keeping real-camera, calibration, ROS launch and physical metric evidence explicitly NOT_EXECUTED.",
+  "decision_supported": "Can synchronized local RGB, aligned-depth, camera metadata and configured AprilTag detections produce contract-valid, traceable Observations that pass the Issue #72 fail-closed ingestion boundary without guessing identity or fabricating hardware evidence?",
+  "allowed_paths": [
+    "docs/task_packets/issue-158-real-rgbd-observations.json",
+    "services/perception/README.md",
+    "services/perception/workbench_perception/__init__.py",
+    "services/perception/workbench_perception/rgbd.py",
+    "tests/unit/test_rgbd_producer.py",
+    "tests/integration/test_rgbd_producer.py"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "hardware/cameras/README.md",
+    "docs/task_packets/issue-72-observation-ingestion.json",
+    "interfaces/json_schema/observation.schema.json",
+    "interfaces/json_schema/pose.schema.json",
+    "interfaces/examples/observation-red-block.json",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/perception/workbench_perception/ingestion.py",
+    "tests/unit/test_observation_ingestion.py",
+    "tests/integration/test_observation_ingestion.py"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "hardware/**",
+    "robot/control/**",
+    "firmware/**",
+    "services/world_model/**",
+    "sim/**",
+    "deploy/**",
+    ".github/**"
+  ],
+  "input_refs": [
+    "hardware/cameras/README.md",
+    "docs/task_packets/issue-72-observation-ingestion.json",
+    "interfaces/json_schema/observation.schema.json",
+    "interfaces/json_schema/pose.schema.json",
+    "interfaces/examples/observation-red-block.json",
+    "services/perception/workbench_perception/ingestion.py"
+  ],
+  "outputs": [
+    "typed known-target RGB-D software producer",
+    "bounded immutable frame metadata evidence store without raw event payloads",
+    "contract Observation output consumable by the Issue #72 ingestion adapter",
+    "explicit NOT_EXECUTED documentation for real camera and Issue #75 evidence"
+  ],
+  "acceptance": [
+    "Configured RGB, aligned-depth, intrinsics and AprilTag inputs produce current contract-valid Observations with deterministic identity, calibrated camera-frame pose, confidence, timestamp, clock, source and evidence reference.",
+    "Unknown tags are reported separately and never receive a guessed entity identity.",
+    "Dimension, sequence, timestamp or clock mismatch, stale/future frames, invalid depth, duplicate tags or frames, occlusion, low decision margin and excess hamming fail closed before Observation delivery.",
+    "Evidence references resolve to bounded immutable frame metadata and RGB/depth hashes; raw sensor bytes are not embedded in Observation or WorldEvent payloads.",
+    "Producer output passes the existing Issue #72 ObservationIngestionAdapter without contract or Pydantic changes.",
+    "Tests use only small local deterministic fixtures, perform no public network access and do not claim a connected camera, ROS launch, physical calibration, fixture accuracy or hardware performance.",
+    "README explicitly records the missing camera serial/firmware, calibration hash, clock measurement, ROS launch, fixture ground truth and target-hardware metrics as NOT_EXECUTED."
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-158-real-rgbd-observations.json",
+    "python -m pytest tests/unit/test_rgbd_producer.py tests/integration/test_rgbd_producer.py -v",
+    "python -m pytest tests/unit tests/integration -k \"observation or rgbd\" -v",
+    "python -m ruff check services/perception/workbench_perception tests/unit/test_rgbd_producer.py tests/integration/test_rgbd_producer.py",
+    "python -m ruff format --check services/perception/workbench_perception tests/unit/test_rgbd_producer.py tests/integration/test_rgbd_producer.py",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "Repository audit showing only a planned D435 README and no serialized camera, calibration artifact/hash, clock measurement, real frames, ROS launch record or physical metrics.",
+    "Focused deterministic normal and fail-closed test output.",
+    "Integration evidence showing produced Observation output passes the Issue #72 ingestion boundary.",
+    "Evidence-store assertions proving bounded retention, stable hashes and absence of raw image/depth payloads.",
+    "Task Packet, full tests, contract, scenario, context, lint and diff-boundary output."
+  ],
+  "stop_conditions": [
+    "A detector enum or Observation/Pose/Pydantic contract change is required.",
+    "A write outside allowed_paths is required, including hardware, deployment, ROS packaging, CI, simulation, World Model, robot control or firmware.",
+    "Real camera, calibration, time-sync, ROS launch, fixture accuracy or target-hardware performance evidence is requested without connected and owner-approved hardware.",
+    "Implementation would add a GPU model, cloud API, vector database, open-vocabulary detector, public-network fixture or guessed entity identity.",
+    "Issue #72 ingestion behavior must change instead of being consumed as the stacked base.",
+    "The worktree contains overlapping user modifications in an allowed path."
+  ],
+  "max_iterations": 5,
+  "data_classification": "Small local synthetic RGB/depth metadata fixtures only; no personal data, captured household imagery or public network access.",
+  "model_policy": "Deterministic typed validation, pinhole projection and explicit AprilTag allow-list only; no model inference.",
+  "risks_and_fallbacks": [
+    "This change is software-only and cannot close Issue #158 until real ROS launch, calibration, ground-truth and hardware metric evidence exists.",
+    "In-memory duplicate suppression and evidence retention do not survive restart; persistent evidence ownership requires a separate approved design.",
+    "Tag orientation is identity in the optical frame because no approved physical tag-size/pose solver evidence exists; add a tested injected pose solver only with owner-approved calibration inputs.",
+    "Reject any frame pair whose timing, calibration, depth or identity cannot be proven instead of guessing."
+  ]
+}

--- a/docs/task_packets/issue-72-observation-ingestion.json
+++ b/docs/task_packets/issue-72-observation-ingestion.json
@@ -1,0 +1,75 @@
+{
+  "issue": 72,
+  "human_owner": "zhangjia-1111",
+  "objective": "Add a fail-closed perception-to-World-Model adapter that validates, calibrates and freshness-gates Observation records before emitting WorldEvents.",
+  "decision_supported": "Whether a raw camera observation is trustworthy enough to enter the canonical World Model event stream.",
+  "allowed_paths": [
+    "services/perception/README.md",
+    "services/perception/workbench_perception/__init__.py",
+    "services/perception/workbench_perception/ingestion.py",
+    "tests/unit/test_observation_ingestion.py",
+    "tests/integration/test_observation_ingestion.py",
+    "docs/task_packets/issue-72-observation-ingestion.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/world_model/**"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "sim/**"
+  ],
+  "input_refs": [
+    "interfaces/json_schema/observation.schema.json",
+    "interfaces/json_schema/pose.schema.json",
+    "interfaces/json_schema/world_event.schema.json",
+    "interfaces/examples/observation-red-block.json"
+  ],
+  "outputs": [
+    "fail-closed Observation ingestion adapter",
+    "deterministic calibration and freshness fixtures",
+    "accepted Observation WorldEvents consumable by the World Model reducer"
+  ],
+  "acceptance": [
+    "only contract-valid Observation records are accepted",
+    "camera ID calibration revision frame pose units confidence timestamp clock and evidence references are validated",
+    "stale future-skewed duplicate and coordinate-frame-mismatched observations are rejected",
+    "frame conversion requires a declared calibration revision",
+    "raw observation provenance is preserved without caller mutation",
+    "deterministic tests cover dropout malformed pose low confidence stale frames and calibration mismatch",
+    "the World Model sink receives only accepted observations"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-72-observation-ingestion.json",
+    "python -m pytest tests/unit tests/integration -k observation -v",
+    "python -m ruff check services/perception/workbench_perception tests/unit/test_observation_ingestion.py tests/integration/test_observation_ingestion.py",
+    "python -m ruff format --check services/perception/workbench_perception tests/unit/test_observation_ingestion.py tests/integration/test_observation_ingestion.py",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check"
+  ],
+  "evidence": [
+    "Task Packet validation output",
+    "focused observation unit and integration test output",
+    "full repository test output",
+    "contract scenario and context validation output"
+  ],
+  "stop_conditions": [
+    "an interface or Pydantic contract change is required",
+    "a write outside the allowed paths is required",
+    "a simulator oracle or raw image payload is required",
+    "a calibration cannot identify source and target frames",
+    "physical sensor evidence is requested without a connected bench"
+  ],
+  "max_iterations": 5,
+  "data_classification": "local synthetic observation fixtures only; no raw images or personal data",
+  "model_policy": "deterministic typed validation and rigid transforms only; no model inference",
+  "risks_and_fallbacks": [
+    "reject observations when their clock domain cannot be compared to an injected deterministic clock",
+    "reject unknown calibration revisions or frames instead of guessing a transform",
+    "preserve the current interfaces and open a separately approved contract issue if new fields are required"
+  ]
+}

--- a/services/perception/README.md
+++ b/services/perception/README.md
@@ -3,3 +3,12 @@
 P0 emits `Observation` from a controlled Gazebo camera using OpenCV plus AprilTag or color recognition. Required fields are documented in `interfaces/json_schema/observation.schema.json`.
 
 Do not use simulator Oracle values in sensor-mode metrics.
+
+`workbench_perception.ObservationIngestionAdapter` is the fail-closed boundary
+between an Observation producer and the World Model event stream. Callers must
+name an approved camera calibration revision and pose unit, and inject a clock
+from the same domain as the Observation. The adapter rejects malformed, stale,
+future-skewed, low-confidence, duplicate, uncalibrated, and frame-mismatched
+records before invoking its World Model sink. It preserves the unmodified JSON
+Observation under `payload.raw_observation` and emits the calibrated pose at
+`payload.pose`; it never writes `WorldState` facts directly.

--- a/services/perception/README.md
+++ b/services/perception/README.md
@@ -12,3 +12,25 @@ future-skewed, low-confidence, duplicate, uncalibrated, and frame-mismatched
 records before invoking its World Model sink. It preserves the unmodified JSON
 Observation under `payload.raw_observation` and emits the calibrated pose at
 `payload.pose`; it never writes `WorldState` facts directly.
+
+## Known-target RGB-D software producer
+
+`workbench_perception.KnownTargetRgbdProducer` implements the deterministic
+software portion of Issue #158. It accepts typed RGB, aligned-depth, camera
+intrinsics and AprilTag detections for an explicit entity allow-list. Unknown
+tags are reported separately and never assigned a guessed identity. Missing or
+invalid depth, stale or unsynchronised frames, clock mismatch, duplicate tags,
+occlusion, and low-margin detections fail closed before any Observation or
+evidence record is published.
+
+The producer returns the existing contract `Observation` plus the camera ID,
+calibration revision, and pose units required by the Issue #72 ingestion
+adapter. Recent evidence references resolve to immutable hashes and frame
+metadata in a bounded store; raw RGB/depth payloads are never embedded in an
+Observation or WorldEvent.
+
+Physical status remains **NOT_EXECUTED**. The repository contains no serialized
+camera, firmware revision, calibration artifact/hash, measured clock
+offset/drift, real ROS launch capture, fixture ground truth, or target-hardware
+latency/CPU/memory output. This software module and its local fixtures are not
+evidence of a connected Intel RealSense D435 or successful real perception.

--- a/services/perception/workbench_perception/__init__.py
+++ b/services/perception/workbench_perception/__init__.py
@@ -1,0 +1,5 @@
+"""Fail-closed perception boundaries for Workbench-1."""
+
+from .ingestion import CalibrationRecord, ObservationIngestionAdapter, ObservationRejected
+
+__all__ = ["CalibrationRecord", "ObservationIngestionAdapter", "ObservationRejected"]

--- a/services/perception/workbench_perception/__init__.py
+++ b/services/perception/workbench_perception/__init__.py
@@ -1,5 +1,33 @@
 """Fail-closed perception boundaries for Workbench-1."""
 
 from .ingestion import CalibrationRecord, ObservationIngestionAdapter, ObservationRejected
+from .rgbd import (
+    CameraIntrinsics,
+    DepthFrame,
+    FrameEvidence,
+    FrameEvidenceStore,
+    KnownEntity,
+    KnownTargetRgbdProducer,
+    ProducedObservation,
+    ProductionBatch,
+    RgbdObservationRejected,
+    RgbFrame,
+    TagDetection,
+)
 
-__all__ = ["CalibrationRecord", "ObservationIngestionAdapter", "ObservationRejected"]
+__all__ = [
+    "CalibrationRecord",
+    "CameraIntrinsics",
+    "DepthFrame",
+    "FrameEvidence",
+    "FrameEvidenceStore",
+    "KnownEntity",
+    "KnownTargetRgbdProducer",
+    "ObservationIngestionAdapter",
+    "ObservationRejected",
+    "ProducedObservation",
+    "ProductionBatch",
+    "RgbFrame",
+    "RgbdObservationRejected",
+    "TagDetection",
+]

--- a/services/perception/workbench_perception/ingestion.py
+++ b/services/perception/workbench_perception/ingestion.py
@@ -1,0 +1,352 @@
+"""Validate and calibrate observations before they enter the World Model.
+
+The adapter deliberately owns no detector and writes no ``WorldState`` facts.
+It turns one untrusted Observation mapping into a contract-shaped observation
+``WorldEvent`` only after every boundary check succeeds.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import OrderedDict
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from threading import Lock
+from typing import Any, Literal
+
+from pydantic import ValidationError
+from workbench_contracts import ClockId, Observation, WorldEvent, WorldEventType
+
+_REQUIRED_OBSERVATION_KEYS = frozenset(
+    {
+        "observation_id",
+        "run_id",
+        "entity_id",
+        "entity_type",
+        "pose",
+        "confidence",
+        "observed_at",
+        "source",
+        "evidence_refs",
+    }
+)
+_QUATERNION_TOLERANCE = 1e-6
+
+
+class ObservationRejected(ValueError):
+    """An observation failed a fail-closed ingestion boundary check."""
+
+
+@dataclass(frozen=True)
+class CalibrationRecord:
+    """One approved rigid transform for a camera calibration revision."""
+
+    camera_id: str
+    revision: str
+    source_frame: str
+    target_frame: str
+    clock_id: ClockId
+    translation_m: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    rotation_xyzw: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0)
+    pose_units: Literal["m"] = "m"
+
+    def __post_init__(self) -> None:
+        for name in ("camera_id", "revision", "source_frame", "target_frame"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"calibration {name} must be non-empty")
+        if not isinstance(self.clock_id, ClockId):
+            raise ValueError("calibration clock_id must be a ClockId")
+        if self.pose_units != "m":
+            raise ValueError("calibration pose_units must be 'm'")
+        if (
+            not isinstance(self.translation_m, tuple)
+            or len(self.translation_m) != 3
+            or not all(_is_finite_number(value) for value in self.translation_m)
+        ):
+            raise ValueError("calibration translation_m must contain three finite numbers")
+        if not isinstance(self.rotation_xyzw, tuple):
+            raise ValueError("calibration rotation_xyzw must be a tuple")
+        _require_unit_quaternion(self.rotation_xyzw, "calibration rotation_xyzw")
+
+
+class ObservationIngestionAdapter:
+    """Emit only validated, fresh and calibrated observation events."""
+
+    def __init__(
+        self,
+        calibrations: Iterable[CalibrationRecord],
+        *,
+        now: Callable[[ClockId], datetime],
+        sink: Callable[[WorldEvent], None] | None = None,
+        minimum_confidence: float = 0.5,
+        maximum_age: timedelta = timedelta(seconds=1),
+        maximum_future_skew: timedelta = timedelta(milliseconds=50),
+        duplicate_window_size: int = 1024,
+    ) -> None:
+        if not callable(now):
+            raise ValueError("now must be callable")
+        if sink is not None and not callable(sink):
+            raise ValueError("sink must be callable or None")
+        if isinstance(minimum_confidence, bool) or not _is_finite_number(minimum_confidence):
+            raise ValueError("minimum_confidence must be a finite number")
+        if not 0.0 <= float(minimum_confidence) <= 1.0:
+            raise ValueError("minimum_confidence must be between 0 and 1")
+        if not isinstance(maximum_age, timedelta) or not isinstance(maximum_future_skew, timedelta):
+            raise ValueError("freshness durations must be timedeltas")
+        if maximum_age < timedelta(0) or maximum_future_skew < timedelta(0):
+            raise ValueError("freshness durations must be non-negative")
+        if (
+            isinstance(duplicate_window_size, bool)
+            or not isinstance(duplicate_window_size, int)
+            or duplicate_window_size < 1
+        ):
+            raise ValueError("duplicate_window_size must be a positive integer")
+
+        calibration_by_key: dict[tuple[str, str], CalibrationRecord] = {}
+        for calibration in calibrations:
+            if not isinstance(calibration, CalibrationRecord):
+                raise ValueError("calibrations must contain CalibrationRecord values")
+            key = (calibration.camera_id, calibration.revision)
+            if key in calibration_by_key:
+                raise ValueError(f"duplicate calibration {key!r}")
+            calibration_by_key[key] = calibration
+        if not calibration_by_key:
+            raise ValueError("at least one calibration is required")
+
+        self._calibrations = calibration_by_key
+        self._now = now
+        self._sink = sink
+        self._minimum_confidence = float(minimum_confidence)
+        self._maximum_age = maximum_age
+        self._maximum_future_skew = maximum_future_skew
+        self._duplicate_window_size = duplicate_window_size
+        self._seen_ids: OrderedDict[tuple[str, str], None] = OrderedDict()
+        self._seen_frames: OrderedDict[tuple[str, str, str, tuple[str, ...]], None] = OrderedDict()
+        self._lock = Lock()
+
+    def ingest(
+        self,
+        record: Mapping[str, object] | None,
+        *,
+        camera_id: str,
+        calibration_revision: str,
+        pose_units: str,
+        sequence_no: int,
+    ) -> WorldEvent:
+        """Validate one record, optionally deliver it, and return its WorldEvent.
+
+        The injected sink is called only after the complete record has passed
+        structural, calibration, freshness and duplicate checks.
+        """
+        raw_record, observation = _parse_contract_observation(record)
+        _require_non_empty(camera_id, "camera_id")
+        _require_non_empty(calibration_revision, "calibration_revision")
+        if isinstance(sequence_no, bool) or not isinstance(sequence_no, int) or sequence_no < 0:
+            raise ObservationRejected("sequence_no must be a non-negative integer")
+
+        calibration = self._calibrations.get((camera_id, calibration_revision))
+        if calibration is None:
+            raise ObservationRejected(f"unknown calibration revision {calibration_revision!r} for camera {camera_id!r}")
+        if pose_units != "m" or pose_units != calibration.pose_units:
+            raise ObservationRejected("pose_units must match the declared calibration unit 'm'")
+        if observation.source != camera_id:
+            raise ObservationRejected(
+                f"Observation source {observation.source!r} does not match camera_id {camera_id!r}"
+            )
+        if observation.clock_id is not calibration.clock_id:
+            raise ObservationRejected(
+                f"Observation clock {observation.clock_id.value!r} does not match calibration clock "
+                f"{calibration.clock_id.value!r}"
+            )
+
+        observed_at = _parse_timestamp(observation.observed_at)
+        now = self._now(observation.clock_id)
+        if not isinstance(now, datetime) or now.tzinfo is None:
+            raise ObservationRejected("injected clock must return a timezone-aware datetime")
+        now = now.astimezone(UTC)
+        age = now - observed_at
+        if age > self._maximum_age:
+            raise ObservationRejected(f"Observation is stale by {age.total_seconds():.6f} seconds")
+        if age < -self._maximum_future_skew:
+            raise ObservationRejected(f"Observation is future-skewed by {-age.total_seconds():.6f} seconds")
+
+        if observation.confidence < self._minimum_confidence:
+            raise ObservationRejected(
+                f"Observation confidence {observation.confidence} is below {self._minimum_confidence}"
+            )
+        _validate_observation_values(observation)
+        transformed_pose = _transform_pose(observation, calibration)
+
+        event = WorldEvent(
+            event_id=f"observation:{observation.observation_id}",
+            run_id=observation.run_id,
+            sequence_no=sequence_no,
+            event_type=WorldEventType.OBSERVATION,
+            occurred_at=observation.observed_at,
+            payload={
+                "entity_id": observation.entity_id,
+                "entity_type": observation.entity_type,
+                "pose": transformed_pose,
+                "confidence": observation.confidence,
+                "detector": observation.detector.value,
+                "camera_id": camera_id,
+                "calibration_revision": calibration_revision,
+                "pose_units": pose_units,
+                "clock_id": observation.clock_id.value,
+                "raw_observation": raw_record,
+            },
+            evidence_refs=list(observation.evidence_refs),
+        )
+
+        observation_key = (observation.run_id, observation.observation_id)
+        frame_key = (observation.run_id, camera_id, observation.entity_id, tuple(observation.evidence_refs))
+        with self._lock:
+            if observation_key in self._seen_ids:
+                raise ObservationRejected(f"duplicate observation_id {observation.observation_id!r}")
+            if frame_key in self._seen_frames:
+                raise ObservationRejected("duplicate camera-frame observation for entity")
+            if self._sink is not None:
+                self._sink(event)
+            _remember(self._seen_ids, observation_key, self._duplicate_window_size)
+            _remember(self._seen_frames, frame_key, self._duplicate_window_size)
+        return event
+
+
+def _parse_contract_observation(record: Mapping[str, object] | None) -> tuple[dict[str, Any], Observation]:
+    if not isinstance(record, Mapping):
+        raise ObservationRejected("Observation record must be a mapping")
+    missing = _REQUIRED_OBSERVATION_KEYS - set(record)
+    if missing:
+        raise ObservationRejected(f"Observation is missing contract fields: {sorted(missing)}")
+    try:
+        serialized = json.dumps(dict(record), allow_nan=False, ensure_ascii=False)
+        raw_record = json.loads(serialized)
+        observation = Observation.model_validate_json(serialized, strict=True)
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise ObservationRejected(f"Observation is not contract-valid: {exc}") from exc
+    return raw_record, observation
+
+
+def _validate_observation_values(observation: Observation) -> None:
+    for name in ("observation_id", "run_id", "entity_id", "entity_type", "source"):
+        _require_non_empty(getattr(observation, name), name)
+    _require_non_empty(observation.pose.frame_id, "pose.frame_id")
+    if observation.hamming is not None and (isinstance(observation.hamming, bool) or observation.hamming < 0):
+        raise ObservationRejected("hamming must be a non-negative integer or null")
+    if observation.decision_margin is not None and not _is_finite_number(observation.decision_margin):
+        raise ObservationRejected("decision_margin must be finite or null")
+
+    position = observation.pose.position
+    if not all(_is_finite_number(value) for value in (position.x, position.y, position.z)):
+        raise ObservationRejected("pose position must contain finite numbers")
+    orientation = observation.pose.orientation
+    _require_unit_quaternion(
+        (orientation.x, orientation.y, orientation.z, orientation.w),
+        "pose orientation",
+        rejection=True,
+    )
+    if len(set(observation.evidence_refs)) != len(observation.evidence_refs):
+        raise ObservationRejected("evidence_refs must not contain duplicates")
+    for reference in observation.evidence_refs:
+        _require_non_empty(reference, "evidence_refs item")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ObservationRejected("observed_at must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ObservationRejected("observed_at must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _transform_pose(observation: Observation, calibration: CalibrationRecord) -> dict[str, object]:
+    pose = observation.pose
+    if pose.frame_id == calibration.target_frame:
+        return pose.model_dump(mode="json")
+    if pose.frame_id != calibration.source_frame:
+        raise ObservationRejected(
+            f"pose frame {pose.frame_id!r} matches neither calibration source "
+            f"{calibration.source_frame!r} nor target {calibration.target_frame!r}"
+        )
+
+    source_position = (pose.position.x, pose.position.y, pose.position.z)
+    rotated = _rotate_vector(calibration.rotation_xyzw, source_position)
+    translated = tuple(rotated[index] + calibration.translation_m[index] for index in range(3))
+    source_orientation = (pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w)
+    target_orientation = _multiply_quaternions(calibration.rotation_xyzw, source_orientation)
+    return {
+        "frame_id": calibration.target_frame,
+        "position": {"x": translated[0], "y": translated[1], "z": translated[2]},
+        "orientation": {
+            "x": target_orientation[0],
+            "y": target_orientation[1],
+            "z": target_orientation[2],
+            "w": target_orientation[3],
+        },
+    }
+
+
+def _multiply_quaternions(
+    left: tuple[float, float, float, float], right: tuple[float, float, float, float]
+) -> tuple[float, float, float, float]:
+    lx, ly, lz, lw = left
+    rx, ry, rz, rw = right
+    product = (
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+        lw * rw - lx * rx - ly * ry - lz * rz,
+    )
+    norm = math.sqrt(sum(component * component for component in product))
+    return tuple(component / norm for component in product)  # type: ignore[return-value]
+
+
+def _rotate_vector(
+    rotation: tuple[float, float, float, float], vector: tuple[float, float, float]
+) -> tuple[float, float, float]:
+    vector_quaternion = (vector[0], vector[1], vector[2], 0.0)
+    conjugate = (-rotation[0], -rotation[1], -rotation[2], rotation[3])
+    rotated = _multiply_raw(_multiply_raw(rotation, vector_quaternion), conjugate)
+    return rotated[0], rotated[1], rotated[2]
+
+
+def _multiply_raw(
+    left: tuple[float, float, float, float], right: tuple[float, float, float, float]
+) -> tuple[float, float, float, float]:
+    lx, ly, lz, lw = left
+    rx, ry, rz, rw = right
+    return (
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+        lw * rw - lx * rx - ly * ry - lz * rz,
+    )
+
+
+def _require_unit_quaternion(value: tuple[float, float, float, float], name: str, *, rejection: bool = False) -> None:
+    error_type = ObservationRejected if rejection else ValueError
+    if len(value) != 4 or not all(_is_finite_number(component) for component in value):
+        raise error_type(f"{name} must contain four finite numbers")
+    norm = math.sqrt(sum(float(component) * float(component) for component in value))
+    if not math.isclose(norm, 1.0, rel_tol=_QUATERNION_TOLERANCE, abs_tol=_QUATERNION_TOLERANCE):
+        raise error_type(f"{name} must be a unit quaternion")
+
+
+def _is_finite_number(value: object) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int | float) and math.isfinite(float(value))
+
+
+def _require_non_empty(value: object, name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ObservationRejected(f"{name} must be a non-empty string")
+
+
+def _remember(cache: OrderedDict[Any, None], key: Any, maximum_size: int) -> None:
+    cache[key] = None
+    while len(cache) > maximum_size:
+        cache.popitem(last=False)

--- a/services/perception/workbench_perception/rgbd.py
+++ b/services/perception/workbench_perception/rgbd.py
@@ -426,7 +426,7 @@ def _format_timestamp(value: datetime) -> str:
 def _pixel_index(value: float, limit: int, name: str) -> int:
     if not 0 <= value < limit:
         raise RgbdObservationRejected(f"{name} must be inside the image")
-    return min(limit - 1, int(math.floor(value + 0.5)))
+    return min(limit - 1, math.floor(value + 0.5))
 
 
 def _require_text(value: object, name: str, *, rejection: bool = False) -> None:

--- a/services/perception/workbench_perception/rgbd.py
+++ b/services/perception/workbench_perception/rgbd.py
@@ -1,0 +1,461 @@
+"""Deterministic software boundary for known-target RGB-D observations.
+
+This module deliberately does not claim a connected camera or ROS runtime.  It
+turns already-synchronised RGB, aligned-depth and AprilTag inputs into the
+existing Observation contract, retaining only bounded immutable frame metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+from collections import OrderedDict
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from threading import Lock
+from typing import Final
+
+from workbench_contracts import ClockId, Detector, Observation, Orientation, Pose, Position
+
+_POSE_UNITS: Final = "m"
+
+
+class RgbdObservationRejected(ValueError):
+    """A frame pair failed a known-target RGB-D boundary check."""
+
+
+@dataclass(frozen=True)
+class KnownEntity:
+    """One configured AprilTag identity; unknown tags are never guessed."""
+
+    tag_id: int
+    entity_id: str
+    entity_type: str
+
+    def __post_init__(self) -> None:
+        if isinstance(self.tag_id, bool) or not isinstance(self.tag_id, int) or self.tag_id < 0:
+            raise ValueError("tag_id must be a non-negative integer")
+        _require_text(self.entity_id, "entity_id")
+        _require_text(self.entity_type, "entity_type")
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    """Validated pinhole intrinsics for one approved camera revision."""
+
+    camera_id: str
+    calibration_revision: str
+    frame_id: str
+    width: int
+    height: int
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    clock_id: ClockId
+
+    def __post_init__(self) -> None:
+        for name in ("camera_id", "calibration_revision", "frame_id"):
+            _require_text(getattr(self, name), name)
+        _require_dimensions(self.width, self.height, "camera intrinsics")
+        for name in ("fx", "fy", "cx", "cy"):
+            if not _finite_number(getattr(self, name)):
+                raise ValueError(f"{name} must be finite")
+        if self.fx <= 0 or self.fy <= 0:
+            raise ValueError("fx and fy must be positive")
+        if not 0 <= self.cx < self.width or not 0 <= self.cy < self.height:
+            raise ValueError("principal point must be inside the image")
+        if not isinstance(self.clock_id, ClockId):
+            raise ValueError("clock_id must be a ClockId")
+
+
+@dataclass(frozen=True)
+class RgbFrame:
+    """One local RGB frame. Bytes are hashed but never embedded in observations."""
+
+    sequence_no: int
+    width: int
+    height: int
+    observed_at: datetime
+    clock_id: ClockId
+    data: bytes
+
+    def __post_init__(self) -> None:
+        _require_sequence(self.sequence_no, "RGB sequence_no")
+        _require_dimensions(self.width, self.height, "RGB frame")
+        _require_timestamp(self.observed_at, "RGB observed_at")
+        if not isinstance(self.clock_id, ClockId):
+            raise ValueError("RGB clock_id must be a ClockId")
+        if not isinstance(self.data, bytes) or len(self.data) != self.width * self.height * 3:
+            raise ValueError("RGB data must contain exactly width * height * 3 bytes")
+
+
+@dataclass(frozen=True)
+class DepthFrame:
+    """Aligned depth in metres, stored row-major for deterministic local fixtures."""
+
+    sequence_no: int
+    width: int
+    height: int
+    observed_at: datetime
+    clock_id: ClockId
+    depth_m: tuple[tuple[float, ...], ...]
+
+    def __post_init__(self) -> None:
+        _require_sequence(self.sequence_no, "depth sequence_no")
+        _require_dimensions(self.width, self.height, "depth frame")
+        _require_timestamp(self.observed_at, "depth observed_at")
+        if not isinstance(self.clock_id, ClockId):
+            raise ValueError("depth clock_id must be a ClockId")
+        if len(self.depth_m) != self.height or any(len(row) != self.width for row in self.depth_m):
+            raise ValueError("depth_m dimensions must match the depth frame")
+
+
+@dataclass(frozen=True)
+class TagDetection:
+    """Detector output required to identify and locate one configured tag."""
+
+    tag_id: int
+    center_x: float
+    center_y: float
+    decision_margin: float
+    hamming: int = 0
+    occluded: bool = False
+
+    def __post_init__(self) -> None:
+        if isinstance(self.tag_id, bool) or not isinstance(self.tag_id, int) or self.tag_id < 0:
+            raise ValueError("tag_id must be a non-negative integer")
+        for name in ("center_x", "center_y", "decision_margin"):
+            if not _finite_number(getattr(self, name)):
+                raise ValueError(f"{name} must be finite")
+        if isinstance(self.hamming, bool) or not isinstance(self.hamming, int) or self.hamming < 0:
+            raise ValueError("hamming must be a non-negative integer")
+        if not isinstance(self.occluded, bool):
+            raise ValueError("occluded must be a boolean")
+
+
+@dataclass(frozen=True)
+class FrameEvidence:
+    """Immutable, bounded metadata for one frame pair; no raw image bytes."""
+
+    reference: str
+    camera_id: str
+    calibration_revision: str
+    rgb_sequence_no: int
+    depth_sequence_no: int
+    observed_at: str
+    clock_id: str
+    rgb_sha256: str
+    depth_sha256: str
+    width: int
+    height: int
+
+
+class FrameEvidenceStore:
+    """Resolve recent evidence references without retaining sensor payloads."""
+
+    def __init__(self, maximum_entries: int = 256) -> None:
+        if isinstance(maximum_entries, bool) or not isinstance(maximum_entries, int) or maximum_entries < 1:
+            raise ValueError("maximum_entries must be a positive integer")
+        self._maximum_entries = maximum_entries
+        self._entries: OrderedDict[str, FrameEvidence] = OrderedDict()
+        self._lock = Lock()
+
+    def add(self, evidence: FrameEvidence) -> None:
+        if not isinstance(evidence, FrameEvidence):
+            raise ValueError("evidence must be FrameEvidence")
+        with self._lock:
+            if evidence.reference in self._entries:
+                raise RgbdObservationRejected("duplicate frame evidence reference")
+            self._entries[evidence.reference] = evidence
+            while len(self._entries) > self._maximum_entries:
+                self._entries.popitem(last=False)
+
+    def resolve(self, reference: str) -> FrameEvidence | None:
+        with self._lock:
+            return self._entries.get(reference)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+@dataclass(frozen=True)
+class ProducedObservation:
+    """A contract Observation plus the #72 ingestion boundary arguments."""
+
+    observation: Observation
+    camera_id: str
+    calibration_revision: str
+    pose_units: str = _POSE_UNITS
+
+
+@dataclass(frozen=True)
+class ProductionBatch:
+    """Atomic result for one frame pair."""
+
+    observations: tuple[ProducedObservation, ...]
+    ignored_tag_ids: tuple[int, ...]
+    evidence_ref: str
+
+
+class KnownTargetRgbdProducer:
+    """Produce contract-valid observations for an explicit AprilTag allow-list."""
+
+    def __init__(
+        self,
+        known_entities: Iterable[KnownEntity],
+        *,
+        now: Callable[[ClockId], datetime],
+        evidence_store: FrameEvidenceStore,
+        minimum_decision_margin: float = 50.0,
+        maximum_hamming: int = 0,
+        maximum_pair_skew: timedelta = timedelta(milliseconds=20),
+        maximum_age: timedelta = timedelta(seconds=1),
+        minimum_depth_m: float = 0.05,
+        maximum_depth_m: float = 10.0,
+    ) -> None:
+        entities: dict[int, KnownEntity] = {}
+        identities: set[str] = set()
+        for entity in known_entities:
+            if not isinstance(entity, KnownEntity):
+                raise ValueError("known_entities must contain KnownEntity values")
+            if entity.tag_id in entities:
+                raise ValueError(f"duplicate configured tag_id {entity.tag_id}")
+            if entity.entity_id in identities:
+                raise ValueError(f"duplicate configured entity_id {entity.entity_id!r}")
+            entities[entity.tag_id] = entity
+            identities.add(entity.entity_id)
+        if not entities:
+            raise ValueError("at least one known entity is required")
+        if not callable(now):
+            raise ValueError("now must be callable")
+        if not isinstance(evidence_store, FrameEvidenceStore):
+            raise ValueError("evidence_store must be FrameEvidenceStore")
+        if not _finite_number(minimum_decision_margin) or minimum_decision_margin < 0:
+            raise ValueError("minimum_decision_margin must be finite and non-negative")
+        if isinstance(maximum_hamming, bool) or not isinstance(maximum_hamming, int) or maximum_hamming < 0:
+            raise ValueError("maximum_hamming must be a non-negative integer")
+        if not isinstance(maximum_pair_skew, timedelta) or maximum_pair_skew < timedelta(0):
+            raise ValueError("maximum_pair_skew must be a non-negative timedelta")
+        if not isinstance(maximum_age, timedelta) or maximum_age < timedelta(0):
+            raise ValueError("maximum_age must be a non-negative timedelta")
+        if not _finite_number(minimum_depth_m) or not _finite_number(maximum_depth_m):
+            raise ValueError("depth bounds must be finite")
+        if minimum_depth_m <= 0 or maximum_depth_m <= minimum_depth_m:
+            raise ValueError("depth bounds must be positive and increasing")
+
+        self._entities = entities
+        self._now = now
+        self._evidence_store = evidence_store
+        self._minimum_decision_margin = float(minimum_decision_margin)
+        self._maximum_hamming = maximum_hamming
+        self._maximum_pair_skew = maximum_pair_skew
+        self._maximum_age = maximum_age
+        self._minimum_depth_m = float(minimum_depth_m)
+        self._maximum_depth_m = float(maximum_depth_m)
+        self._seen_pairs: set[tuple[int, int, str]] = set()
+        self._lock = Lock()
+
+    def produce(
+        self,
+        *,
+        run_id: str,
+        rgb: RgbFrame,
+        depth: DepthFrame,
+        intrinsics: CameraIntrinsics,
+        detections: Sequence[TagDetection],
+    ) -> ProductionBatch:
+        """Validate one aligned frame pair and atomically produce observations."""
+        _require_text(run_id, "run_id", rejection=True)
+        if not isinstance(rgb, RgbFrame) or not isinstance(depth, DepthFrame):
+            raise RgbdObservationRejected("rgb and depth must be typed frames")
+        if not isinstance(intrinsics, CameraIntrinsics):
+            raise RgbdObservationRejected("intrinsics must be CameraIntrinsics")
+        if not isinstance(detections, Sequence) or isinstance(detections, str | bytes):
+            raise RgbdObservationRejected("detections must be a sequence")
+        if any(not isinstance(item, TagDetection) for item in detections):
+            raise RgbdObservationRejected("detections must contain TagDetection values")
+
+        self._validate_frame_pair(rgb, depth, intrinsics)
+        tag_ids = [item.tag_id for item in detections]
+        if len(tag_ids) != len(set(tag_ids)):
+            raise RgbdObservationRejected("duplicate tag detections fail closed")
+
+        known_detections: list[tuple[KnownEntity, TagDetection, float]] = []
+        ignored: list[int] = []
+        for detection in detections:
+            entity = self._entities.get(detection.tag_id)
+            if entity is None:
+                ignored.append(detection.tag_id)
+                continue
+            if detection.occluded:
+                raise RgbdObservationRejected(f"configured tag {detection.tag_id} is occluded")
+            if detection.decision_margin < self._minimum_decision_margin:
+                raise RgbdObservationRejected(f"configured tag {detection.tag_id} has low decision margin")
+            if detection.hamming > self._maximum_hamming:
+                raise RgbdObservationRejected(f"configured tag {detection.tag_id} exceeds hamming limit")
+            pixel_x = _pixel_index(detection.center_x, intrinsics.width, "center_x")
+            pixel_y = _pixel_index(detection.center_y, intrinsics.height, "center_y")
+            distance = depth.depth_m[pixel_y][pixel_x]
+            if not _finite_number(distance) or not self._minimum_depth_m <= distance <= self._maximum_depth_m:
+                raise RgbdObservationRejected(f"configured tag {detection.tag_id} has invalid aligned depth")
+            known_detections.append((entity, detection, float(distance)))
+
+        evidence = _frame_evidence(rgb, depth, intrinsics)
+        pair_key = (rgb.sequence_no, depth.sequence_no, evidence.reference)
+        produced = tuple(
+            self._produce_observation(run_id, intrinsics, evidence, entity, detection, distance)
+            for entity, detection, distance in known_detections
+        )
+        with self._lock:
+            if pair_key in self._seen_pairs:
+                raise RgbdObservationRejected("duplicate RGB-D frame pair")
+            self._evidence_store.add(evidence)
+            self._seen_pairs.add(pair_key)
+        return ProductionBatch(
+            observations=produced,
+            ignored_tag_ids=tuple(sorted(ignored)),
+            evidence_ref=evidence.reference,
+        )
+
+    def _validate_frame_pair(self, rgb: RgbFrame, depth: DepthFrame, intrinsics: CameraIntrinsics) -> None:
+        if (rgb.width, rgb.height) != (depth.width, depth.height) or (rgb.width, rgb.height) != (
+            intrinsics.width,
+            intrinsics.height,
+        ):
+            raise RgbdObservationRejected("RGB, aligned depth and intrinsics dimensions must match")
+        if rgb.sequence_no != depth.sequence_no:
+            raise RgbdObservationRejected("RGB and aligned depth sequence numbers must match")
+        if rgb.clock_id is not depth.clock_id or rgb.clock_id is not intrinsics.clock_id:
+            raise RgbdObservationRejected("RGB, depth and calibration clock domains must match")
+        skew = abs(rgb.observed_at.astimezone(UTC) - depth.observed_at.astimezone(UTC))
+        if skew > self._maximum_pair_skew:
+            raise RgbdObservationRejected("RGB and aligned depth timestamps are unsynchronised")
+        current = self._now(rgb.clock_id)
+        if not isinstance(current, datetime) or current.tzinfo is None:
+            raise RgbdObservationRejected("injected clock must return a timezone-aware datetime")
+        observed_at = max(rgb.observed_at.astimezone(UTC), depth.observed_at.astimezone(UTC))
+        age = current.astimezone(UTC) - observed_at
+        if age < timedelta(0):
+            raise RgbdObservationRejected("RGB-D frame pair is future-skewed")
+        if age > self._maximum_age:
+            raise RgbdObservationRejected("RGB-D frame pair is stale")
+
+    @staticmethod
+    def _produce_observation(
+        run_id: str,
+        intrinsics: CameraIntrinsics,
+        evidence: FrameEvidence,
+        entity: KnownEntity,
+        detection: TagDetection,
+        distance: float,
+    ) -> ProducedObservation:
+        x = (detection.center_x - intrinsics.cx) * distance / intrinsics.fx
+        y = (detection.center_y - intrinsics.cy) * distance / intrinsics.fy
+        identity_bytes = "\x1f".join((run_id, evidence.reference, str(detection.tag_id), entity.entity_id)).encode()
+        observation_id = f"rgbd-{hashlib.sha256(identity_bytes).hexdigest()[:24]}"
+        confidence = min(1.0, max(0.0, detection.decision_margin / 100.0))
+        observation = Observation(
+            observation_id=observation_id,
+            run_id=run_id,
+            entity_id=entity.entity_id,
+            entity_type=entity.entity_type,
+            pose=Pose(
+                frame_id=intrinsics.frame_id,
+                position=Position(x=x, y=y, z=distance),
+                orientation=Orientation(x=0.0, y=0.0, z=0.0, w=1.0),
+            ),
+            confidence=confidence,
+            detector=Detector.APRILTAG,
+            hamming=detection.hamming,
+            decision_margin=detection.decision_margin,
+            observed_at=evidence.observed_at,
+            clock_id=intrinsics.clock_id,
+            source=intrinsics.camera_id,
+            evidence_refs=[evidence.reference],
+        )
+        return ProducedObservation(
+            observation=observation,
+            camera_id=intrinsics.camera_id,
+            calibration_revision=intrinsics.calibration_revision,
+        )
+
+
+def _frame_evidence(rgb: RgbFrame, depth: DepthFrame, intrinsics: CameraIntrinsics) -> FrameEvidence:
+    rgb_digest = hashlib.sha256(rgb.data).hexdigest()
+    depth_hash = hashlib.sha256()
+    for row in depth.depth_m:
+        for value in row:
+            depth_hash.update(struct.pack("!d", float(value)))
+    depth_digest = depth_hash.hexdigest()
+    observed_at = max(rgb.observed_at.astimezone(UTC), depth.observed_at.astimezone(UTC))
+    identity = "\x1f".join(
+        (
+            intrinsics.camera_id,
+            intrinsics.calibration_revision,
+            str(rgb.sequence_no),
+            str(depth.sequence_no),
+            _format_timestamp(observed_at),
+            rgb_digest,
+            depth_digest,
+        )
+    )
+    reference = f"evidence://rgbd/{intrinsics.camera_id}/{hashlib.sha256(identity.encode()).hexdigest()}"
+    return FrameEvidence(
+        reference=reference,
+        camera_id=intrinsics.camera_id,
+        calibration_revision=intrinsics.calibration_revision,
+        rgb_sequence_no=rgb.sequence_no,
+        depth_sequence_no=depth.sequence_no,
+        observed_at=_format_timestamp(observed_at),
+        clock_id=intrinsics.clock_id.value,
+        rgb_sha256=rgb_digest,
+        depth_sha256=depth_digest,
+        width=rgb.width,
+        height=rgb.height,
+    )
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _pixel_index(value: float, limit: int, name: str) -> int:
+    if not 0 <= value < limit:
+        raise RgbdObservationRejected(f"{name} must be inside the image")
+    return min(limit - 1, int(math.floor(value + 0.5)))
+
+
+def _require_text(value: object, name: str, *, rejection: bool = False) -> None:
+    error = RgbdObservationRejected if rejection else ValueError
+    if not isinstance(value, str) or not value.strip():
+        raise error(f"{name} must be a non-empty string")
+
+
+def _require_sequence(value: object, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _require_dimensions(width: object, height: object, name: str) -> None:
+    if (
+        isinstance(width, bool)
+        or isinstance(height, bool)
+        or not isinstance(width, int)
+        or not isinstance(height, int)
+        or width < 1
+        or height < 1
+    ):
+        raise ValueError(f"{name} dimensions must be positive integers")
+
+
+def _require_timestamp(value: object, name: str) -> None:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise ValueError(f"{name} must be timezone-aware")
+
+
+def _finite_number(value: object) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int | float) and math.isfinite(float(value))

--- a/tests/integration/test_observation_ingestion.py
+++ b/tests/integration/test_observation_ingestion.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [
+    str(ROOT / "libs/contracts"),
+    str(ROOT / "services/perception"),
+    str(ROOT / "services/world_model"),
+]
+
+from workbench_contracts import ClockId
+from workbench_perception import CalibrationRecord, ObservationIngestionAdapter, ObservationRejected
+from workbench_world_model import reduce_events
+
+
+def test_world_model_receives_only_accepted_observations() -> None:
+    accepted_events = []
+    adapter = ObservationIngestionAdapter(
+        [
+            CalibrationRecord(
+                camera_id="camera-01",
+                revision="cal-v1",
+                source_frame="camera_optical",
+                target_frame="workbench",
+                clock_id=ClockId.WALL,
+            )
+        ],
+        now=lambda _clock_id: datetime(2026, 8, 28, 4, 0, 1, tzinfo=UTC),
+        sink=accepted_events.append,
+        minimum_confidence=0.8,
+        maximum_age=timedelta(seconds=2),
+    )
+    valid_record = {
+        "observation_id": "obs-valid",
+        "run_id": "run-observation",
+        "entity_id": "red_block",
+        "entity_type": "block",
+        "pose": {
+            "frame_id": "camera_optical",
+            "position": {"x": 0.2, "y": 0.1, "z": 0.02},
+            "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        },
+        "confidence": 0.95,
+        "detector": "apriltag",
+        "observed_at": "2026-08-28T04:00:00Z",
+        "clock_id": "wall",
+        "source": "camera-01",
+        "evidence_refs": ["frame://camera-01/valid"],
+    }
+
+    adapter.ingest(
+        valid_record,
+        camera_id="camera-01",
+        calibration_revision="cal-v1",
+        pose_units="m",
+        sequence_no=0,
+    )
+    with pytest.raises(ObservationRejected):
+        adapter.ingest(
+            {**valid_record, "observation_id": "obs-low", "confidence": 0.2},
+            camera_id="camera-01",
+            calibration_revision="cal-v1",
+            pose_units="m",
+            sequence_no=1,
+        )
+
+    state = reduce_events("run-observation", accepted_events)
+
+    assert len(accepted_events) == 1
+    assert state.applied_event_ids == ["observation:obs-valid"]
+    assert state.entity_confidence == {"red_block": 0.95}
+    assert state.entity_evidence_refs == {"red_block": ["frame://camera-01/valid"]}

--- a/tests/integration/test_rgbd_producer.py
+++ b/tests/integration/test_rgbd_producer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "libs/contracts"), str(ROOT / "services/perception")]
+
+from workbench_contracts import ClockId, WorldEventType
+from workbench_perception import (
+    CalibrationRecord,
+    CameraIntrinsics,
+    DepthFrame,
+    FrameEvidenceStore,
+    KnownEntity,
+    KnownTargetRgbdProducer,
+    ObservationIngestionAdapter,
+    RgbFrame,
+    TagDetection,
+)
+
+
+def test_rgbd_output_passes_issue_72_ingestion_boundary() -> None:
+    now = datetime(2026, 8, 30, 4, 0, 0, tzinfo=UTC)
+    producer = KnownTargetRgbdProducer(
+        [KnownEntity(tag_id=12, entity_id="parcel_fixture", entity_type="parcel")],
+        now=lambda clock_id: now,
+        evidence_store=FrameEvidenceStore(),
+    )
+    produced = producer.produce(
+        run_id="run-rgbd-integration",
+        rgb=RgbFrame(
+            sequence_no=1,
+            width=2,
+            height=2,
+            observed_at=now - timedelta(milliseconds=5),
+            clock_id=ClockId.WALL,
+            data=bytes(range(12)),
+        ),
+        depth=DepthFrame(
+            sequence_no=1,
+            width=2,
+            height=2,
+            observed_at=now - timedelta(milliseconds=4),
+            clock_id=ClockId.WALL,
+            depth_m=((1.0, 1.0), (1.0, 1.0)),
+        ),
+        intrinsics=CameraIntrinsics(
+            camera_id="camera-d435-front",
+            calibration_revision="cal-not-executed-fixture-v1",
+            frame_id="camera_color_optical_frame",
+            width=2,
+            height=2,
+            fx=2.0,
+            fy=2.0,
+            cx=0.5,
+            cy=0.5,
+            clock_id=ClockId.WALL,
+        ),
+        detections=[TagDetection(tag_id=12, center_x=0.5, center_y=0.5, decision_margin=90.0)],
+    ).observations[0]
+    events = []
+    ingestion = ObservationIngestionAdapter(
+        [
+            CalibrationRecord(
+                camera_id="camera-d435-front",
+                revision="cal-not-executed-fixture-v1",
+                source_frame="camera_color_optical_frame",
+                target_frame="table",
+                clock_id=ClockId.WALL,
+                translation_m=(0.1, 0.2, 0.3),
+            )
+        ],
+        now=lambda clock_id: now,
+        sink=events.append,
+    )
+
+    event = ingestion.ingest(
+        produced.observation.model_dump(mode="json"),
+        camera_id=produced.camera_id,
+        calibration_revision=produced.calibration_revision,
+        pose_units=produced.pose_units,
+        sequence_no=1,
+    )
+
+    assert event.event_type is WorldEventType.OBSERVATION
+    assert event.payload["pose"]["frame_id"] == "table"
+    assert event.payload["calibration_revision"] == "cal-not-executed-fixture-v1"
+    assert events == [event]

--- a/tests/unit/test_observation_ingestion.py
+++ b/tests/unit/test_observation_ingestion.py
@@ -119,10 +119,11 @@ class ObservationIngestionTests(unittest.TestCase):
         Draft202012Validator(schema).validate(event)
 
     def test_raw_provenance_is_preserved_and_detached(self) -> None:
-        record = observation_record(vendor_metadata={"exposure_us": 5000})
+        record = observation_record()
         original = deepcopy(record)
         event = ingest(adapter(), record)
         record["entity_id"] = "mutated"
+        record["pose"]["position"]["x"] = 99.0  # type: ignore[index]
         record["evidence_refs"].append("frame://mutated")  # type: ignore[union-attr]
 
         self.assertEqual(event.payload["raw_observation"], original)

--- a/tests/unit/test_observation_ingestion.py
+++ b/tests/unit/test_observation_ingestion.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import math
+import sys
+import unittest
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "libs/contracts"), str(ROOT / "services/perception")]
+
+from workbench_contracts import ClockId, WorldEventType
+from workbench_perception import CalibrationRecord, ObservationIngestionAdapter, ObservationRejected
+
+NOW = datetime(2026, 8, 28, 4, 0, 1, tzinfo=UTC)
+
+
+def observation_record(**updates: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "observation_id": "obs-001",
+        "run_id": "run-001",
+        "entity_id": "red_block",
+        "entity_type": "block",
+        "pose": {
+            "frame_id": "camera_optical",
+            "position": {"x": 0.2, "y": 0.1, "z": 0.02},
+            "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        },
+        "confidence": 0.98,
+        "detector": "apriltag",
+        "hamming": 0,
+        "decision_margin": 72.5,
+        "observed_at": "2026-08-28T04:00:00Z",
+        "clock_id": "wall",
+        "source": "camera-01",
+        "evidence_refs": ["frame://camera-01/001"],
+    }
+    record.update(updates)
+    return record
+
+
+def calibration(**updates: object) -> CalibrationRecord:
+    values: dict[str, object] = {
+        "camera_id": "camera-01",
+        "revision": "cal-v1",
+        "source_frame": "camera_optical",
+        "target_frame": "workbench",
+        "clock_id": ClockId.WALL,
+        "translation_m": (1.0, 2.0, 3.0),
+    }
+    values.update(updates)
+    return CalibrationRecord(**values)  # type: ignore[arg-type]
+
+
+def adapter(*, sink=None, **updates: object) -> ObservationIngestionAdapter:
+    values: dict[str, object] = {
+        "now": lambda _clock_id: NOW,
+        "sink": sink,
+        "minimum_confidence": 0.7,
+        "maximum_age": timedelta(seconds=2),
+        "maximum_future_skew": timedelta(milliseconds=100),
+    }
+    values.update(updates)
+    return ObservationIngestionAdapter([calibration()], **values)  # type: ignore[arg-type]
+
+
+def ingest(target: ObservationIngestionAdapter, record: dict[str, object] | None = None, **updates: object):
+    context: dict[str, object] = {
+        "camera_id": "camera-01",
+        "calibration_revision": "cal-v1",
+        "pose_units": "m",
+        "sequence_no": 0,
+    }
+    context.update(updates)
+    return target.ingest(observation_record() if record is None else record, **context)  # type: ignore[arg-type]
+
+
+class CalibrationRecordTests(unittest.TestCase):
+    def test_calibration_requires_bounded_rigid_transform(self) -> None:
+        invalid_updates = (
+            {"camera_id": ""},
+            {"camera_id": 1},
+            {"clock_id": "wall"},
+            {"translation_m": 1.0},
+            {"translation_m": (0.0, math.nan, 0.0)},
+            {"rotation_xyzw": [0.0, 0.0, 0.0, 1.0]},
+            {"rotation_xyzw": (0.0, 0.0, 0.0, 0.0)},
+            {"pose_units": "cm"},
+        )
+
+        for updates in invalid_updates:
+            with self.subTest(updates=updates), self.assertRaises(ValueError):
+                calibration(**updates)
+
+
+class ObservationIngestionTests(unittest.TestCase):
+    def test_valid_observation_is_calibrated_and_delivered(self) -> None:
+        delivered = []
+        target = adapter(sink=delivered.append)
+
+        event = ingest(target)
+
+        self.assertEqual(delivered, [event])
+        self.assertEqual(event.event_type, WorldEventType.OBSERVATION)
+        self.assertEqual(event.event_id, "observation:obs-001")
+        self.assertEqual(event.payload["pose"]["frame_id"], "workbench")
+        self.assertEqual(event.payload["pose"]["position"], {"x": 1.2, "y": 2.1, "z": 3.02})
+        self.assertEqual(event.payload["calibration_revision"], "cal-v1")
+        self.assertEqual(event.evidence_refs, ["frame://camera-01/001"])
+
+    def test_world_event_satisfies_current_contract(self) -> None:
+        event = ingest(adapter()).model_dump(mode="json")
+        schema_path = ROOT / "interfaces/json_schema/world_event.schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        Draft202012Validator(schema).validate(event)
+
+    def test_raw_provenance_is_preserved_and_detached(self) -> None:
+        record = observation_record(vendor_metadata={"exposure_us": 5000})
+        original = deepcopy(record)
+        event = ingest(adapter(), record)
+        record["entity_id"] = "mutated"
+        record["evidence_refs"].append("frame://mutated")  # type: ignore[union-attr]
+
+        self.assertEqual(event.payload["raw_observation"], original)
+
+    def test_dropout_and_contract_invalid_records_fail_closed(self) -> None:
+        target = adapter()
+        with self.assertRaises(ObservationRejected):
+            target.ingest(
+                None,
+                camera_id="camera-01",
+                calibration_revision="cal-v1",
+                pose_units="m",
+                sequence_no=0,
+            )
+
+        invalid_records = [
+            {},
+            {key: value for key, value in observation_record().items() if key != "source"},
+            observation_record(confidence="0.98"),
+            observation_record(hamming=-1),
+            observation_record(decision_margin=float("nan")),
+        ]
+
+        for record in invalid_records:
+            with self.subTest(record=record), self.assertRaises(ObservationRejected):
+                ingest(adapter(), record)  # type: ignore[arg-type]
+
+    def test_malformed_pose_is_rejected(self) -> None:
+        invalid_poses = [
+            {
+                "frame_id": "camera_optical",
+                "position": {"x": float("nan"), "y": 0.0, "z": 0.0},
+                "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+            },
+            {
+                "frame_id": "camera_optical",
+                "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+                "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0},
+            },
+        ]
+
+        for pose in invalid_poses:
+            with self.subTest(pose=pose), self.assertRaises(ObservationRejected):
+                ingest(adapter(), observation_record(pose=pose))
+
+    def test_confidence_and_freshness_gates_fail_closed(self) -> None:
+        invalid_records = (
+            observation_record(confidence=0.69),
+            observation_record(observed_at="2026-08-28T03:59:58Z"),
+            observation_record(observed_at="2026-08-28T04:00:01.101Z"),
+            observation_record(observed_at="not-a-timestamp"),
+            observation_record(observed_at="2026-08-28T04:00:00"),
+        )
+
+        for record in invalid_records:
+            with self.subTest(record=record), self.assertRaises(ObservationRejected):
+                ingest(adapter(), record)
+
+    def test_camera_calibration_units_clock_and_frames_are_validated(self) -> None:
+        cases = (
+            (observation_record(), {"camera_id": "camera-02"}),
+            (observation_record(), {"calibration_revision": "missing"}),
+            (observation_record(), {"pose_units": "cm"}),
+            (observation_record(clock_id="monotonic"), {}),
+            (
+                observation_record(
+                    pose={
+                        "frame_id": "unknown_frame",
+                        "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+                        "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                    }
+                ),
+                {},
+            ),
+        )
+
+        for record, context in cases:
+            with self.subTest(context=context), self.assertRaises(ObservationRejected):
+                ingest(adapter(), record, **context)
+
+    def test_target_frame_pose_is_not_transformed_again(self) -> None:
+        pose = {
+            "frame_id": "workbench",
+            "position": {"x": 0.2, "y": 0.1, "z": 0.02},
+            "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+        }
+
+        event = ingest(adapter(), observation_record(pose=pose))
+
+        self.assertEqual(event.payload["pose"], pose)
+
+    def test_duplicate_ids_and_entity_frames_are_rejected(self) -> None:
+        target = adapter()
+        ingest(target)
+
+        with self.assertRaisesRegex(ObservationRejected, "observation_id"):
+            ingest(target)
+        with self.assertRaisesRegex(ObservationRejected, "camera-frame"):
+            ingest(target, observation_record(observation_id="obs-002"), sequence_no=1)
+
+    def test_invalid_observations_never_reach_world_model_sink(self) -> None:
+        delivered = []
+        target = adapter(sink=delivered.append)
+
+        with self.assertRaises(ObservationRejected):
+            ingest(target, observation_record(confidence=0.1))
+
+        self.assertEqual(delivered, [])
+
+    def test_duplicate_tracking_is_bounded(self) -> None:
+        target = adapter(duplicate_window_size=1)
+        ingest(target)
+        ingest(
+            target,
+            observation_record(
+                observation_id="obs-002",
+                entity_id="blue_block",
+                evidence_refs=["frame://camera-01/002"],
+            ),
+            sequence_no=1,
+        )
+
+        event = ingest(target, sequence_no=2)
+
+        self.assertEqual(event.event_id, "observation:obs-001")
+
+    def test_adapter_configuration_rejects_unsafe_values(self) -> None:
+        with self.assertRaises(ValueError):
+            ObservationIngestionAdapter([], now=lambda _clock: NOW)
+        with self.assertRaises(ValueError):
+            adapter(minimum_confidence=float("nan"))
+        with self.assertRaises(ValueError):
+            adapter(maximum_age=timedelta(seconds=-1))
+        with self.assertRaises(ValueError):
+            adapter(duplicate_window_size=0)
+        with self.assertRaises(ValueError):
+            adapter(duplicate_window_size=1.5)
+        with self.assertRaises(ValueError):
+            ObservationIngestionAdapter([object()], now=lambda _clock: NOW)  # type: ignore[list-item]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rgbd_producer.py
+++ b/tests/unit/test_rgbd_producer.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "libs/contracts"), str(ROOT / "services/perception")]
+
+from workbench_contracts import ClockId, Observation
+from workbench_perception import (
+    CameraIntrinsics,
+    DepthFrame,
+    FrameEvidenceStore,
+    KnownEntity,
+    KnownTargetRgbdProducer,
+    RgbdObservationRejected,
+    RgbFrame,
+    TagDetection,
+)
+
+NOW = datetime(2026, 8, 30, 4, 0, 0, tzinfo=UTC)
+
+
+def intrinsics(**changes: object) -> CameraIntrinsics:
+    values = {
+        "camera_id": "camera-d435-front",
+        "calibration_revision": "cal-not-executed-fixture-v1",
+        "frame_id": "camera_color_optical_frame",
+        "width": 3,
+        "height": 3,
+        "fx": 2.0,
+        "fy": 2.0,
+        "cx": 1.0,
+        "cy": 1.0,
+        "clock_id": ClockId.WALL,
+    }
+    values.update(changes)
+    return CameraIntrinsics(**values)  # type: ignore[arg-type]
+
+
+def rgb(**changes: object) -> RgbFrame:
+    values = {
+        "sequence_no": 7,
+        "width": 3,
+        "height": 3,
+        "observed_at": NOW - timedelta(milliseconds=10),
+        "clock_id": ClockId.WALL,
+        "data": bytes(range(27)),
+    }
+    values.update(changes)
+    return RgbFrame(**values)  # type: ignore[arg-type]
+
+
+def depth(**changes: object) -> DepthFrame:
+    values = {
+        "sequence_no": 7,
+        "width": 3,
+        "height": 3,
+        "observed_at": NOW - timedelta(milliseconds=5),
+        "clock_id": ClockId.WALL,
+        "depth_m": ((1.0, 1.0, 1.0), (1.0, 2.0, 1.0), (1.0, 1.0, 1.0)),
+    }
+    values.update(changes)
+    return DepthFrame(**values)  # type: ignore[arg-type]
+
+
+def detection(**changes: object) -> TagDetection:
+    values = {"tag_id": 12, "center_x": 1.0, "center_y": 1.0, "decision_margin": 90.0}
+    values.update(changes)
+    return TagDetection(**values)  # type: ignore[arg-type]
+
+
+def producer(store: FrameEvidenceStore | None = None) -> KnownTargetRgbdProducer:
+    return KnownTargetRgbdProducer(
+        [KnownEntity(tag_id=12, entity_id="parcel_fixture", entity_type="parcel")],
+        now=lambda clock_id: NOW,
+        evidence_store=store if store is not None else FrameEvidenceStore(),
+    )
+
+
+def test_known_tag_produces_contract_observation_and_projected_pose() -> None:
+    batch = producer().produce(
+        run_id="run-rgbd-fixture", rgb=rgb(), depth=depth(), intrinsics=intrinsics(), detections=[detection()]
+    )
+
+    assert len(batch.observations) == 1
+    produced = batch.observations[0]
+    assert isinstance(produced.observation, Observation)
+    assert produced.observation.entity_id == "parcel_fixture"
+    assert produced.observation.pose.position.model_dump() == {"x": 0.0, "y": 0.0, "z": 2.0}
+    assert produced.observation.source == "camera-d435-front"
+    assert produced.observation.evidence_refs == [batch.evidence_ref]
+    assert produced.calibration_revision == "cal-not-executed-fixture-v1"
+    assert produced.pose_units == "m"
+
+
+def test_unknown_tag_is_reported_without_guessed_identity() -> None:
+    batch = producer().produce(
+        run_id="run-rgbd-fixture",
+        rgb=rgb(),
+        depth=depth(),
+        intrinsics=intrinsics(),
+        detections=[detection(tag_id=999)],
+    )
+
+    assert batch.observations == ()
+    assert batch.ignored_tag_ids == (999,)
+
+
+@pytest.mark.parametrize(
+    "detections, message",
+    [
+        ([detection(), detection()], "duplicate tag"),
+        ([detection(occluded=True)], "occluded"),
+        ([detection(decision_margin=49.9)], "low decision margin"),
+        ([detection(hamming=1)], "hamming"),
+        ([detection(center_x=3.0)], "center_x"),
+    ],
+)
+def test_bad_detections_fail_closed(detections: list[TagDetection], message: str) -> None:
+    with pytest.raises(RgbdObservationRejected, match=message):
+        producer().produce(
+            run_id="run-rgbd-fixture",
+            rgb=rgb(),
+            depth=depth(),
+            intrinsics=intrinsics(),
+            detections=detections,
+        )
+
+
+@pytest.mark.parametrize("bad_depth", [0.0, float("nan"), float("inf"), 20.0])
+def test_missing_or_invalid_aligned_depth_fails_closed(bad_depth: float) -> None:
+    rows = ((1.0, 1.0, 1.0), (1.0, bad_depth, 1.0), (1.0, 1.0, 1.0))
+    with pytest.raises(RgbdObservationRejected, match="invalid aligned depth"):
+        producer().produce(
+            run_id="run-rgbd-fixture",
+            rgb=rgb(),
+            depth=depth(depth_m=rows),
+            intrinsics=intrinsics(),
+            detections=[detection()],
+        )
+
+
+@pytest.mark.parametrize(
+    "rgb_frame, depth_frame, calibration, message",
+    [
+        (rgb(), depth(sequence_no=8), intrinsics(), "sequence numbers"),
+        (
+            rgb(),
+            depth(observed_at=NOW - timedelta(milliseconds=50)),
+            intrinsics(),
+            "unsynchronised",
+        ),
+        (
+            rgb(observed_at=NOW - timedelta(seconds=2)),
+            depth(observed_at=NOW - timedelta(seconds=2)),
+            intrinsics(),
+            "stale",
+        ),
+        (rgb(clock_id=ClockId.MONOTONIC), depth(), intrinsics(), "clock domains"),
+        (rgb(), depth(), intrinsics(width=4), "dimensions"),
+    ],
+)
+def test_invalid_frame_pairs_fail_closed(
+    rgb_frame: RgbFrame, depth_frame: DepthFrame, calibration: CameraIntrinsics, message: str
+) -> None:
+    with pytest.raises(RgbdObservationRejected, match=message):
+        producer().produce(
+            run_id="run-rgbd-fixture",
+            rgb=rgb_frame,
+            depth=depth_frame,
+            intrinsics=calibration,
+            detections=[detection()],
+        )
+
+
+def test_evidence_is_deterministic_bounded_and_contains_no_raw_payload() -> None:
+    first_store = FrameEvidenceStore(maximum_entries=1)
+    first = producer(first_store).produce(
+        run_id="run-rgbd-fixture", rgb=rgb(), depth=depth(), intrinsics=intrinsics(), detections=[detection()]
+    )
+    repeat_store = FrameEvidenceStore(maximum_entries=1)
+    repeat = producer(repeat_store).produce(
+        run_id="run-rgbd-fixture", rgb=rgb(), depth=depth(), intrinsics=intrinsics(), detections=[detection()]
+    )
+    assert first.evidence_ref == repeat.evidence_ref
+    assert first.observations[0].observation.observation_id == repeat.observations[0].observation.observation_id
+    evidence = first_store.resolve(first.evidence_ref)
+    assert evidence is not None
+    assert not hasattr(evidence, "data")
+    assert not hasattr(evidence, "depth_m")
+    assert len(evidence.rgb_sha256) == 64
+    assert len(evidence.depth_sha256) == 64
+
+    next_batch = producer(first_store).produce(
+        run_id="run-rgbd-fixture",
+        rgb=rgb(sequence_no=8, data=bytes(reversed(range(27)))),
+        depth=depth(sequence_no=8),
+        intrinsics=intrinsics(),
+        detections=[detection()],
+    )
+    assert len(first_store) == 1
+    assert first_store.resolve(first.evidence_ref) is None
+    assert first_store.resolve(next_batch.evidence_ref) is not None
+
+
+def test_same_running_producer_rejects_duplicate_frame_pair() -> None:
+    target = producer()
+    arguments = {
+        "run_id": "run-rgbd-fixture",
+        "rgb": rgb(),
+        "depth": depth(),
+        "intrinsics": intrinsics(),
+        "detections": [detection()],
+    }
+    target.produce(**arguments)
+    with pytest.raises(RgbdObservationRejected, match="duplicate RGB-D frame pair"):
+        target.produce(**arguments)
+
+
+def test_typed_inputs_are_not_mutated() -> None:
+    rgb_frame = rgb()
+    depth_frame = depth()
+    calibration = intrinsics()
+    tag = detection()
+    before = (rgb_frame, depth_frame, calibration, tag)
+
+    producer().produce(
+        run_id="run-rgbd-fixture",
+        rgb=rgb_frame,
+        depth=depth_frame,
+        intrinsics=calibration,
+        detections=[tag],
+    )
+
+    assert before == (rgb_frame, depth_frame, calibration, tag)


### PR DESCRIPTION
## Related Issue

Related to #158.

This PR implements only the deterministic software portion. Real camera, calibration, ROS launch, fixture-accuracy and target-hardware performance evidence remain **NOT_EXECUTED**, so this PR intentionally does not close #158.

## What changed

- add a typed `KnownTargetRgbdProducer` for configured AprilTag/known-entity mappings;
- validate synchronized RGB, aligned depth, camera intrinsics, dimensions, sequence numbers, timestamps and clock domains;
- project valid aligned depth into a calibrated camera-frame pose using approved pinhole intrinsics;
- generate deterministic contract-valid `Observation` identities and evidence references;
- report unknown tags separately and never assign a guessed entity identity;
- fail closed on stale or future-skewed frame pairs, timestamp/clock mismatch, invalid depth, duplicate tags or frames, occlusion, low decision margin and excess hamming;
- retain bounded immutable RGB/depth hashes and frame metadata without embedding raw sensor payloads in observations or events;
- expose the camera ID, calibration revision and pose units required by the Issue #72 ingestion boundary;
- document the missing physical evidence as `NOT_EXECUTED`;
- add an Issue #158 Task Packet plus deterministic unit and integration coverage.

## Interfaces affected

None.

- no changes to `interfaces/`;
- no changes to `libs/contracts/`;
- no changes to hardware, deployment, ROS packaging, simulation, World Model, robot control or firmware;
- the producer consumes the existing `Observation`, `Pose`, detector and clock contracts;
- output is integrated through the existing Issue #72 `ObservationIngestionAdapter`.

## Tests and commands

```text
python -m pytest tests/unit/test_rgbd_producer.py tests/integration/test_rgbd_producer.py -q
20 passed

python -m pytest tests/unit/test_observation_ingestion.py tests/integration/test_observation_ingestion.py tests/unit/test_rgbd_producer.py tests/integration/test_rgbd_producer.py -q
34 passed

python -m pytest -q
480 passed

python -m ruff check services/perception/workbench_perception tests/unit/test_rgbd_producer.py tests/integration/test_rgbd_producer.py
PASS

python -m ruff format --check services/perception/workbench_perception tests/unit/test_rgbd_producer.py tests/integration/test_rgbd_producer.py
PASS

python tools/scripts/check_task_packet.py docs/task_packets/issue-158-real-rgbd-observations.json
PASS

python tools/scripts/validate_contracts.py
PASS

python tools/scripts/validate_scenarios.py
PASS — 12 frozen and 24 expanded manifests

python tools/scripts/check_context.py
PASS

git diff --check
PASS
```

The local Windows environment does not provide `make`; the corresponding Python test and validation commands were run directly.

## Evidence

- repository audit found only a planned Intel RealSense D435 README and no serialized camera, firmware revision, calibration artifact/hash, clock offset/drift measurement, real frames, ROS launch record or physical metrics;
- deterministic fixtures cover valid known tags, unknown tags, invalid/missing depth, stale and unsynchronised frames, clock mismatch, duplicate tags/frames, occlusion, low margin and excess hamming;
- integration coverage proves producer output passes the Issue #72 fail-closed ingestion adapter;
- evidence-store assertions prove bounded retention, deterministic hashes and absence of raw RGB/depth payloads;
- full tests, contracts, scenarios, context, lint, formatting and Task Packet validation pass.

## Risks and rollback

- this is a software-only stacked PR based on `feat/72-observation-ingestion`;
- #158 must remain open until a real ROS launch, owner-approved #75 calibration/time-sync evidence, fixture ground truth and target-hardware detection/latency/CPU/memory metrics exist;
- in-memory duplicate suppression and evidence retention do not survive process restart;
- tag orientation remains identity in the optical frame because no approved physical tag-size/pose-solver evidence exists;
- unknown calibration, depth, timing or identity fails closed instead of being guessed;
- after #72 merges, change this PR base to `main` and recheck the six-file diff and CI;
- rollback by reverting commit `9cc28625b55ab97294cf220ddaeb30e724019e59`; no schema or persistent-data migration is required.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.
