### PR TITLE
feat: add optional OmniLink knowledge adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,30 @@ For an offline fixture, run:
 python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
 ```
 
+## Optional: Connect OmniLink Knowledge Search
+
+[OmniLink AI](https://github.com/vivekmaru/omnilink-ai) is a separate, optional knowledge layer for maintenance docs, ADRs, issues, and run summaries. It does not plan tasks, execute actions, verify robot state, or control an emergency stop. Run it as its own service with its own SQLite database.
+
+```bash
+git clone https://github.com/vivekmaru/omnilink-ai.git
+cd omnilink-ai
+npm install
+npm run dev
+```
+
+OmniLink normally listens on `http://127.0.0.1:3000` (check its current configuration). The Workbench adapter adds no runtime dependency:
+
+```python
+from integrations.omnilink import OmniLinkClient, RunSummaryExporter
+
+client = OmniLinkClient("http://127.0.0.1:3000")
+docs = client.search("gripper calibration")
+answer = client.ask("Which calibration notes mention the gripper?")
+RunSummaryExporter(client, "http://127.0.0.1:8080").export(summary)
+```
+
+The exporter sends only a bounded run summary, never raw JSONL, `TaskGraph`, `SemanticAction`, action results, camera data, or safety state. Catch `OmniLinkError` so an unavailable knowledge service cannot block offline operation. For production, use private binding, authentication/TLS, outbound URL allowlists, a pinned commit/image digest, and a reviewed license and Gemini data-handling policy.
+
 For a configured external runner, provide tokenized argv through
 `WORKBENCH_GAZEBO_COMMAND` or `--command`. The runner uses each manifest's
 timeout, captures bounded stdout/stderr, terminates the process tree on timeout,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,6 +168,30 @@ make dashboard        # 启动只读本地看板
 python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
 ```
 
+## 可选：接入 OmniLink 知识库
+
+[OmniLink AI](https://github.com/vivekmaru/omnilink-ai) 在 Workbench 中是独立的知识层，用于检索维修文档、ADR、Issue 和运行摘要，不参与任务规划、动作执行、验证器或急停链路。它不是 Python 三方库，请单独部署服务和它自己的 SQLite 数据库。
+
+```bash
+git clone https://github.com/vivekmaru/omnilink-ai.git
+cd omnilink-ai
+npm install
+npm run dev
+```
+
+OmniLink 通常监听 `http://127.0.0.1:3000`（以 OmniLink 项目当前配置为准）。Workbench 侧无需新增运行时依赖：
+
+```python
+from integrations.omnilink import OmniLinkClient, RunSummaryExporter
+
+client = OmniLinkClient("http://127.0.0.1:3000")
+docs = client.search("gripper calibration")
+answer = client.ask("Which calibration notes mention the gripper?")
+RunSummaryExporter(client, "http://127.0.0.1:8080").export(summary)
+```
+
+导出器只发送运行摘要，不发送原始 JSONL、`TaskGraph`、`SemanticAction`、动作结果、相机数据或安全状态。捕获 `OmniLinkError` 可保证服务不可用时离线流程继续运行。生产部署请使用私网绑定、认证/TLS、出站 URL allowlist、固定 commit/image digest，并确认许可证和 Gemini 数据处理策略。
+
 真实 runner 需要通过 `WORKBENCH_GAZEBO_COMMAND` 或 `--command` 提供 tokenized
 argv。runner 会使用每个 manifest 的 timeout，限制 stdout/stderr 大小，在超时时终止整棵
 进程树，并在发布 artifact 前校验事件日志。

--- a/docs/task_packets/omnilink-integration.json
+++ b/docs/task_packets/omnilink-integration.json
@@ -6,7 +6,7 @@
   "read_only_paths": ["interfaces/**", "services/world_model/**", "robot/control/**", "firmware/**"],
   "forbidden": ["TaskGraph generation", "SemanticAction execution", "raw event export", "shared SQLite database"],
   "acceptance": ["bounded HTTP client", "response schema checks", "safe one-way run summary export", "offline failures remain isolated"],
-  "commands": ["pytest tests/integration/test_omnilink_client.py", "ruff check integrations tests/integration/test_omnilink_client.py"],
+  "commands": ["python -m pytest tests/integration/test_omnilink_client.py", "python -m ruff check integrations tests/integration/test_omnilink_client.py"],
   "evidence": ["mock HTTP test output"],
   "stop_conditions": ["license or security review failure", "interface conflict", "safety implication"]
 }

--- a/docs/task_packets/omnilink-integration.json
+++ b/docs/task_packets/omnilink-integration.json
@@ -1,0 +1,12 @@
+{
+  "issue": 2,
+  "human_owner": "Quchaosheng",
+  "objective": "Add an optional, read/search and run-summary export adapter for a separately hosted OmniLink instance.",
+  "allowed_paths": ["integrations/omnilink/**", "tests/integration/test_omnilink_client.py", "docs/task_packets/omnilink-integration.json"],
+  "read_only_paths": ["interfaces/**", "services/world_model/**", "robot/control/**", "firmware/**"],
+  "forbidden": ["TaskGraph generation", "SemanticAction execution", "raw event export", "shared SQLite database"],
+  "acceptance": ["bounded HTTP client", "response schema checks", "safe one-way run summary export", "offline failures remain isolated"],
+  "commands": ["pytest tests/integration/test_omnilink_client.py", "ruff check integrations tests/integration/test_omnilink_client.py"],
+  "evidence": ["mock HTTP test output"],
+  "stop_conditions": ["license or security review failure", "interface conflict", "safety implication"]
+}

--- a/integrations/omnilink/README.md
+++ b/integrations/omnilink/README.md
@@ -1,0 +1,23 @@
+# OmniLink integration
+
+This is an optional HTTP adapter to a separately hosted [OmniLink AI](https://github.com/vivekmaru/omnilink-ai) instance.
+It adds knowledge search, RAG questions, and one-way export of Workbench run summaries.
+
+## Quick start
+
+```python
+from integrations.omnilink import OmniLinkClient, RunSummaryExporter
+
+client = OmniLinkClient("http://127.0.0.1:3000")
+results = client.search("gripper calibration")
+answer = client.ask("Which calibration notes mention the gripper?")
+RunSummaryExporter(client, "http://127.0.0.1:8080").export(run_summary)
+```
+
+Keep OmniLink in its own process/container and database. The adapter never sends raw event streams,
+`TaskGraph`, `SemanticAction`, action results, camera data, or safety state. OmniLink being unavailable
+must not block Workbench's offline/control paths; catch `OmniLinkError` at optional call sites.
+
+Before deployment, bind OmniLink to a private interface, put authentication/TLS/rate limiting in front
+of it, allowlist outbound URLs, pin the OmniLink commit/image digest, and review its license and Gemini
+data handling policy.

--- a/integrations/omnilink/__init__.py
+++ b/integrations/omnilink/__init__.py
@@ -1,0 +1,11 @@
+"""Optional OmniLink knowledge integration for Workbench."""
+
+from .client import OmniLinkClient, OmniLinkError, OmniLinkResponseTooLarge
+from .exporter import RunSummaryExporter
+
+__all__ = [
+    "OmniLinkClient",
+    "OmniLinkError",
+    "OmniLinkResponseTooLarge",
+    "RunSummaryExporter",
+]

--- a/integrations/omnilink/client.py
+++ b/integrations/omnilink/client.py
@@ -1,0 +1,100 @@
+"""Small, fail-closed REST client for a separately hosted OmniLink instance."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+MAX_RESPONSE_BYTES = 1 * 1024 * 1024
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+class OmniLinkError(RuntimeError):
+    """OmniLink is unavailable or returned an invalid response."""
+
+
+class OmniLinkResponseTooLarge(OmniLinkError):
+    """The remote response exceeded the integration limit."""
+
+
+@dataclass(frozen=True)
+class OmniLinkClient:
+    base_url: str
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+    max_response_bytes: int = MAX_RESPONSE_BYTES
+
+    def __post_init__(self) -> None:
+        parsed = urllib.parse.urlparse(self.base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("base_url must be an http(s) URL")
+        if self.timeout_seconds <= 0 or self.max_response_bytes <= 0:
+            raise ValueError("timeout and response limit must be positive")
+        object.__setattr__(self, "base_url", self.base_url.rstrip("/"))
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                length = response.headers.get("Content-Length")
+                if length and int(length) > self.max_response_bytes:
+                    raise OmniLinkResponseTooLarge("OmniLink response exceeds configured limit")
+                raw = response.read(self.max_response_bytes + 1)
+        except OmniLinkResponseTooLarge:
+            raise
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise OmniLinkError("OmniLink request failed") from exc
+        if len(raw) > self.max_response_bytes:
+            raise OmniLinkResponseTooLarge("OmniLink response exceeds configured limit")
+        try:
+            decoded = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise OmniLinkError("OmniLink returned invalid JSON") from exc
+        if not isinstance(decoded, dict):
+            raise OmniLinkError("OmniLink response must be a JSON object")
+        return decoded
+
+    def search(self, query: str, *, limit: int = 10) -> dict[str, Any]:
+        if not query.strip():
+            raise ValueError("query must be non-empty")
+        if not 1 <= limit <= 50:
+            raise ValueError("limit must be between 1 and 50")
+        result = self._post("/api/ai/search/hybrid", {"query": query.strip(), "limit": limit})
+        if not isinstance(result.get("results"), list):
+            raise OmniLinkError("OmniLink search response is missing results")
+        return result
+
+    def ask(self, question: str) -> dict[str, Any]:
+        if not question.strip():
+            raise ValueError("question must be non-empty")
+        result = self._post("/api/ai/ask", {"question": question.strip()})
+        if not isinstance(result.get("answer"), str):
+            raise OmniLinkError("OmniLink answer response is missing answer")
+        return result
+
+    def save_bookmark(self, url: str, *, title: str, notes: str, tags: list[str] | None = None) -> dict[str, Any]:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("bookmark URL must be an http(s) URL")
+        result = self._post(
+            "/api/links",
+            {
+                "url": url,
+                "title": title[:500],
+                "notes": notes[:4000],
+                "tags": (tags or [])[:20],
+                "autoAiExtract": False,
+            },
+        )
+        if not isinstance(result.get("link"), dict):
+            raise OmniLinkError("OmniLink bookmark response is missing link")
+        return result

--- a/integrations/omnilink/exporter.py
+++ b/integrations/omnilink/exporter.py
@@ -1,0 +1,33 @@
+"""One-way export of safe run summaries into OmniLink bookmarks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .client import OmniLinkClient
+
+
+class RunSummaryExporter:
+    def __init__(self, client: OmniLinkClient, backend_base_url: str) -> None:
+        self.client = client
+        self.backend_base_url = backend_base_url.rstrip("/")
+
+    def export(self, summary: dict[str, Any]) -> dict[str, Any]:
+        """Export only the public projection; raw events and payloads stay local."""
+        run_id = summary.get("run_id")
+        if not isinstance(run_id, str) or not run_id:
+            raise ValueError("summary.run_id must be a non-empty string")
+        status = summary.get("status", "unknown")
+        title = f"Workbench run {run_id} ({status})"
+        notes = (
+            f"Run ID: {run_id}\nStatus: {status}\n"
+            f"Goal: {str(summary.get('goal', ''))[:500]}\n"
+            f"Event count: {summary.get('event_count', 0)}\n"
+            f"Evidence refs: {', '.join(str(x) for x in summary.get('evidence_refs', [])[:20])}"
+        )
+        return self.client.save_bookmark(
+            f"{self.backend_base_url}/api/v1/runs/{run_id}",
+            title=title,
+            notes=notes,
+            tags=["workbench", "run-summary", str(status)],
+        )

--- a/tests/integration/test_omnilink_client.py
+++ b/tests/integration/test_omnilink_client.py
@@ -1,0 +1,65 @@
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from integrations.omnilink import OmniLinkClient, OmniLinkError, OmniLinkResponseTooLarge, RunSummaryExporter
+
+
+class Handler(BaseHTTPRequestHandler):
+    response: ClassVar[dict[str, Any]] = {"results": [{"link": {"title": "Guide"}}]}
+    requests: ClassVar[list[tuple[str, dict[str, Any]]]] = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        self.__class__.requests.append((self.path, json.loads(self.rfile.read(length))))
+        body = json.dumps(self.response).encode()
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+
+@pytest.fixture
+def server():
+    Handler.requests = []
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_port}"
+    httpd.shutdown()
+
+
+def test_search_and_export_send_only_safe_projection(server):
+    client = OmniLinkClient(server)
+    assert client.search("robot safety")["results"]
+    Handler.response = {"link": {"id": "x"}}
+    RunSummaryExporter(client, server).export(
+        {"run_id": "run-1", "status": "confirmed", "goal": "secret?", "event_count": 3, "evidence_refs": ["sha256:abc"]}
+    )
+    assert Handler.requests[0][0] == "/api/ai/search/hybrid"
+    path, payload = Handler.requests[1]
+    assert path == "/api/links"
+    assert payload["autoAiExtract"] is False
+    assert "secret?" in payload["notes"]
+    assert "events" not in payload["notes"]
+
+
+def test_invalid_response_and_size_fail_closed(server):
+    Handler.response = {"unexpected": True}
+    with pytest.raises(OmniLinkError):
+        OmniLinkClient(server).search("x")
+    Handler.response = {"results": ["x" * 1000]}
+    with pytest.raises(OmniLinkResponseTooLarge):
+        OmniLinkClient(server, max_response_bytes=50).search("x")


### PR DESCRIPTION
## Summary
- add an optional REST client for OmniLink hybrid search, RAG Q&A, and bookmark creation
- export only bounded Workbench run summaries; keep raw events and control paths local
- add mock integration coverage and a task packet documenting boundaries

## Safety and compatibility
- no changes to interfaces/, services/world_model/, robot/control/, or firmware/
- no new runtime dependency; uses Python standard library
- OmniLink remains a separate process/database and is not required for offline operation

## Validation
- python -m pytest -q -> 881 passed, 1 skipped
- python -m ruff check integrations tests/integration/test_omnilink_client.py -> passed