### PR TITLE
docs: refresh README for a clearer project entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,259 +2,114 @@
 
 > **Verify before you say done.**
 >
-> Workbench Home Robot is an evidence-first foundation for mobile domestic
-> manipulators:
-> bounded actions, replayable event logs, and a verifier that can say
-> **confirmed**, **refuted**, or **insufficient evidence** instead of guessing.
-
-![Workbench Home Robot premium product concept](docs/assets/workbench-home-robot-premium.png)
-
-[Explore the interactive 3D product view](docs/assets/premium-product-render.html)
-
-The hero shows the bimanual parcel-assist pose; cleaning and supervised induction tools
-are separate quick-change concepts, not simultaneous performance claims.
+> An evidence-first foundation for mobile domestic robots: bounded actions,
+> replayable events, and a verifier that can say **confirmed**, **refuted**, or
+> **insufficient evidence**.
 
 [![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)](pyproject.toml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-2ea44f)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Quchaosheng/workbench-desk-robot?display_name=tag)](https://github.com/Quchaosheng/workbench-desk-robot/releases/latest)
-[![Status](https://img.shields.io/badge/status-software%20foundation-f0c36b)](#honest-status)
+[![CI](https://github.com/Quchaosheng/workbench-desk-robot/actions/workflows/ci.yml/badge.svg)](https://github.com/Quchaosheng/workbench-desk-robot/actions)
 
-[简体中文](README.zh-CN.md)
+![Workbench Home Robot](docs/assets/workbench-home-robot-premium.png)
 
-**Current software release:** [v0.2.0](https://github.com/Quchaosheng/workbench-desk-robot/releases/tag/v0.2.0),
-covering the deterministic offline runtime, five task families, hardened replay
-and contract boundaries, and the software-only MCU, CAN, Motion, and BSP foundations.
+[简体中文](README.zh-CN.md) · [Interactive 3D view](docs/assets/premium-product-render.html)
 
-The project is built around one practical question: **did the robot actually
-complete the task, and can we prove it?**
+## Why Workbench?
 
-The current mechanical baseline is **Revision D**: a 540 x 520 mm stabilized
-mobile base, 350 mm braked liftable torso, two seven-axis arms, 18 L parcel bay,
-and locked quick-change tools. Bimanual parcel handling, cleaning, and induction-cooking assistance
-are target capabilities awaiting end-to-end simulation and physical validation; the visual is not a claim of
-an assembled or certified product.
-
-## Why It Matters
-
-Most robot demos treat a successful command as a successful task. That is how a
-robot can report “placed” while the part is still on the floor.
-
-Workbench separates the layers that are usually blurred together:
-
-1. **Intent** — the model chooses from bounded semantic actions.
-2. **Execution** — trusted runtime code dispatches and records what happened.
-3. **Verification** — evidence is evaluated after the action, with no silent success.
-4. **Replay** — the complete event trail can be inspected and reconstructed.
-
-## What You Can Try Today
-
-The repository currently ships a deterministic, offline tabletop runtime. It
-covers placement, three-part kitting, inspection, obstacle-clearance recovery,
-and evidence-first parcel intake.
-
-```bash
-python tools/scripts/sim_cli.py doctor
-python tools/scripts/sim_cli.py list
-python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
-python tools/scripts/demo_scripted.py
-```
-
-The scripted runner creates an inspectable artifact containing the source
-manifest, materialized scene, event log, stdout/stderr, metadata, and checksums.
-It is deliberately labelled `SCRIPTED_FIXTURE` and `release_eligible: false`.
-
-## Core Contributions
-
-**Evidence-first verification**
-
-- Three-valued task status: `confirmed`, `refuted`, `insufficient_evidence`
-- Structured evidence references instead of a bare pass/fail bit
-- Post-action checks that retain failed attempts and recovery history
-
-**Contract-driven runtime**
-
-- 11 JSON schemas define module boundaries
-- Strict ingress validation and matching Pydantic models
-- Append-only SQLite event storage with integrity-checked replay, checkpoints,
-  and checksum-verified snapshot restore
-
-**Bounded agent behavior**
-
-- Model routes only to semantic actions such as `observe`, `grasp`, `place`,
-  `ask_confirm`, `express`, and `stop`
-- Registry-backed exact field, type, and range validation plus fail-closed policy checks
-- Joint positions, velocities, and emergency stop remain outside model reach
-- Dangerous or mixed-boundary goals fail closed
-
-**Operator visibility**
-
-- Read-only dashboard for task status, evidence, recovery, and replay
-- `doctor`, `list`, and `run` simulation controls with explicit execution states
-- Atomic run artifacts with raw logs, metadata, and SHA-256 checksums
-
-## Honest Status
-
-**Works today:** deterministic Python runtime, five task families, integrity-checked
-SQLite replay, read-only dashboard, local model routing, scenario validation,
-strict MCU Wire V1 and virtual safety-state tests, ROS-free motion preflight, and
-fail-closed simulation controls.
-
-**Not built yet:** an end-to-end Gazebo task world, a semantic MoveIt grasp/place
-adapter, an executed physical camera bridge, release-eligible Gazebo task results,
-and physical hardware evidence. The camera BSP integration is specified, but
-package compatibility, calibration and real sensor data remain `NOT_EXECUTED`.
-Scripted scenario fixtures are pipeline tests, not robot or Gazebo task evidence.
-The separate Phase 1/2 Motion artifacts are bounded evidence at their recorded
-commits; they do not prove an end-to-end task world or physical execution.
-
-**BSP baseline:** the logical prototype baseline names one Jetson Orin Nano Super 8 GB
-Linux board and six controller domains: base, left/right arm, left/right tool,
-and independent safety. The repository includes CAN identity, kernel/service
-requirements, firmware compatibility, cost review and fail-closed readiness
-checks under [`bsp/`](bsp/). Carrier-board pin/IRQ data, supplier protocols,
-boot images, AVL approval and physical bring-up remain blocked or
-`NOT_EXECUTED` until real evidence is attached.
-JetPack, L4T, kernel, rootfs, recovery, and toolchain sources and hashes remain
-unresolved; `bsp/image/build-inputs.yaml` intentionally records
-`status: inputs_unresolved`, and no boot image has been built.
-
-The camera baseline is one head-mounted Intel RealSense D435 over USB 3 using
-the Linux `uvcvideo`/V4L2 stack, `librealsense2`, and ROS 2
-`realsense2_camera`. Wrist cameras are intentionally deferred until a measured
-occlusion study justifies their cost. See the
-[camera BSP integration](docs/architecture/robot-bsp-camera-v0.1.md).
-
-The reproducibility guarantees are deliberately separate:
-
-1. The same frozen manifest and seed produce the same materialized scene hash.
-2. The same valid, ordered event log reduces to the same replay state.
-3. The scripted fixture generator emits the same ordered events only when its
-   complete input, including versions and configuration, is identical.
-
-A seed alone does not determine event order. None of these guarantees implies
-deterministic Gazebo physics, sensor noise, process timing, or physical behavior.
-
-## Validation and Platform Support
-
-The portable Python runtime is tested on Python 3.12. Native Windows support
-covers contracts, event processing, the read-only backend, monitoring, task
-packet validation, and deterministic fixture workflows. Linux-only features
-remain explicitly separate:
-
-| Boundary | Supported evidence | Not implied |
-| --- | --- | --- |
-| Python runtime | Unit and integration tests on Linux and Windows | Gazebo, ROS 2, or robot motion |
-| Containers | Runtime and devcontainer share one immutable Ubuntu digest | Reproducibility on an unpinned base image |
-| Dashboard backend | Versioned read-only API and bounded allow-listed remote event source | Public authentication or control authority |
-| `wbcan` | Kernel build, virtual fault/recovery stress, diagnostics, and idle/status-reader latency reports | Physical CAN timing, hard real-time guarantees, MCU behavior, or actuator safety |
-| Safety MCU | Platform-independent C state machine, Wire V1 codec, watchdog/STOP timing, and replay protection tested on Host/QEMU | CH32V307 CAN HAL behavior, electrical timing, or physical safety evidence |
-| Motion foundation | ROS-free deterministic trajectory preflight plus recorded Phase 1/2 reachability/controller evidence | A merged semantic planning/execution adapter, complete Gazebo task loop, or physical motion safety |
-| Robot BSP | Logical topology, provisional board/camera manifests, fail-closed readiness and unresolved image-input gates | A bootable image, approved orderable SKUs, calibration, physical CAN, E-stop, or thermal evidence |
-| Scripted scenarios | Deterministic fixture artifacts with checksums | Physical or Gazebo execution |
-
-The complete portable check is `python -m pytest`. Linux CI additionally owns
-container, MCU-QEMU, and privileged kernel-module gates. A merge is not treated
-as validated when any required job fails or is skipped.
-
-## Quickstart
-
-Ubuntu 24.04, WSL2, or Windows 11 with Python 3.12; no GPU is required for the
-portable runtime. Kernel-module, ROS 2, and container checks require Linux.
-
-```bash
-git clone https://github.com/Quchaosheng/workbench-desk-robot.git
-cd workbench-desk-robot
-make bootstrap
-make demo-scripted
-```
-
-On native Windows, install the editable development package and run the
-portable checks directly:
-
-```powershell
-py -3.12 -m pip install -e ".[dev]"
-py -3.12 -m pytest
-py -3.12 tools/scripts/demo_scripted.py
-```
-
-Useful commands:
-
-```bash
-make test             # unit and integration tests
-make lint             # Ruff checks
-make scenario-check   # manifest validation and deterministic scene checks
-make sim-doctor       # diagnose simulator dependencies
-make sim-list         # list scenarios and scene hashes
-make sim              # configured Gazebo runner; missing Gazebo is NOT_EXECUTED
-make dashboard        # read-only local dashboard
-```
-
-For an offline fixture, run:
-
-```bash
-python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
-```
-
-## Optional: Connect OmniLink Knowledge Search
-
-[OmniLink AI](https://github.com/vivekmaru/omnilink-ai) is a separate, optional knowledge layer for maintenance docs, ADRs, issues, and run summaries. It does not plan tasks, execute actions, verify robot state, or control an emergency stop. Run it as its own service with its own SQLite database.
-
-```bash
-git clone https://github.com/vivekmaru/omnilink-ai.git
-cd omnilink-ai
-npm install
-npm run dev
-```
-
-OmniLink normally listens on `http://127.0.0.1:3000` (check its current configuration). The Workbench adapter adds no runtime dependency:
-
-```python
-from integrations.omnilink import OmniLinkClient, RunSummaryExporter
-
-client = OmniLinkClient("http://127.0.0.1:3000")
-docs = client.search("gripper calibration")
-answer = client.ask("Which calibration notes mention the gripper?")
-RunSummaryExporter(client, "http://127.0.0.1:8080").export(summary)
-```
-
-The exporter sends only a bounded run summary, never raw JSONL, `TaskGraph`, `SemanticAction`, action results, camera data, or safety state. Catch `OmniLinkError` so an unavailable knowledge service cannot block offline operation. For production, use private binding, authentication/TLS, outbound URL allowlists, a pinned commit/image digest, and a reviewed license and Gemini data-handling policy.
-
-For a configured external runner, provide tokenized argv through
-`WORKBENCH_GAZEBO_COMMAND` or `--command`. The runner uses each manifest's
-timeout, captures bounded stdout/stderr, terminates the process tree on timeout,
-and validates the resulting event log before publishing the artifact.
-
-## Architecture Boundary
+Robot demos often treat “command accepted” as “task complete”. Workbench keeps
+the proof in the loop:
 
 ```text
 goal -> bounded planner -> semantic action -> trusted executor
                                       \-> event store -> verifier -> replay/dashboard
 ```
 
-The dashboard API is read-only. HTTP write methods return `405`; this service
-does not publish ROS, motion, MCU, or emergency-stop commands.
+| Layer | Responsibility |
+| --- | --- |
+| Intent | Select from a small, typed action vocabulary |
+| Execution | Dispatch through trusted runtime code |
+| Verification | Check post-action evidence; never guess success |
+| Replay | Rebuild the state from an append-only event stream |
 
-## Roadmap
+## Quickstart
 
-- **v0.1.0** — frozen regression baseline and evidence contracts
-- **v0.2.0 (current)** — five scripted task families, recovery paths, hardened
-  replay/contracts, and software-only MCU, CAN, Motion, and BSP foundations
-- **Next** — real Gazebo world, perception bridge, semantic motion adapter,
-  and simulation fault injectors
-- **Later** — hardware validation without changing the evidence boundary
+Requirements: Python 3.12. No GPU is required for the offline runtime.
+
+```bash
+git clone https://github.com/Quchaosheng/workbench-desk-robot.git
+cd workbench-desk-robot
+python -m pip install -e ".[dev]"
+python tools/scripts/sim_cli.py doctor
+python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
+```
+
+Run the full portable checks:
+
+```bash
+python -m pytest -q
+python -m ruff check .
+```
+
+The scripted runner writes a replayable artifact (manifest, scene, events,
+logs, metadata, and SHA-256 checksums) labelled `SCRIPTED_FIXTURE`.
+
+## What is included
+
+- Evidence-first verification with `confirmed`, `refuted`, and `insufficient_evidence`.
+- Strict JSON schemas and matching Pydantic contracts.
+- Append-only SQLite event storage with integrity-checked replay.
+- Fail-closed policy validation for bounded semantic tools.
+- Read-only dashboard and deterministic simulation fixtures.
+- Software-only foundations for MCU, CAN, Motion, and BSP boundaries.
+
+## Optional: OmniLink knowledge layer
+
+[OmniLink AI](https://github.com/vivekmaru/omnilink-ai) is an independent service
+for searching maintenance notes, ADRs, issues, and Workbench run summaries. It
+is not a planner, executor, verifier, or robot-control dependency.
+
+```bash
+git clone https://github.com/vivekmaru/omnilink-ai.git
+cd omnilink-ai
+npm install
+npm run dev                 # normally http://127.0.0.1:3000
+```
+
+Workbench uses the standard-library adapter in [`integrations/omnilink/`](integrations/omnilink/):
+
+```python
+from integrations.omnilink import OmniLinkClient
+
+client = OmniLinkClient("http://127.0.0.1:3000")
+results = client.search("gripper calibration")
+answer = client.ask("Which calibration notes mention the gripper?")
+```
+
+Only bounded run summaries are exportable. Raw JSONL, `TaskGraph`,
+`SemanticAction`, action results, camera data, and safety state stay in
+Workbench. Catch `OmniLinkError` so an unavailable knowledge service cannot
+block offline operation. See the [integration guide](integrations/omnilink/README.md)
+for deployment and security requirements.
+
+## Honest status
+
+The offline runtime and software boundaries are tested. End-to-end Gazebo worlds,
+real perception, semantic motion execution, and physical hardware evidence are
+not yet release claims. See [`docs/architecture/`](docs/architecture/) and
+[`sim/README.md`](sim/README.md) for the current evidence boundary.
 
 ## Documentation
 
 - [User guide](docs/user-guide/index.md)
 - [System architecture](docs/architecture/system.md)
+- [Simulation boundary](sim/README.md)
 - [Motion foundation](robot/control/README.md)
 - [Safety MCU](firmware/mcu/README.md)
 - [Robot BSP](bsp/README.md)
-- [Simulation boundary](sim/README.md)
 - [Deployment](docs/deployment/multi-host.md)
 - [Security policy](SECURITY.md)
-- [Contributing](CONTRIBUTING.md)
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+Apache-2.0. See [LICENSE](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,229 +2,102 @@
 
 > **先验证，再说完成。**
 >
-> Workbench Home Robot 是一个面向移动家务作业机器人的证据优先基础：受限语义动作、
-> 可回放事件日志，以及能够明确说出**已确认、未满足、证据不足**的验证器。
-
-![Workbench Home Robot 高质感产品概念图](docs/assets/workbench-home-robot-premium.png)
-
-[查看可旋转的 3D 产品主视觉](docs/assets/premium-product-render.html)
-
-主视觉只展示双臂取件姿态；清洁和感应炉锅边工具是独立快换概念，不代表同时执行或已完成验证。
+> 面向移动家务机器人的证据优先基础：受限动作、可回放事件，以及能够明确说出
+> **已确认、未满足、证据不足** 的验证器。
 
 [![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)](pyproject.toml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-2ea44f)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Quchaosheng/workbench-desk-robot?display_name=tag)](https://github.com/Quchaosheng/workbench-desk-robot/releases/latest)
-[![状态](https://img.shields.io/badge/status-软件基础-f0c36b)](#诚实状态)
+[![CI](https://github.com/Quchaosheng/workbench-desk-robot/actions/workflows/ci.yml/badge.svg)](https://github.com/Quchaosheng/workbench-desk-robot/actions)
 
-[English](README.md)
+![Workbench Home Robot](docs/assets/workbench-home-robot-premium.png)
 
-**当前软件版本：**[v0.2.0](https://github.com/Quchaosheng/workbench-desk-robot/releases/tag/v0.2.0)，
-覆盖确定性离线运行时、五类任务、强化后的回放与契约边界，以及仅限软件范围的 MCU、CAN、
-Motion 和 BSP 基础。
+[English](README.md) · [可旋转的 3D 产品视图](docs/assets/premium-product-render.html)
 
-这个项目只问一个很实际的问题：**机器人真的完成任务了吗？我们能证明吗？**
+## 为什么做 Workbench？
 
-当前机械基线是 **Revision D**：`540 × 520 mm` 稳定移动底座、`350 mm` 带刹车升降躯干、
-两只七轴机械臂、18 L 货舱和机械锁止快换工具。双臂取快递、清洁和感应炉锅边备餐是目标能力，
-仍需端到端仿真和样机验证；宣传图不是已装配或已认证产品的性能承诺。头部屏幕提供 `idle`、`happy`、
-`thinking`、`help_needed`、`task_complete`、`hot_zone_warning` 等状态。
-
-## 为什么值得做
-
-很多机器人 Demo 把“命令发送成功”当成“任务完成”。于是机器人可能报告“已放置”，
-但零件其实还在地上。
-
-Workbench 把容易混在一起的几层拆开：
-
-1. **意图**：模型只能选择受限的语义动作。
-2. **执行**：受信运行时负责下发，并记录真实结果。
-3. **验证**：动作之后检查证据，不静默报成功。
-4. **回放**：完整事件轨迹可以检查、重建和复盘。
-
-## 现在可以试什么
-
-仓库当前提供确定性的离线桌面运行时，覆盖放置、三件套齐套、工件检验、清障恢复和
-证据优先的快递入库分拣。
-
-```bash
-python tools/scripts/sim_cli.py doctor
-python tools/scripts/sim_cli.py list
-python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
-python tools/scripts/demo_scripted.py
-```
-
-脚本 runner 会生成可检查的 artifact：源 manifest、物化场景、事件日志、stdout/stderr、
-metadata 和 checksums。它会明确标记为 `SCRIPTED_FIXTURE`，并保持
-`release_eligible: false`。
-
-## 核心能力
-
-**证据优先验证**
-
-- 三态任务结论：`confirmed`、`refuted`、`insufficient_evidence`
-- 结构化证据引用，而不是一个裸的通过/失败字段
-- 动作之后检查，并保留失败尝试和恢复历史
-
-**契约驱动运行时**
-
-- 11 个 JSON schema 定义模块边界
-- 入口严格校验，并配套 Pydantic 模型
-- 仅追加 SQLite 事件库，支持完整性校验回放、检查点和带 checksum 校验的 snapshot 恢复
-
-**受限的 Agent 行为**
-
-- 模型只能路由 `observe`、`grasp`、`place`、`ask_confirm`、`express`、`stop`
-- 基于 registry 的字段、类型和范围精确校验，以及失败关闭式策略检查
-- 关节位置、速度和硬件急停不在模型权限内
-- 危险目标和越界目标默认失败关闭
-
-**操作员可见性**
-
-- 只读看板展示任务状态、证据、恢复和回放
-- `doctor`、`list`、`run` 明确区分真实执行、fixture 和未执行
-- 原子运行 artifact 保存原始日志、metadata 和 SHA-256 checksums
-
-## 诚实状态
-
-**现在可用：**确定性 Python runtime、五类任务、带完整性校验的 SQLite 回放、只读 dashboard、
-本地模型路由、场景校验、严格的 MCU Wire V1 与虚拟安全状态测试、无 ROS 依赖的运动预检，
-以及失败关闭式仿真控制面。
-
-**还没有：**端到端 Gazebo 任务世界、语义 MoveIt 抓取放置适配器、真实相机桥接、
-可用于发布判定的 Gazebo 任务结果和真实硬件证据。脚本场景 fixture 是软件链路测试，
-不是机器人或 Gazebo 任务证据。独立的 Phase 1/2 Motion artifact 只证明其记录提交上的有界能力，
-不证明端到端任务世界或物理执行。
-
-**BSP 基线：**逻辑原型基线指定一块 Jetson Orin Nano Super 8 GB Linux 主控和六个控制域：
-底盘、左右机械臂、左右末端以及独立安全域。[`bsp/`](bsp/) 已包含 CAN 身份、kernel/服务
-要求、固件兼容、成本审查和失败关闭式 readiness 校验。载板 pin/IRQ、供应商协议、启动镜像、
-AVL 审批和实机 bring-up 在真实证据到位前仍保持 `BLOCKED` 或 `NOT_EXECUTED`。
-JetPack、L4T、kernel、rootfs、recovery 和工具链来源及 hash 仍未解析；
-`bsp/image/build-inputs.yaml` 有意保持 `status: inputs_unresolved`，当前没有构建启动镜像。
-
-仓库提供的确定性保证彼此独立：
-
-1. 同一冻结 manifest 和 seed 会得到同一物化场景 hash。
-2. 同一份合法且顺序一致的事件日志会归约为同一回放状态。
-3. 只有完整输入、版本和配置都一致时，脚本 fixture 生成器才保证输出同一有序事件序列。
-
-seed 本身不能决定事件顺序；这些保证也不代表 Gazebo 物理、传感器噪声、进程时序或真实
-机器人行为完全确定。
-
-## 验证与平台支持
-
-可移植 Python 运行时以 Python 3.12 为基线。原生 Windows 支持覆盖契约、事件处理、只读后端、
-监控、Task Packet 校验和确定性 fixture 流程；Linux 专属能力保持独立边界：
-
-| 边界 | 已支持的证据 | 不代表 |
-| --- | --- | --- |
-| Python runtime | Linux 和 Windows 上的单元、集成测试 | Gazebo、ROS 2 或机器人运动 |
-| 容器 | runtime 与 devcontainer 使用同一个不可变 Ubuntu digest | 未固定基础镜像也可复现 |
-| Dashboard 后端 | 版本化只读 API 和有界 allow-list 远程事件源 | 公网认证或任何控制权限 |
-| `wbcan` | 内核构建、虚拟故障/恢复压力测试、诊断及 idle/status-reader 延迟报告 | 真实 CAN 时序、硬实时保证、MCU 行为或执行器安全 |
-| 安全 MCU | 跨平台 C 状态机、Wire V1 codec、watchdog/STOP 时序和 Host/QEMU replay protection 测试 | CH32V307 CAN HAL 行为、电气时序或物理安全证据 |
-| Motion 基础 | 无 ROS 依赖的确定性轨迹预检，以及已记录的 Phase 1/2 可达性/控制器证据 | 已合并的语义规划执行适配器、完整 Gazebo 任务闭环或物理运动安全 |
-| 机器人 BSP | 逻辑拓扑、暂定板卡/相机 manifest、失败关闭式 readiness 和未解析镜像输入门禁 | 可启动镜像、获批可采购 SKU、标定、真实 CAN、急停或散热证据 |
-| 脚本场景 | 带 checksum 的确定性 fixture artifact | 真实机器人或 Gazebo 执行 |
-
-完整的可移植检查是 `python -m pytest`。Linux CI 另外负责容器、MCU-QEMU 和特权内核模块
-门禁。任何必需 job 失败或被跳过时，都不能把该次合并视为已经验证。
-
-## 快速开始
-
-Ubuntu 24.04、WSL2 或安装 Python 3.12 的 Windows 11 都可运行可移植 runtime，且不需要
-GPU。内核模块、ROS 2 和容器检查仍要求 Linux。
-
-```bash
-git clone https://github.com/Quchaosheng/workbench-desk-robot.git
-cd workbench-desk-robot
-make bootstrap
-make demo-scripted
-```
-
-原生 Windows 可直接安装开发依赖并运行可移植检查：
-
-```powershell
-py -3.12 -m pip install -e ".[dev]"
-py -3.12 -m pytest
-py -3.12 tools/scripts/demo_scripted.py
-```
-
-常用命令：
-
-```bash
-make test             # 单元和集成测试
-make lint             # Ruff 检查
-make scenario-check   # 场景 manifest 和确定性校验
-make sim-doctor       # 诊断仿真依赖
-make sim-list         # 列出场景和 scene hash
-make sim              # 配置的 Gazebo runner；缺失时为 NOT_EXECUTED
-make dashboard        # 启动只读本地看板
-```
-
-离线 fixture：
-
-```bash
-python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
-```
-
-## 可选：接入 OmniLink 知识库
-
-[OmniLink AI](https://github.com/vivekmaru/omnilink-ai) 在 Workbench 中是独立的知识层，用于检索维修文档、ADR、Issue 和运行摘要，不参与任务规划、动作执行、验证器或急停链路。它不是 Python 三方库，请单独部署服务和它自己的 SQLite 数据库。
-
-```bash
-git clone https://github.com/vivekmaru/omnilink-ai.git
-cd omnilink-ai
-npm install
-npm run dev
-```
-
-OmniLink 通常监听 `http://127.0.0.1:3000`（以 OmniLink 项目当前配置为准）。Workbench 侧无需新增运行时依赖：
-
-```python
-from integrations.omnilink import OmniLinkClient, RunSummaryExporter
-
-client = OmniLinkClient("http://127.0.0.1:3000")
-docs = client.search("gripper calibration")
-answer = client.ask("Which calibration notes mention the gripper?")
-RunSummaryExporter(client, "http://127.0.0.1:8080").export(summary)
-```
-
-导出器只发送运行摘要，不发送原始 JSONL、`TaskGraph`、`SemanticAction`、动作结果、相机数据或安全状态。捕获 `OmniLinkError` 可保证服务不可用时离线流程继续运行。生产部署请使用私网绑定、认证/TLS、出站 URL allowlist、固定 commit/image digest，并确认许可证和 Gemini 数据处理策略。
-
-真实 runner 需要通过 `WORKBENCH_GAZEBO_COMMAND` 或 `--command` 提供 tokenized
-argv。runner 会使用每个 manifest 的 timeout，限制 stdout/stderr 大小，在超时时终止整棵
-进程树，并在发布 artifact 前校验事件日志。
-
-## 架构边界
+很多机器人 Demo 把“命令已接受”当成“任务已完成”。Workbench 把证据放回主链路：
 
 ```text
 目标 -> 受限规划器 -> 语义动作 -> 受信执行器
                          \-> 事件库 -> 验证器 -> 回放/看板
 ```
 
-Dashboard API 只读。所有 HTTP 写方法返回 `405`；服务不会发布 ROS、运动、MCU 或硬件急停命令。
+| 层 | 职责 |
+| --- | --- |
+| 意图 | 从小而严格的动作词表中选择 |
+| 执行 | 由受信运行时下发并记录 |
+| 验证 | 检查动作后的证据，不猜成功 |
+| 回放 | 从追加式事件流重建状态 |
 
-## 路线图
+## 3 分钟开始
 
-- **v0.1.0**：冻结回归基线和证据契约
-- **v0.2.0（当前）**：五类脚本任务、恢复路径、强化后的回放/契约，以及仅限软件范围的
-  MCU、CAN、Motion 和 BSP 基础
-- **下一步**：真实 Gazebo 世界、感知桥、语义运动适配器和仿真故障注入
-- **更远**：不改变证据边界的硬件验证
+要求：Python 3.12。离线运行时不需要 GPU。
+
+```bash
+git clone https://github.com/Quchaosheng/workbench-desk-robot.git
+cd workbench-desk-robot
+python -m pip install -e ".[dev]"
+python tools/scripts/sim_cli.py doctor
+python tools/scripts/sim_cli.py run normal-001 --runner scripted --output-dir runs/demo
+```
+
+运行完整的可移植检查：
+
+```bash
+python -m pytest -q
+python -m ruff check .
+```
+
+脚本 runner 会生成包含 manifest、场景、事件、日志、metadata 和 SHA-256 checksum 的可回放 artifact，并明确标记为 `SCRIPTED_FIXTURE`。
+
+## 当前包含
+
+- `confirmed`、`refuted`、`insufficient_evidence` 三态验证。
+- 严格 JSON schema 与对应的 Pydantic 契约。
+- 带完整性校验回放的追加式 SQLite 事件库。
+- 受限语义工具的失败关闭式策略校验。
+- 只读 dashboard 与确定性仿真 fixture。
+- MCU、CAN、Motion、BSP 的软件基础边界。
+
+## 可选：OmniLink 知识层
+
+[OmniLink AI](https://github.com/vivekmaru/omnilink-ai) 是独立运行的知识服务，用于检索维修笔记、ADR、Issue 和 Workbench 运行摘要。它不参与规划、执行、验证或机器人控制。
+
+```bash
+git clone https://github.com/vivekmaru/omnilink-ai.git
+cd omnilink-ai
+npm install
+npm run dev                 # 通常监听 http://127.0.0.1:3000
+```
+
+Workbench 通过 [`integrations/omnilink/`](integrations/omnilink/) 中的标准库适配器访问：
+
+```python
+from integrations.omnilink import OmniLinkClient
+
+client = OmniLinkClient("http://127.0.0.1:3000")
+results = client.search("gripper calibration")
+answer = client.ask("Which calibration notes mention the gripper?")
+```
+
+只能导出有界的运行摘要。原始 JSONL、`TaskGraph`、`SemanticAction`、动作结果、相机数据和安全状态始终留在 Workbench。捕获 `OmniLinkError` 可保证知识服务不可用时离线流程继续。部署和安全要求见[集成说明](integrations/omnilink/README.md)。
+
+## 诚实状态
+
+离线运行时和软件边界已有测试。端到端 Gazebo 世界、真实感知、语义运动执行和物理硬件证据尚不构成发布承诺。当前证据边界见 [`docs/architecture/`](docs/architecture/) 和 [`sim/README.md`](sim/README.md)。
 
 ## 文档
 
 - [用户指南](docs/user-guide/index.md)
 - [系统架构](docs/architecture/system.md)
+- [仿真边界](sim/README.md)
 - [Motion 基础](robot/control/README.md)
 - [安全 MCU](firmware/mcu/README.md)
 - [机器人 BSP](bsp/README.md)
-- [仿真边界](sim/README.md)
-- [分机部署](docs/deployment/multi-host.md)
+- [多主机部署](docs/deployment/multi-host.md)
 - [安全策略](SECURITY.md)
-- [贡献指南](CONTRIBUTING.md)
 
 ## 许可证
 
-Apache-2.0。详见 [LICENSE](LICENSE) 和 [NOTICE](NOTICE)。
+Apache-2.0，详见 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary
- streamline English and Chinese README pages around Quickstart, architecture, capabilities, and honest status
- make OmniLink integration a concise optional knowledge-layer section
- move deep implementation detail to linked documentation

## Validation
- git diff --check passed
- existing full test suite remains green on the source branch (881 passed, 1 skipped)