### PR TITLE
feat(linux): add UART/SPI software contract and fake transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 
 .PHONY: bootstrap lint fmt test contract scenario-check golden-check evaluation-check evaluation-scripted context-check \
 	dashboard-test dashboard demo demo-scripted demo-offline demo-model model-provision performance-test benchmark-startup \
-	benchmark-resources performance-regression-test offline-integration docs task-check check container-smoke \
+	benchmark-resources performance-regression-test offline-integration uart-spi-test docs task-check check container-smoke \
 	sim sim-doctor sim-list sim-run
 
 bootstrap:
@@ -89,6 +89,9 @@ dashboard-test:
 
 offline-integration:
 	$(PYTHON) -m pytest tests/integration/test_offline_system.py -v
+
+uart-spi-test:
+	$(PYTHON) -m pytest tests/unit/test_uart_spi_contract.py -v
 
 dashboard:
 	$(PYTHON) -m workbench_backend.server --host 127.0.0.1 --port 8080

--- a/docs/architecture/linux-drivers.md
+++ b/docs/architecture/linux-drivers.md
@@ -98,3 +98,7 @@ LINUX5/LINUX6 的实现必须在硬件资源确认后补充以下内容：
 不能作为真实吞吐、延迟或 jitter 的证据。后续驱动 PR 应先补齐目标控制器型号、
 寄存器/设备树资源和内核版本，再分别实现 CAN、UART/SPI、GPIO、DMA 和 IRQ 模块，
 并沿用本架构的错误回滚、数据所有权和证据要求。
+
+LINUX3 的 UART/SPI 软件契约和 fake transport 测试位于仓库的
+`hardware/linux_drivers/uart_spi/`。该契约是 owner-gated 的提案：它固化边界、CRC、
+序号、背压和重试测试，但不冻结物理控制器、pinmux、设备树、DMA 或 IRQ 参数。

--- a/docs/task_packets/linux-uart-spi-contract.json
+++ b/docs/task_packets/linux-uart-spi-contract.json
@@ -1,0 +1,58 @@
+{
+  "issue": "LINUX3",
+  "human_owner": "Quchaosheng",
+  "objective": "Define and test a bounded software UART/SPI framing contract with an injectable fake transport while leaving physical controller, pinmux and device-tree choices to the hardware owners.",
+  "allowed_paths": [
+    "hardware/linux_drivers/uart_spi/**",
+    "hardware/linux_drivers/README.md",
+    "tests/unit/test_uart_spi_contract.py",
+    "Makefile",
+    "docs/architecture/linux-drivers.md",
+    "docs/task_packets/linux-uart-spi-contract.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**"
+  ],
+  "acceptance": [
+    "UART and SPI frames have bounded magic, version, transport, sequence, payload-length and CRC validation",
+    "partial reads and writes are reassembled without changing frame ownership",
+    "duplicate, stale and ambiguous sequence numbers fail closed, including the 16-bit wrap boundary",
+    "fake transport queue capacity, closed state, transient write failure and retry budget are observable",
+    "tests cover both UART and SPI while no frozen interface schema or physical hardware ABI is changed",
+    "documentation marks baud rate, SPI clock, pinmux, DMA, IRQ and device-tree resources as owner-gated prerequisites"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/linux-uart-spi-contract.json",
+    "python3 -m pytest tests/unit/test_uart_spi_contract.py -v",
+    "make uart-spi-test",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "focused UART/SPI contract test output",
+    "fake transport partial-I/O, CRC, sequence, backpressure and retry assertions",
+    "repository gate output",
+    "software-only scope and owner-gated hardware prerequisites"
+  ],
+  "stop_conditions": [
+    "a production UART/SPI ABI or frozen interface schema change is required",
+    "a physical controller, pinmux, device-tree, DMA or IRQ choice is required",
+    "MCU firmware changes are required to define frame semantics",
+    "software fake evidence would be presented as line-rate, signal-integrity or hard-real-time hardware evidence"
+  ]
+}

--- a/hardware/linux_drivers/README.md
+++ b/hardware/linux_drivers/README.md
@@ -13,6 +13,10 @@
 面向发布的架构说明位于
 [`docs/architecture/linux-drivers.md`](../../docs/architecture/linux-drivers.md)。
 
+LINUX3 的软件 UART/SPI 帧契约和 fake transport 位于
+[`uart_spi/README.md`](uart_spi/README.md)。该实现只验证有界编码、CRC、序号、背压、
+重试和错误处理；真实控制器、pinmux、设备树、DMA 和 IRQ 参数仍由硬件负责人确认。
+
 ## 分层边界
 
 ```text

--- a/hardware/linux_drivers/uart_spi/README.md
+++ b/hardware/linux_drivers/uart_spi/README.md
@@ -1,0 +1,42 @@
+# UART/SPI 软件契约
+
+这是 LINUX3 的软件提案和 fake transport 测试边界，不是已经冻结的生产硬件 ABI。
+它不决定真实 UART 波特率、SPI 时钟、设备树节点、DMA 通道、IRQ 号或 pinmux；这些
+参数需要 PCB、MCU 和 Linux Owner 共同确认后才能实现物理驱动。
+
+## 帧格式
+
+每个传输使用一个有界二进制帧：
+
+| 字段 | 大小 | 编码 |
+|---|---:|---|
+| magic | 2 | ASCII `WB` |
+| version | 1 | `0x01` |
+| transport | 1 | UART=`1`，SPI=`2` |
+| sequence | 2 | big-endian，无符号 |
+| payload length | 2 | big-endian，最大 256 |
+| payload | 0-256 | 不可变字节串 |
+| CRC | 2 | CRC-16/CCITT-FALSE，覆盖 header + payload |
+
+最小帧长为 10 字节，最大帧长为 266 字节。接收方在校验 magic、版本、传输类型、
+长度和 CRC 之前不得把 payload 交给上层。
+
+## 序号、重试和队列
+
+- 序号为 16 位；接收方使用模 65536 的半范围规则判断新帧。
+- 重复、过期或半范围歧义的序号直接拒绝，不更新接收状态。
+- 重试复用同一序号和同一帧字节，不得因重试产生新的逻辑消息。
+- fake transport 的队列容量有上限；队列满返回 backpressure，不能静默丢弃。
+- `UartSpiSession` 最多允许 3 次重试；关闭的传输、写入异常和超时都显式失败。
+- partial write/read 由 session 重组；只有完整 CRC 校验通过的帧才会返回。
+
+## 生产接入前的待确认项
+
+1. UART/SPI 控制器和 Linux 内核版本；
+2. 设备树/ACPI 节点、设备名、pinmux、CS 和电平转换；
+3. MCU 端帧语义、ACK 关联、超时和错误码；
+4. 是否启用 DMA、IRQ 触发方式和缓存一致性要求；
+5. 队列容量、实时预算和目标硬件原始收发证据。
+
+当前 fake transport 只能验证编码、边界、所有权、重试、背压和错误恢复。它不能证明
+物理信号完整性、UART/SPI 线速、DMA 吞吐、IRQ jitter 或 MCU 行为。

--- a/hardware/linux_drivers/uart_spi/__init__.py
+++ b/hardware/linux_drivers/uart_spi/__init__.py
@@ -1,0 +1,33 @@
+"""Software-only UART/SPI framing contract and deterministic fake transport."""
+
+from .contract import (
+    MAX_PAYLOAD_BYTES,
+    FrameCrcError,
+    FrameError,
+    FrameFormatError,
+    SequenceError,
+    TransportBackpressure,
+    TransportClosed,
+    TransportIOError,
+    TransportKind,
+    UartSpiFrame,
+    UartSpiSession,
+    crc16_ccitt,
+)
+from .fake_transport import FakeTransport
+
+__all__ = [
+    "MAX_PAYLOAD_BYTES",
+    "FakeTransport",
+    "FrameCrcError",
+    "FrameError",
+    "FrameFormatError",
+    "SequenceError",
+    "TransportBackpressure",
+    "TransportClosed",
+    "TransportIOError",
+    "TransportKind",
+    "UartSpiFrame",
+    "UartSpiSession",
+    "crc16_ccitt",
+]

--- a/hardware/linux_drivers/uart_spi/contract.py
+++ b/hardware/linux_drivers/uart_spi/contract.py
@@ -79,7 +79,13 @@ class UartSpiFrame:
             raise FrameFormatError(f"payload exceeds {MAX_PAYLOAD_BYTES} bytes")
 
     def encode(self) -> bytes:
-        header = HEADER.pack(MAGIC, PROTOCOL_VERSION, int(self.transport), self.sequence, len(self.payload))
+        header = HEADER.pack(
+            MAGIC,
+            PROTOCOL_VERSION,
+            int(self.transport),
+            self.sequence,
+            len(self.payload),
+        )
         body = header + self.payload
         return body + CRC.pack(crc16_ccitt(body))
 
@@ -105,7 +111,7 @@ class UartSpiFrame:
         expected_length = HEADER.size + payload_length + CRC.size
         if len(raw) != expected_length:
             raise FrameFormatError("frame length does not match its payload length")
-        if CRC.unpack(raw[-CRC.size:])[0] != crc16_ccitt(raw[:-CRC.size]):
+        if CRC.unpack(raw[-CRC.size :])[0] != crc16_ccitt(raw[: -CRC.size]):
             raise FrameCrcError("frame CRC does not match payload")
         return cls(transport, sequence, raw[HEADER.size : HEADER.size + payload_length])
 

--- a/hardware/linux_drivers/uart_spi/contract.py
+++ b/hardware/linux_drivers/uart_spi/contract.py
@@ -105,7 +105,7 @@ class UartSpiFrame:
         expected_length = HEADER.size + payload_length + CRC.size
         if len(raw) != expected_length:
             raise FrameFormatError("frame length does not match its payload length")
-        if CRC.unpack(raw[-CRC.size :])[0] != crc16_ccitt(raw[:-CRC.size]):
+        if CRC.unpack(raw[-CRC.size:])[0] != crc16_ccitt(raw[:-CRC.size]):
             raise FrameCrcError("frame CRC does not match payload")
         return cls(transport, sequence, raw[HEADER.size : HEADER.size + payload_length])
 

--- a/hardware/linux_drivers/uart_spi/contract.py
+++ b/hardware/linux_drivers/uart_spi/contract.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import struct
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Callable, Protocol
+from typing import Protocol
 
 MAGIC = b"WB"
 PROTOCOL_VERSION = 1
@@ -83,7 +84,7 @@ class UartSpiFrame:
         return body + CRC.pack(crc16_ccitt(body))
 
     @classmethod
-    def decode(cls, raw: bytes, *, expected_transport: TransportKind | None = None) -> "UartSpiFrame":
+    def decode(cls, raw: bytes, *, expected_transport: TransportKind | None = None) -> UartSpiFrame:
         if not isinstance(raw, bytes) or len(raw) < HEADER.size + CRC.size:
             raise FrameFormatError("frame is shorter than the minimum header and CRC")
         if len(raw) > MAX_FRAME_BYTES:

--- a/hardware/linux_drivers/uart_spi/contract.py
+++ b/hardware/linux_drivers/uart_spi/contract.py
@@ -1,0 +1,211 @@
+"""Bounded UART/SPI framing contract for software adapter tests."""
+
+from __future__ import annotations
+
+import struct
+import time
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Callable, Protocol
+
+MAGIC = b"WB"
+PROTOCOL_VERSION = 1
+MAX_PAYLOAD_BYTES = 256
+HEADER = struct.Struct(">2sBBHH")
+CRC = struct.Struct(">H")
+MAX_FRAME_BYTES = HEADER.size + MAX_PAYLOAD_BYTES + CRC.size
+
+
+class FrameError(ValueError):
+    """Base class for malformed or unsupported frames."""
+
+
+class FrameFormatError(FrameError):
+    """The frame shape, header or bounds are invalid."""
+
+
+class FrameCrcError(FrameError):
+    """The frame payload was corrupted in transit."""
+
+
+class SequenceError(FrameError):
+    """An inbound frame is duplicate, stale or ambiguous."""
+
+
+class TransportClosed(ConnectionError):
+    """The transport is not open."""
+
+
+class TransportBackpressure(TimeoutError):
+    """The bounded transport queue is full."""
+
+
+class TransportIOError(ConnectionError):
+    """The fake transport injected an I/O failure."""
+
+
+class TransportKind(IntEnum):
+    UART = 1
+    SPI = 2
+
+
+def crc16_ccitt(data: bytes, initial: int = 0xFFFF) -> int:
+    """Return CRC-16/CCITT-FALSE for one bounded frame."""
+    crc = initial
+    for byte in data:
+        crc ^= byte << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x1021) & 0xFFFF if crc & 0x8000 else (crc << 1) & 0xFFFF
+    return crc
+
+
+@dataclass(frozen=True, slots=True)
+class UartSpiFrame:
+    """A complete framed payload owned by one UART or SPI endpoint."""
+
+    transport: TransportKind
+    sequence: int
+    payload: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.transport, TransportKind):
+            raise FrameFormatError("transport must be UART or SPI")
+        if type(self.sequence) is not int or not 0 <= self.sequence <= 0xFFFF:
+            raise FrameFormatError("sequence must be an unsigned 16-bit integer")
+        if not isinstance(self.payload, bytes):
+            raise FrameFormatError("payload must be immutable bytes")
+        if len(self.payload) > MAX_PAYLOAD_BYTES:
+            raise FrameFormatError(f"payload exceeds {MAX_PAYLOAD_BYTES} bytes")
+
+    def encode(self) -> bytes:
+        header = HEADER.pack(MAGIC, PROTOCOL_VERSION, int(self.transport), self.sequence, len(self.payload))
+        body = header + self.payload
+        return body + CRC.pack(crc16_ccitt(body))
+
+    @classmethod
+    def decode(cls, raw: bytes, *, expected_transport: TransportKind | None = None) -> "UartSpiFrame":
+        if not isinstance(raw, bytes) or len(raw) < HEADER.size + CRC.size:
+            raise FrameFormatError("frame is shorter than the minimum header and CRC")
+        if len(raw) > MAX_FRAME_BYTES:
+            raise FrameFormatError("frame exceeds the maximum bounded size")
+        magic, version, kind, sequence, payload_length = HEADER.unpack(raw[: HEADER.size])
+        if magic != MAGIC:
+            raise FrameFormatError("invalid frame magic")
+        if version != PROTOCOL_VERSION:
+            raise FrameFormatError(f"unsupported protocol version: {version}")
+        try:
+            transport = TransportKind(kind)
+        except ValueError as exc:
+            raise FrameFormatError(f"unsupported transport kind: {kind}") from exc
+        if expected_transport is not None and transport is not expected_transport:
+            raise FrameFormatError("frame transport does not match the endpoint")
+        if payload_length > MAX_PAYLOAD_BYTES:
+            raise FrameFormatError("payload length exceeds the bounded maximum")
+        expected_length = HEADER.size + payload_length + CRC.size
+        if len(raw) != expected_length:
+            raise FrameFormatError("frame length does not match its payload length")
+        if CRC.unpack(raw[-CRC.size :])[0] != crc16_ccitt(raw[:-CRC.size]):
+            raise FrameCrcError("frame CRC does not match payload")
+        return cls(transport, sequence, raw[HEADER.size : HEADER.size + payload_length])
+
+
+class TransportPort(Protocol):
+    def open(self) -> None: ...
+
+    def close(self) -> None: ...
+
+    def write(self, data: bytes, timeout_s: float) -> int: ...
+
+    def read(self, max_bytes: int, timeout_s: float) -> bytes: ...
+
+
+def _is_newer(sequence: int, previous: int) -> bool:
+    delta = (sequence - previous) & 0xFFFF
+    return 0 < delta <= 0x7FFF
+
+
+class UartSpiSession:
+    """Bounded framed I/O session over an injected UART/SPI transport."""
+
+    def __init__(
+        self,
+        transport: TransportPort,
+        kind: TransportKind,
+        *,
+        max_retries: int = 1,
+        read_chunk_bytes: int = 64,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if type(max_retries) is not int or not 0 <= max_retries <= 3:
+            raise ValueError("max_retries must be between 0 and 3")
+        if type(read_chunk_bytes) is not int or not 1 <= read_chunk_bytes <= MAX_FRAME_BYTES:
+            raise ValueError("read_chunk_bytes is outside the bounded range")
+        if not isinstance(kind, TransportKind):
+            raise ValueError("kind must be UART or SPI")
+        self.transport = transport
+        self.kind = kind
+        self.max_retries = max_retries
+        self.read_chunk_bytes = read_chunk_bytes
+        self.clock = clock
+        self._rx_buffer = bytearray()
+        self._last_rx_sequence: int | None = None
+
+    def open(self) -> None:
+        self.transport.open()
+
+    def close(self) -> None:
+        self.transport.close()
+
+    def send(self, payload: bytes, sequence: int, *, timeout_s: float = 1.0) -> UartSpiFrame:
+        frame = UartSpiFrame(self.kind, sequence, payload)
+        encoded = frame.encode()
+        last_error: Exception | None = None
+        for _attempt in range(self.max_retries + 1):
+            offset = 0
+            try:
+                while offset < len(encoded):
+                    written = self.transport.write(encoded[offset:], timeout_s)
+                    if type(written) is not int or not 0 < written <= len(encoded) - offset:
+                        raise TransportIOError("transport returned an invalid write length")
+                    offset += written
+                return frame
+            except (TransportBackpressure, TransportClosed, TransportIOError) as exc:
+                if offset:
+                    raise TransportIOError("partial write failed; retry is unsafe") from exc
+                last_error = exc
+        assert last_error is not None
+        raise last_error
+
+    def receive(self, *, timeout_s: float = 1.0) -> UartSpiFrame:
+        deadline = self.clock() + timeout_s
+        while True:
+            frame = self._take_frame_from_buffer()
+            if frame is not None:
+                if self._last_rx_sequence is not None and not _is_newer(frame.sequence, self._last_rx_sequence):
+                    raise SequenceError(
+                        f"sequence {frame.sequence} is duplicate or stale after {self._last_rx_sequence}"
+                    )
+                self._last_rx_sequence = frame.sequence
+                return frame
+            remaining = deadline - self.clock()
+            if remaining <= 0:
+                raise TimeoutError("timed out waiting for a complete UART/SPI frame")
+            chunk = self.transport.read(self.read_chunk_bytes, remaining)
+            if not chunk:
+                raise TimeoutError("transport returned no data before the deadline")
+            self._rx_buffer.extend(chunk)
+            if len(self._rx_buffer) > MAX_FRAME_BYTES:
+                raise FrameFormatError("receive buffer exceeded the bounded frame size")
+
+    def _take_frame_from_buffer(self) -> UartSpiFrame | None:
+        if len(self._rx_buffer) < HEADER.size:
+            return None
+        payload_length = HEADER.unpack(self._rx_buffer[: HEADER.size])[-1]
+        if payload_length > MAX_PAYLOAD_BYTES:
+            raise FrameFormatError("payload length exceeds the maximum")
+        frame_length = HEADER.size + payload_length + CRC.size
+        if len(self._rx_buffer) < frame_length:
+            return None
+        raw = bytes(self._rx_buffer[:frame_length])
+        del self._rx_buffer[:frame_length]
+        return UartSpiFrame.decode(raw, expected_transport=self.kind)

--- a/hardware/linux_drivers/uart_spi/fake_transport.py
+++ b/hardware/linux_drivers/uart_spi/fake_transport.py
@@ -1,0 +1,73 @@
+"""Deterministic bounded fake UART/SPI transport for contract tests."""
+
+from __future__ import annotations
+
+from collections import deque
+
+from .contract import TransportBackpressure, TransportClosed, TransportIOError
+
+
+class FakeTransport:
+    """Loopback transport with bounded queues and injectable failures."""
+
+    def __init__(self, *, capacity: int = 4, max_write_bytes: int | None = None) -> None:
+        if type(capacity) is not int or not 1 <= capacity <= 64:
+            raise ValueError("capacity must be between 1 and 64")
+        if max_write_bytes is not None and (type(max_write_bytes) is not int or max_write_bytes < 1):
+            raise ValueError("max_write_bytes must be positive")
+        self.capacity = capacity
+        self.max_write_bytes = max_write_bytes
+        self._chunks: deque[bytes] = deque()
+        self.opened = False
+        self.fail_next_write = False
+        self.fail_next_read = False
+
+    @property
+    def queued_chunks(self) -> int:
+        return len(self._chunks)
+
+    def open(self) -> None:
+        self.opened = True
+
+    def close(self) -> None:
+        self.opened = False
+
+    def write(self, data: bytes, timeout_s: float) -> int:
+        del timeout_s
+        self._ensure_open()
+        if self.fail_next_write:
+            self.fail_next_write = False
+            raise TransportIOError("injected write failure")
+        if not data:
+            raise TransportIOError("empty writes are not valid")
+        if len(self._chunks) >= self.capacity:
+            raise TransportBackpressure("fake transport queue is full")
+        count = min(len(data), self.max_write_bytes or len(data))
+        self._chunks.append(bytes(data[:count]))
+        return count
+
+    def read(self, max_bytes: int, timeout_s: float) -> bytes:
+        del timeout_s
+        self._ensure_open()
+        if self.fail_next_read:
+            self.fail_next_read = False
+            raise TransportIOError("injected read failure")
+        if not self._chunks:
+            raise TimeoutError("fake transport has no data")
+        chunk = self._chunks.popleft()
+        if len(chunk) <= max_bytes:
+            return chunk
+        self._chunks.appendleft(chunk[max_bytes:])
+        return chunk[:max_bytes]
+
+    def inject_rx(self, data: bytes) -> None:
+        self._ensure_open()
+        if not isinstance(data, bytes) or not data:
+            raise ValueError("injected data must be non-empty bytes")
+        if len(self._chunks) >= self.capacity:
+            raise TransportBackpressure("fake transport queue is full")
+        self._chunks.append(data)
+
+    def _ensure_open(self) -> None:
+        if not self.opened:
+            raise TransportClosed("fake transport is closed")

--- a/tests/unit/test_uart_spi_contract.py
+++ b/tests/unit/test_uart_spi_contract.py
@@ -29,7 +29,9 @@ def session(
 
 
 @pytest.mark.parametrize("kind", [TransportKind.UART, TransportKind.SPI])
-def test_frame_round_trip_preserves_transport_sequence_and_payload(kind: TransportKind) -> None:
+def test_frame_round_trip_preserves_transport_sequence_and_payload(
+    kind: TransportKind,
+) -> None:
     frame = UartSpiFrame(kind, 42, b"status")
 
     decoded = UartSpiFrame.decode(frame.encode(), expected_transport=kind)

--- a/tests/unit/test_uart_spi_contract.py
+++ b/tests/unit/test_uart_spi_contract.py
@@ -1,0 +1,131 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "hardware" / "linux_drivers"))
+
+from uart_spi import (
+    FakeTransport,
+    FrameCrcError,
+    FrameFormatError,
+    SequenceError,
+    TransportBackpressure,
+    TransportClosed,
+    TransportKind,
+    UartSpiFrame,
+    UartSpiSession,
+)
+
+
+def session(
+    kind: TransportKind = TransportKind.UART, **transport_options: object
+) -> tuple[UartSpiSession, FakeTransport]:
+    transport = FakeTransport(**transport_options)
+    current = UartSpiSession(transport, kind, read_chunk_bytes=7)
+    current.open()
+    return current, transport
+
+
+@pytest.mark.parametrize("kind", [TransportKind.UART, TransportKind.SPI])
+def test_frame_round_trip_preserves_transport_sequence_and_payload(kind: TransportKind) -> None:
+    frame = UartSpiFrame(kind, 42, b"status")
+
+    decoded = UartSpiFrame.decode(frame.encode(), expected_transport=kind)
+
+    assert decoded == frame
+
+
+def test_frame_rejects_crc_version_length_and_transport_errors() -> None:
+    valid = UartSpiFrame(TransportKind.UART, 1, b"hello").encode()
+    corrupted = valid[:-1] + bytes([valid[-1] ^ 0xFF])
+    with pytest.raises(FrameCrcError):
+        UartSpiFrame.decode(corrupted)
+
+    wrong_version = valid[:2] + bytes([2]) + valid[3:]
+    with pytest.raises(FrameFormatError, match="version"):
+        UartSpiFrame.decode(wrong_version)
+
+    with pytest.raises(FrameFormatError, match="length"):
+        UartSpiFrame.decode(valid[:-1])
+
+    with pytest.raises(FrameFormatError, match="does not match"):
+        UartSpiFrame.decode(valid, expected_transport=TransportKind.SPI)
+
+
+def test_frame_rejects_mutable_or_oversized_payload() -> None:
+    with pytest.raises(FrameFormatError, match="immutable"):
+        UartSpiFrame(TransportKind.UART, 1, bytearray(b"bad"))
+    with pytest.raises(FrameFormatError, match="256"):
+        UartSpiFrame(TransportKind.UART, 1, b"x" * 257)
+
+
+def test_session_reassembles_partial_writes_and_reads() -> None:
+    current, transport = session(capacity=16, max_write_bytes=3)
+
+    sent = current.send(b"partial", 10)
+    received = current.receive()
+
+    assert sent.sequence == received.sequence == 10
+    assert received.payload == b"partial"
+    assert transport.queued_chunks == 0
+
+
+def test_session_retries_a_transient_write_failure_with_same_frame() -> None:
+    current, _transport = session()
+    current.transport.fail_next_write = True
+
+    sent = current.send(b"retry", 11)
+    received = current.receive()
+
+    assert sent == received
+
+
+def test_session_rejects_duplicate_and_stale_sequences() -> None:
+    current, transport = session()
+    frame = UartSpiFrame(TransportKind.UART, 5, b"one").encode()
+    transport.inject_rx(frame)
+    assert current.receive().sequence == 5
+
+    transport.inject_rx(frame)
+    with pytest.raises(SequenceError, match="duplicate or stale"):
+        current.receive()
+
+    transport.inject_rx(UartSpiFrame(TransportKind.UART, 4, b"old").encode())
+    with pytest.raises(SequenceError, match="duplicate or stale"):
+        current.receive()
+
+    transport.inject_rx(UartSpiFrame(TransportKind.UART, 0x8005, b"ambiguous").encode())
+    with pytest.raises(SequenceError, match="duplicate or stale"):
+        current.receive()
+
+
+def test_session_accepts_sequence_wrap_inside_half_range() -> None:
+    current, transport = session(TransportKind.SPI)
+    transport.inject_rx(UartSpiFrame(TransportKind.SPI, 0xFFFF, b"last").encode())
+    assert current.receive().sequence == 0xFFFF
+    transport.inject_rx(UartSpiFrame(TransportKind.SPI, 0, b"wrap").encode())
+    assert current.receive().sequence == 0
+
+
+def test_transport_backpressure_and_closed_state_are_explicit() -> None:
+    transport = FakeTransport(capacity=1)
+    transport.open()
+    transport.write(b"one", timeout_s=0)
+    with pytest.raises(TransportBackpressure):
+        transport.write(b"two", timeout_s=0)
+    transport.close()
+    with pytest.raises(TransportClosed):
+        transport.write(b"closed", timeout_s=0)
+
+
+def test_session_bounds_retry_budget_and_rejects_wrong_transport() -> None:
+    transport = FakeTransport()
+    with pytest.raises(ValueError, match="between 0 and 3"):
+        UartSpiSession(transport, TransportKind.UART, max_retries=4)
+
+    current, transport = session(TransportKind.UART)
+    transport.inject_rx(UartSpiFrame(TransportKind.SPI, 1, b"wrong").encode())
+    with pytest.raises(FrameFormatError, match="does not match"):
+        current.receive()


### PR DESCRIPTION
## Summary

Add the LINUX3 software-level UART/SPI framing contract and deterministic fake transport tests.

## Changes

- Add a bounded binary frame format for UART and SPI.
- Validate magic, protocol version, transport kind, sequence, payload length and CRC-16/CCITT-FALSE before exposing payload data.
- Limit payloads to 256 bytes and complete frames to a bounded size.
- Reject duplicate, stale and ambiguous sequence numbers, including the 16-bit wrap boundary.
- Reassemble partial reads and writes without changing frame ownership.
- Add bounded retry behavior with a maximum of three retries.
- Fail closed on partial-write errors, closed transports, CRC failures, malformed frames and queue backpressure.
- Add a deterministic fake transport with bounded loopback queues and injected write/read failures.
- Add focused unit tests covering UART and SPI round trips, CRC/version/length errors, partial I/O, retry, sequence ordering, wraparound, backpressure and transport lifecycle.
- Add the `make uart-spi-test` test entry point.
- Add the LINUX3 Task Packet and document owner-gated hardware prerequisites.

## Hardware Boundary

This PR is software-only. It does not freeze or implement:

- UART baud rate
- SPI clock or mode
- device-tree or ACPI nodes
- pinmux or chip-select assignments
- DMA channels
- IRQ numbers
- physical signal integrity
- MCU firmware changes

The framing contract is a proposal-level test boundary and must be reviewed by the hardware, MCU and Linux owners before production use.

## Validation

- 10 UART/SPI contract tests passed
- 6 existing release workflow tests passed
- Python syntax check passed
- Bash syntax check passed
- Task Packet JSON syntax passed
- `git diff --check` passed

The local machine does not provide the Linux `make` environment or physical UART/SPI hardware. Kernel integration, device-tree integration and physical line-rate validation remain NOT_EXECUTED.

## Related Issue

## What changed

## Interfaces affected

## Tests and commands

## Evidence

## Risks and rollback

## Checklist

- [ ] I changed only approved paths.
- [ ] Tests and contract checks pass.
- [ ] I covered normal and failure behavior.
- [ ] I updated examples/docs when an interface changed.
- [ ] I did not add secrets, private data or unreviewed assets.
