### PR TITLE
bug(evaluation): compute replay metrics from canonical WorldState

### DIFF
--- a/docs/task_packets/issue-207-canonical-worldstate-replay-metrics.json
+++ b/docs/task_packets/issue-207-canonical-worldstate-replay-metrics.json
@@ -1,0 +1,89 @@
+{
+  "issue": 207,
+  "human_owner": "zhangjia-1111",
+  "objective": "Replace evaluation's event-envelope replay digest with Issue #47's canonical WorldEvent validation, World Model reducer and WorldState.state_hash, while failing closed on malformed or unreplayable logs.",
+  "decision_supported": "Do replay metrics represent successful canonical WorldState reconstruction and semantic state consistency rather than sorted event-envelope identity?",
+  "allowed_paths": [
+    "docs/task_packets/issue-207-canonical-worldstate-replay-metrics.json",
+    "tools/scripts/collect_metrics.py",
+    "tests/unit/test_evaluation_tools.py",
+    "tests/unit/test_canonical_replay_metrics.py"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "interfaces/json_schema/world_event.schema.json",
+    "interfaces/json_schema/world_state.schema.json",
+    "interfaces/examples/world-event-observation.json",
+    "interfaces/examples/world-state-block-in-tray.json",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/world_model/workbench_world_model/reducer.py",
+    "services/world_model/workbench_world_model/event_payloads.py",
+    "tests/integration/test_world_state_snapshot_replay.py",
+    "tools/scripts/run_evaluation.py"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "services/world_model/**",
+    "services/agent_runtime/**",
+    "services/perception/**",
+    "robot/control/**",
+    "firmware/**",
+    "sim/**",
+    "deploy/**",
+    ".github/**"
+  ],
+  "input_refs": [
+    "interfaces/json_schema/world_event.schema.json",
+    "interfaces/json_schema/world_state.schema.json",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/world_model/workbench_world_model/reducer.py",
+    "services/world_model/workbench_world_model/event_payloads.py",
+    "tests/integration/test_world_state_snapshot_replay.py"
+  ],
+  "outputs": [
+    "canonical WorldEvent-to-WorldState replay metrics",
+    "state_hash_consistency derived only from Issue #47 WorldState.state_hash",
+    "fail-closed evaluation log validation and deterministic focused tests"
+  ],
+  "acceptance": [
+    "Each non-empty JSONL log is parsed through the strict WorldEvent Pydantic contract and Issue #47 create_world_state_snapshot reducer boundary.",
+    "state_hash_consistency compares canonical WorldState hashes for forward and permuted delivery, with no evaluation-owned reducer or hash algorithm.",
+    "A semantic Observation confidence, location or attribute change changes the canonical WorldState hash.",
+    "Permutations of one valid stream produce the same canonical WorldState hash.",
+    "Mixed run IDs, duplicate sequence ownership, duplicate run ownership, malformed JSON/events, legacy non-contract envelopes and reducer failures stop collection with a typed RuntimeError.",
+    "replay_success_rate counts successful canonical replay and does not require contiguous sequence numbers.",
+    "Existing non-replay evaluation metrics operate on detached, contract-normalized WorldEvent dumps after successful canonical replay."
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/issue-207-canonical-worldstate-replay-metrics.json",
+    "python -m pytest tests/unit/test_canonical_replay_metrics.py tests/unit/test_evaluation_tools.py -v",
+    "python -m ruff check tools/scripts/collect_metrics.py tests/unit/test_canonical_replay_metrics.py tests/unit/test_evaluation_tools.py",
+    "python -m ruff format --check tools/scripts/collect_metrics.py tests/unit/test_canonical_replay_metrics.py tests/unit/test_evaluation_tools.py",
+    "make test",
+    "make contract",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "Focused tests proving semantic Observation changes alter the Issue #47 state hash and delivery permutations do not.",
+    "Fail-closed tests for mixed runs, duplicate sequence/run ownership, malformed JSON, extra envelope fields, unsupported event types and reducer errors.",
+    "Regression evidence showing non-contiguous but valid streams count as successful canonical replay.",
+    "Full tests, contracts, context, lint, formatting, Task Packet and diff-boundary output."
+  ],
+  "stop_conditions": [
+    "Issue #47 canonical WorldState or create_world_state_snapshot changes or is rejected as the stacked base.",
+    "Implementation requires an evaluation-owned state reducer, canonical serializer or hash algorithm.",
+    "A WorldEvent/WorldState schema, Pydantic model or World Model change is required.",
+    "Compatibility with legacy non-contract evaluation envelopes requires modifying run_evaluation.py or silently dropping, rewriting or inventing events.",
+    "A write outside allowed_paths is required or the worktree contains overlapping user modifications in an allowed path."
+  ],
+  "max_iterations": 5,
+  "data_classification": "Local deterministic JSON event fixtures only; no personal data or network access.",
+  "model_policy": "Strict Pydantic contract validation and the Issue #47 canonical World Model reducer only; no evaluation-specific state or hash inference.",
+  "risks_and_fallbacks": [
+    "Legacy scripted evaluation logs contain extra evaluation metadata and unsupported task_graph events, so they now fail closed until their producer is separately migrated to the WorldEvent contract.",
+    "A successful collection has replay_success_rate 1.0 because any invalid run aborts metric publication rather than contributing a misleading partial score.",
+    "This PR remains stacked on feat/47-deterministic-world-state-snapshots and cannot merge before Issue #47."
+  ]
+}

--- a/tests/unit/test_canonical_replay_metrics.py
+++ b/tests/unit/test_canonical_replay_metrics.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [
+    str(ROOT / "libs/contracts"),
+    str(ROOT / "services/world_model"),
+    str(ROOT / "tools/scripts"),
+]
+
+from collect_metrics import canonical_replay_hash, collect
+
+
+def event(
+    *,
+    event_id: str,
+    sequence_no: int,
+    run_id: str = "run-canonical-metrics",
+    confidence: float = 0.9,
+    location: str = "on:table",
+) -> dict[str, object]:
+    return {
+        "event_id": event_id,
+        "run_id": run_id,
+        "sequence_no": sequence_no,
+        "event_type": "observation",
+        "occurred_at": f"2026-08-30T00:00:{sequence_no:02d}Z",
+        "payload": {
+            "entity_id": "parcel_fixture",
+            "entity_type": "parcel",
+            "location": location,
+            "confidence": confidence,
+            "attributes": {"label_status": "verified"},
+        },
+        "evidence_refs": [f"frame://{event_id}"],
+    }
+
+
+def write_run(path: Path, events: list[dict[str, object]]) -> None:
+    path.write_text("".join(f"{json.dumps(item)}\n" for item in events), encoding="utf-8")
+
+
+def test_state_hash_comes_from_canonical_world_state_and_is_permutation_stable() -> None:
+    events = [event(event_id="obs-0", sequence_no=0), event(event_id="obs-5", sequence_no=5, confidence=0.8)]
+
+    assert canonical_replay_hash(events) == canonical_replay_hash(list(reversed(events)))
+
+
+def test_semantically_different_observation_changes_canonical_state_hash() -> None:
+    baseline = [event(event_id="obs-0", sequence_no=0, confidence=0.9)]
+    changed = deepcopy(baseline)
+    changed_payload = changed[0]["payload"]
+    assert isinstance(changed_payload, dict)
+    changed_payload["confidence"] = 0.4
+
+    assert canonical_replay_hash(baseline) != canonical_replay_hash(changed)
+
+
+def test_non_contiguous_but_valid_canonical_stream_counts_as_success(tmp_path: Path) -> None:
+    write_run(
+        tmp_path / "run.jsonl",
+        [event(event_id="obs-2", sequence_no=2), event(event_id="obs-9", sequence_no=9, confidence=0.8)],
+    )
+
+    metrics = collect(tmp_path)
+
+    assert metrics["replay_success_rate"] == 1.0
+    assert metrics["state_hash_consistency"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("events", "message"),
+    [
+        (
+            [event(event_id="obs-0", sequence_no=0), event(event_id="obs-1", sequence_no=1, run_id="other")],
+            "does not match requested run_id",
+        ),
+        (
+            [event(event_id="obs-0", sequence_no=0), event(event_id="obs-1", sequence_no=0)],
+            "sequence_no 0 is shared",
+        ),
+        (
+            [{**event(event_id="obs-0", sequence_no=0), "unexpected": True}],
+            "Extra inputs are not permitted",
+        ),
+        (
+            [event(event_id="obs-0", sequence_no=0, location="beside:table")],
+            "cannot be represented",
+        ),
+    ],
+)
+def test_invalid_or_unreplayable_streams_fail_closed(
+    tmp_path: Path, events: list[dict[str, object]], message: str
+) -> None:
+    write_run(tmp_path / "run.jsonl", events)
+
+    with pytest.raises(RuntimeError, match=message):
+        collect(tmp_path)
+
+
+def test_malformed_json_and_duplicate_run_ownership_fail_closed(tmp_path: Path) -> None:
+    (tmp_path / "bad.jsonl").write_text("{bad-json}\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="unreadable JSONL"):
+        collect(tmp_path)
+
+    (tmp_path / "bad.jsonl").unlink()
+    values = [event(event_id="obs-0", sequence_no=0)]
+    write_run(tmp_path / "first.jsonl", values)
+    write_run(tmp_path / "second.jsonl", values)
+    with pytest.raises(RuntimeError, match="owned by more than one event log"):
+        collect(tmp_path)
+
+
+def test_legacy_evaluation_envelope_and_non_contract_event_type_fail_closed(tmp_path: Path) -> None:
+    legacy = event(event_id="evt-0", sequence_no=0)
+    legacy["evaluation"] = {"runner": "scripted"}
+    write_run(tmp_path / "legacy.jsonl", [legacy])
+    with pytest.raises(RuntimeError, match="Extra inputs are not permitted"):
+        collect(tmp_path)
+
+    legacy.pop("evaluation")
+    legacy["event_type"] = "task_graph"
+    write_run(tmp_path / "legacy.jsonl", [legacy])
+    with pytest.raises(RuntimeError, match="event_type"):
+        collect(tmp_path)

--- a/tests/unit/test_evaluation_tools.py
+++ b/tests/unit/test_evaluation_tools.py
@@ -22,6 +22,59 @@ from scenario_tools import canonical_hash, materialize_scenario
 from validate_golden_set import validate, validate_diverse, validate_parcels
 
 
+def canonical_metric_events(
+    run_id: str,
+    *,
+    task_id: str,
+    entity_ids: tuple[str, ...],
+    status: str = "confirmed",
+) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+
+    def append(event_type: str, payload: dict[str, object], evidence_refs: list[str] | None = None) -> None:
+        sequence_no = len(events)
+        events.append(
+            {
+                "event_id": f"{run_id}-evt-{sequence_no:03d}",
+                "run_id": run_id,
+                "sequence_no": sequence_no,
+                "event_type": event_type,
+                "occurred_at": f"2026-08-30T00:00:{sequence_no:02d}Z",
+                "payload": payload,
+                "evidence_refs": evidence_refs or [],
+            }
+        )
+
+    append("task_accepted", {"task_id": task_id})
+    evidence_refs = []
+    for index, entity_id in enumerate(entity_ids):
+        evidence_ref = f"frame://{run_id}/{entity_id}"
+        evidence_refs.append(evidence_ref)
+        append(
+            "observation",
+            {
+                "observation_id": f"{run_id}-obs-{index:03d}",
+                "run_id": run_id,
+                "entity_id": entity_id,
+                "entity_type": "fixture",
+                "location": "on:table",
+                "confidence": 0.9 - index * 0.1,
+            },
+            [evidence_ref],
+        )
+    append(
+        "verification",
+        {
+            "status": status,
+            "required_conditions": ["known-entities-observed"],
+            "evaluated_conditions": ["known-entities-observed"],
+            "evidence_refs": evidence_refs,
+        },
+        evidence_refs,
+    )
+    return events
+
+
 class ScenarioToolTests(unittest.TestCase):
     def test_same_seed_produces_same_scene_hash(self) -> None:
         manifest = json.loads((ROOT / "sim" / "scenarios" / "frozen" / "normal-001.json").read_text())
@@ -150,10 +203,14 @@ class EvaluationPipelineTests(unittest.TestCase):
             root = Path(temp_dir)
             version_dir = root / "v-test"
             version_dir.mkdir()
-            events = scripted_events("v-test", manifest, "abc123", 1000)
+            events = canonical_metric_events(
+                "v-test--occlusion-001",
+                task_id=manifest["task_id"],
+                entity_ids=("red_block",),
+                status="insufficient_evidence",
+            )
             log_path = version_dir / "occlusion-001.jsonl"
             write_jsonl(log_path, events)
-            validate_event_log(log_path, "v-test--occlusion-001")
             (root / "summary.json").write_text(
                 json.dumps({"runner": "scripted", "release_eligible": False}),
                 encoding="utf-8",
@@ -178,7 +235,15 @@ class EvaluationPipelineTests(unittest.TestCase):
             for manifest in manifests:
                 write_jsonl(
                     version_dir / f"{manifest['scenario_id']}.jsonl",
-                    scripted_events("v-test", manifest, "abc123", 1000),
+                    canonical_metric_events(
+                        f"v-test--{manifest['scenario_id']}",
+                        task_id=manifest["task_id"],
+                        entity_ids=(
+                            ("red_block",)
+                            if manifest["scenario_id"] == "normal-001"
+                            else ("red_block", "blue_cylinder", "green_gear")
+                        ),
+                    ),
                 )
             (root / "summary.json").write_text(
                 json.dumps({"runner": "scripted", "release_eligible": False}),

--- a/tools/scripts/collect_metrics.py
+++ b/tools/scripts/collect_metrics.py
@@ -2,7 +2,6 @@
 """Extract reproducible metrics from one version's JSON Lines event logs."""
 
 import argparse
-import hashlib
 import json
 import math
 from collections import Counter
@@ -10,20 +9,62 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from workbench_contracts import WorldEvent
+from workbench_world_model import create_world_state_snapshot
+
 ALLOWED_ACTIONS = {"ask_confirm", "express", "grasp", "observe", "place", "stop"}
 
 
 def load_runs(run_dir: Path) -> dict[str, list[dict[str, Any]]]:
     runs: dict[str, list[dict[str, Any]]] = {}
     for log_file in sorted(run_dir.glob("*.jsonl")):
-        events = [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+        events: list[dict[str, Any]] = []
+        for line_number, line in enumerate(log_file.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise RuntimeError(f"unreadable JSONL event at {log_file}:{line_number}") from error
+            if type(event) is not dict:
+                raise RuntimeError(f"WorldEvent at {log_file}:{line_number} must be a JSON object")
+            events.append(event)
         if not events:
             continue
-        run_id = str(events[0].get("run_id", ""))
-        if not run_id:
+        run_id = events[0].get("run_id")
+        if type(run_id) is not str or not run_id.strip():
             raise RuntimeError(f"event log has no run_id: {log_file}")
-        runs[run_id] = sorted(events, key=lambda event: event.get("sequence_no", -1))
+        if run_id in runs:
+            raise RuntimeError(f"run_id {run_id!r} is owned by more than one event log")
+        runs[run_id] = events
     return runs
+
+
+def _canonical_replay(run_id: str, events: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str, str]:
+    typed_events: list[WorldEvent] = []
+    try:
+        for event in events:
+            encoded = json.dumps(event, allow_nan=False, ensure_ascii=False, separators=(",", ":"))
+            typed_events.append(WorldEvent.model_validate_json(encoded))
+        forward = create_world_state_snapshot(run_id, typed_events)
+        reverse = create_world_state_snapshot(run_id, list(reversed(typed_events)))
+    except (TypeError, UnicodeError, ValueError) as error:
+        raise RuntimeError(f"canonical replay failed for run_id {run_id!r}: {error}") from error
+    canonical_events = [
+        event.model_dump(mode="json") for event in sorted(typed_events, key=lambda item: item.sequence_no)
+    ]
+    return canonical_events, forward.state_hash, reverse.state_hash
+
+
+def canonical_replay_hash(events: list[dict[str, Any]]) -> str:
+    """Return #47's canonical WorldState hash for one untrusted event stream."""
+    if not events:
+        raise RuntimeError("canonical replay requires a non-empty event stream")
+    run_id = events[0].get("run_id")
+    if type(run_id) is not str or not run_id.strip():
+        raise RuntimeError("canonical replay requires a non-empty run_id")
+    _, state_hash, _ = _canonical_replay(run_id, events)
+    return state_hash
 
 
 def verification_statuses(events: list[dict[str, Any]]) -> list[str]:
@@ -59,25 +100,6 @@ def durations(runs: dict[str, list[dict[str, Any]]]) -> list[float]:
     return result
 
 
-def replay_digest(events: list[dict[str, Any]]) -> str:
-    state = {
-        "run_id": events[0].get("run_id") if events else None,
-        "event_ids": [],
-        "last_action": None,
-        "verification_status": None,
-        "evidence_refs": [],
-    }
-    for event in sorted(events, key=lambda item: item.get("sequence_no", -1)):
-        state["event_ids"].append(event.get("event_id"))
-        if event.get("event_type") == "action_result":
-            state["last_action"] = event.get("payload")
-        if event.get("event_type") == "verification":
-            state["verification_status"] = event.get("payload", {}).get("status")
-        state["evidence_refs"].extend(event.get("evidence_refs", []))
-    encoded = json.dumps(state, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.sha256(encoded).hexdigest()
-
-
 def audit_false_completions(
     runs: dict[str, list[dict[str, Any]]], audit_path: Path | None
 ) -> tuple[int | None, bool, str | None]:
@@ -99,9 +121,11 @@ def audit_false_completions(
 
 
 def collect(run_dir: Path, audit_path: Path | None = None) -> dict[str, Any]:
-    runs = load_runs(run_dir)
-    if not runs:
+    untrusted_runs = load_runs(run_dir)
+    if not untrusted_runs:
         raise RuntimeError(f"no JSON Lines event logs found in {run_dir}")
+    replayed = {run_id: _canonical_replay(run_id, run) for run_id, run in untrusted_runs.items()}
+    runs = {run_id: result[0] for run_id, result in replayed.items()}
     events = [event for run in runs.values() for event in run]
     final_statuses = [verification_statuses(run)[-1] for run in runs.values() if verification_statuses(run)]
     verified = sum(status == "confirmed" for status in final_statuses)
@@ -113,19 +137,17 @@ def collect(run_dir: Path, audit_path: Path | None = None) -> dict[str, Any]:
 
     recoverable = [run for run in runs.values() if "refuted" in verification_statuses(run)[:-1]]
     recovered = sum(verification_statuses(run)[-1] == "confirmed" for run in recoverable)
-    valid_replays = sum(
-        [event.get("sequence_no") for event in run] == list(range(len(run)))
-        and all(event.get("run_id") == run_id for event in run)
-        for run_id, run in runs.items()
-    )
-    stable_hashes = sum(replay_digest(run) == replay_digest(list(reversed(run))) for run in runs.values())
+    valid_replays = len(replayed)
+    stable_hashes = sum(forward_hash == reverse_hash for _, forward_hash, reverse_hash in replayed.values())
     false_completions, audit_complete, reviewed_by = audit_false_completions(runs, audit_path)
     run_task_ids = {run_id: task_id(run) for run_id, run in runs.items()}
     task_family_distribution = Counter(run_task_ids.values())
     task_family_vtcr = {}
     for family, family_run_count in sorted(task_family_distribution.items()):
         family_runs = [run for run_id, run in runs.items() if run_task_ids[run_id] == family]
-        family_verified = sum(verification_statuses(run)[-1] == "confirmed" for run in family_runs)
+        family_verified = sum(
+            bool(verification_statuses(run)) and verification_statuses(run)[-1] == "confirmed" for run in family_runs
+        )
         task_family_vtcr[family] = family_verified / family_run_count
     observed_entities = [
         len(


### PR DESCRIPTION
## Related Issue

Closes #207

## What changed

- replace the evaluation-owned event-envelope replay digest with strict canonical `WorldEvent` parsing;
- replay each run through Issue #47's `create_world_state_snapshot` reducer;
- compute `state_hash_consistency` exclusively from canonical `WorldState.state_hash` values;
- define `replay_success_rate` from successful canonical replay rather than contiguous sequence numbering;
- normalize downstream metric inputs from detached typed `WorldEvent` dumps;
- fail closed on malformed JSONL, non-object records, mixed run IDs, duplicate event ownership, extra fields, unsupported event types and reducer failures;
- add deterministic unit coverage and an Issue #207 Task Packet.

## Interfaces affected

None.

- no changes to `interfaces/` or `libs/contracts/`;
- no changes to `services/world_model/`;
- evaluation consumes the public canonical replay API introduced by #47;
- no evaluation-owned reducer or state hash is introduced.

## Tests and commands

```text
python -m pytest tests/unit/test_canonical_replay_metrics.py tests/unit/test_evaluation_tools.py -q
22 passed

python tools/scripts/check_task_packet.py docs/task_packets/issue-207-canonical-worldstate-replay-metrics.json
PASS

python tools/scripts/validate_contracts.py
PASS

python tools/scripts/validate_scenarios.py
PASS — 12 frozen and 24 expanded manifests

python tools/scripts/check_context.py
PASS

python -m ruff check tools/scripts/collect_metrics.py tests/unit/test_canonical_replay_metrics.py tests/unit/test_evaluation_tools.py
PASS

python -m ruff format --check tools/scripts/collect_metrics.py tests/unit/test_canonical_replay_metrics.py tests/unit/test_evaluation_tools.py
PASS

git diff --check
PASS
```

The filtered software suite passed 899 tests. The unfiltered local run reached 913 passed and 1 skipped, with 4 environment-only failures caused by missing `kiutils`, a Windows file-lock behavior and unavailable Docker; no #207 test failed.

## Evidence

- deterministic fixtures prove forward and reversed canonical event order produce the same `WorldState.state_hash`;
- semantic state changes produce different canonical hashes;
- malformed records, legacy extra fields, mixed run ownership, duplicate sequence ownership and reducer failures abort metric collection;
- downstream metrics receive validated, detached canonical event records;
- the stacked diff against #47 contains exactly four approved files.

## Risks and rollback

- this is a stacked PR based on `feat/47-deterministic-world-state-snapshots`; after #47 merges, change the base to `main` and re-check the diff and CI;
- legacy scripted evaluation logs containing the evaluation-only envelope or `task_graph` events now fail closed and require a separately approved producer migration;
- successful collection reports `replay_success_rate = 1.0` because unreplayable runs abort at the boundary;
- rollback by reverting commit `ec66245`; no schema or persistent-data migration is required.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior.
- [x] I updated examples/docs when an interface changed.
- [x] I did not add secrets, private data or unreviewed assets.