### PR TITLE
docs(product): define Design Partner handoff boundary

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -22,6 +22,7 @@ Every proposed scenario should answer two separate questions:
 - [90-day execution](90-day-plan.md): an evidence-gated operating cadence adapted from the product-manager plan.
 - [Problem card template](problem-card-template.md): turn interviews into traceable problem evidence.
 - [Design Partner scenario template](design-partner-scenario-template.md): define a bounded real-task collaboration.
+- [Design Partner handoff boundary](design-partner-handoff.md): separate product acceptance, Motion/MCU/Safety authority, and evidence classes before a trial.
 - [Feedback record template](feedback-record-template.md): make external installation and trial failures reproducible.
 - [Metrics and decision log](metrics-and-decision-log.md): distinguish activity metrics from product and evidence outcomes.
 
@@ -31,9 +32,10 @@ Use the lightest artifact that preserves the decision trail:
 
 1. **Problem card** records a user problem, quote, recent example, frequency, impact, and falsification condition.
 2. **Design Partner scenario** records one bounded real task, responsibilities, safety boundary, and evidence agreement.
-3. **Feedback record** records a reproducible installation, trial, or task result with version and run references.
-4. **Engineering artifact** records the Scenario Registry entry, Event Store run, verifier result, and replay hash.
-5. **Decision log** records whether to continue, change, defer, or stop, with links to the preceding evidence.
+3. **Handoff boundary** records the allowed semantic interface, owner inputs/outputs, stop authority, and evidence class before scheduling the trial.
+4. **Feedback record** records a reproducible installation, trial, or task result with version and run references.
+5. **Engineering artifact** records the Scenario Registry entry, Event Store run, verifier result, and replay hash.
+6. **Decision log** records whether to `continue`, `change`, `defer`, or `reject`, with links to the preceding evidence.
 
 Do not skip from a conversation directly to a feature Issue. A feature becomes
 ready only after its problem card, success condition, non-goals, and evidence
@@ -67,6 +69,8 @@ User statements, product hypotheses, scripted fixtures, Gazebo evidence, and
 physical evidence are different evidence classes. None of them may silently
 upgrade another class. In particular, a scripted fixture remains
 `release_eligible: false` unless the applicable release gate says otherwise.
+User feedback may motivate a product decision, but it is not execution or
+physical evidence unless the applicable run and verification artifacts exist.
 
 ## Ownership boundary
 

--- a/docs/product/design-partner-handoff.md
+++ b/docs/product/design-partner-handoff.md
@@ -1,0 +1,281 @@
+# Design Partner Handoff and Physical-Evidence Boundary
+
+Status: proposed handoff policy for Issue #318. This document defines the
+boundary between a product trial and an engineering or safety acceptance; it
+does not grant a scenario, partner, model, dashboard, or adapter control over a
+robot. It is a documentation contract, not a new public interface or a
+replacement for the trusted runtime and physical safety procedures.
+
+## 1. Decision vocabulary
+
+Every handoff decision applies to one named claim, one scenario version, and
+one evidence class. It must name an owner, a next action, and a review date.
+
+| Decision | Meaning | Required follow-up |
+|---|---|---|
+| `continue` | The declared claim is supported by its current evidence gate and the next bounded step is safe to schedule. | Record the next environment, owner, and evidence artifact. |
+| `change` | The user problem is useful, but the task, action, success condition, or evidence request is ambiguous or out of bounds. | Revise the handoff and re-run the applicable readiness checks. |
+| `defer` | The scope is acceptable, but a dependency, owner approval, environment, or eligible evidence source is missing. | Keep the claim open and record the blocking input and date. |
+| `reject` | The request would cross a safety, privacy, contract, or authority boundary, or the evidence rule cannot be made truthful. | Preserve the reason and offer a bounded semantic alternative where one exists. |
+
+`continue` never means “the robot is safe” or “the task is physically
+complete” by itself. A product decision can continue a software trial while a
+physical or safety claim remains `insufficient_evidence`, `not_executed`, or
+`blocked`.
+
+## 2. Semantic action contract
+
+The Scenario layer describes a user task. It does not describe how a
+controller should move. Until a separately approved versioned contract adds
+more actions, the current public semantic action set is:
+
+`observe`, `grasp`, `place`, `ask_confirm`, `express`, and `stop`.
+
+A scenario may refer to an action only when that action is registered and
+version-compatible. It may provide:
+
+- a scenario ID and version, a bounded goal, and an opaque `target_id`;
+- a registered semantic action name and a closed set of typed policy selectors;
+- required adapter capability names, evidence-policy and verifier references,
+  and a bounded recovery-policy reference;
+- an expected starting state and observable success condition.
+
+These names describe the handoff vocabulary only. They are not an instruction
+to add fields to the current public Schema; any new public action or manifest
+field still requires the normal producer/consumer approval process.
+
+The following are never Scenario fields or Design Partner inputs:
+
+- joint positions, Cartesian poses, trajectories, velocities, accelerations,
+  efforts, force/torque limits, controller goals, planner internals, or TF
+  commands;
+- CAN arbitration IDs, raw CAN frames, retry/sequence internals, device
+  handles, pin/IRQ/DMA assignments, firmware commands, or vendor register
+  values;
+- E-stop, safe-enable, watchdog, brake, power, reset, or emergency-recovery
+  writes;
+- credentials, network endpoints with write authority, arbitrary executable
+  parameters, or an unbounded JSON property bag.
+
+An adapter capability is a name and a versioned ownership reference, not a
+permission to expose its implementation parameters. The adapter resolves
+that reference against owner-approved configuration and fails closed when the
+target, version, capability, or policy is unknown. A Design Partner can
+describe the job and the observable goal; it cannot negotiate a controller
+goal or safety limit in the Scenario manifest.
+
+### Illustrative allowed request
+
+The following is pseudocode for a handoff, not a new public JSON Schema:
+
+```yaml
+scenario_id: partner-parcel-001
+scenario_version: "1"
+goal:
+  entity: parcel-17
+  observed_condition: placed_in_slot
+actions:
+  - type: observe
+    target_id: parcel-17
+  - type: grasp
+    target_id: parcel-17
+    policy: standard_grasp_v1
+evidence_policy: parcel-placement-observation-v1
+verifier: parcel-slot-verifier-v1
+recovery_policy: bounded-observation-retry-v1
+```
+
+The policy names above resolve to controlled definitions. They do not permit
+the caller to add a pose, force, speed, joint, CAN, or controller field.
+
+## 3. Motion adapter result boundary
+
+The Motion adapter consumes a validated semantic action plus an approved
+context. It returns a typed `ActionResult` and separate health/fault evidence;
+it does not write `WorldState` and does not decide whether the user's goal is
+observed.
+
+### ActionResult minimum interpretation
+
+The existing result contract carries the following distinctions:
+
+| Field/group | What it proves | What it does not prove |
+|---|---|---|
+| `action_id`, `run_id`, timestamps, and clock | Which request and time interval were handled. | That the physical scene has the desired state. |
+| `outcome` | The adapter's bounded execution outcome, such as `completed`, `failed`, `timeout`, or `safe_stop`. | Task-level success or user value. |
+| `dispatch_state` | Whether the request left the trusted host boundary. | That a controller executed it correctly. |
+| `device_state` | The device acknowledgement state when the adapter has one. | That perception observed the intended result. |
+| `error_code`, `error_reason`, retry count | A stable diagnostic and bounded retry history. | Permission to retry indefinitely or bypass safety. |
+| `evidence_refs` | Where supporting raw or derived records can be found. | Validity of a record that the referenced verifier has not accepted. |
+
+In particular, `ActionOutcome.COMPLETED` and `DeviceState.CONFIRMED` are
+execution/acknowledgement facts. They are not an observed WorldState fact.
+Product task acceptance requires the relevant observation, provenance,
+freshness/conflict checks, and World Model verifier result in addition to the
+ActionResult. A missing or contradictory observation stays
+`insufficient_evidence`; it is never filled in from a successful action.
+
+### Health and fault record
+
+For a product handoff, the Motion adapter must expose (or reference) a
+bounded, read-only health/fault record. This may be an existing owner-
+controlled artifact; it does not require a new public schema. It contains:
+
+- adapter/source identity, interface and configuration/commit hash;
+- readiness and lifecycle state, queue depth/capacity, drop/deadline counts,
+  and the monotonic timestamp/clock used for the observation;
+- stable fault code, severity, latched/non-latched state, first/last observed
+  time, affected capability, and whether a bounded recovery is permitted;
+- raw-capture or evidence references, without raw controller handles or
+  private partner data.
+
+Health is not a safety permissive. A healthy adapter cannot clear an E-stop,
+enable a drive, or turn an unverified ActionResult into a verified task.
+
+## 4. Handoff checklist
+
+The handoff owner copies this table into the private trial record and commits
+only anonymized IDs and opaque evidence references to the repository.
+
+| Owner | Inputs required before the trial | Outputs required after the trial | Cannot authorize |
+|---|---|---|---|
+| Product / Project Owner | Problem card, partner reference, user job, declared claim, success condition, test window, privacy/consent choice | `continue`/`change`/`defer`/`reject`, product feedback record, next owner/date | Motion parameters, E-stop reset, release or physical-safety claim |
+| Motion Owner | Versioned semantic action, known target/capability, approved context and preflight result | ActionResult, adapter health/fault record, execution/evidence references, stop outcome | Raw scenario controller goals, independent safety clearance, observed task truth |
+| MCU / Safety Owner | Firmware/config hashes, node/lifecycle status, watchdog and safety-chain readiness, approved reset procedure | ACK/fault/heartbeat evidence, safety inhibit state, reset/stop disposition | Product completion, automatic clearing of a latched E-stop, arbitrary Scenario fields |
+| Runtime / Integration Owner | Runtime version, policy/verifier versions, queue/lifecycle limits, event/evidence sink and read-only exposure configuration | Correlated run/event IDs, cancellation/shutdown result, provenance and replay references | Hardware E-stop authority, raw device write access, verifier override |
+| Site / Partner Operator | Environment access, trained operator, known starting state, safety briefing, equipment and calibration references | Operator record, observed task feedback, raw evidence handoff, incident/abort report | Changing the product contract or approving an unsafe reset |
+| Evidence / QA Reviewer | Declared evidence class, acceptance rule, artifact schema and hash procedure | Independent evidence review, status classification, gap list and disposition | Promoting a lower evidence class to physical or release evidence |
+
+Minimum handoff inputs are: an opaque partner ID, scenario/version, named
+claim, environment class, owner matrix, starting state, success and failure
+conditions, preflight/abort rule, privacy decision, and an evidence owner.
+No trial starts while one of these is silently assumed.
+
+## 5. Evidence ladder
+
+Evidence classes are independent. A higher class requires its own eligible
+artifact; passing a lower class is not a promotion token.
+
+| Class | May support | Required minimum evidence | Explicit limitation |
+|---|---|---|---|
+| `software` | Contract, parser, policy, lifecycle, and deterministic unit behavior | Versioned source/config, deterministic test output, and reproducible command | No user trial, physics, actuator, wire, or safety claim |
+| `scripted_fixture` | Product-flow and failure-routing behavior using a controlled fixture | Fixture/manifest hash, run ID, replay/verifier output, failure corpus, and privacy-safe record | `release_eligible: false` by default; not Gazebo or physical evidence |
+| `gazebo` | Declared simulator task behavior and simulation observations | Simulator/world/plugin/config hashes, seed/clock, raw run bundle, verifier output, and explicit simulator status | Not physical CAN, actuator, E-stop, calibration, or site acceptance |
+| `physical` | Only the specifically declared hardware/site claim | Serialized unit and revision, approved configuration hashes, calibrated instruments, trained operator/reviewer, safety preflight, raw capture hash, and repeatable procedure | Does not automatically prove a different task, device, site, or release claim |
+
+The evidence ladder is per claim, not per conversation. A Design Partner's
+verbal approval, interview, or video can be useful product feedback, but none
+of them alone is execution or physical evidence and none proves physical task
+completion. The handoff record must retain the weaker status whenever evidence
+is missing, stale, conflicting, or from the wrong class:
+
+- `confirmed`: the declared evidence rule for this claim passed;
+- `failed`: the declared run or task outcome was not met;
+- `refuted`: the declared product hypothesis or claim was contradicted;
+- `insufficient_evidence`: the run cannot establish the claim;
+- `not_executed`: the required run or environment did not happen;
+- `blocked`: a prerequisite or owner gate prevents execution.
+
+For `physical`, the site procedure must additionally identify the independent
+E-stop/safe-enable authority, power and motion inhibit state, calibration
+references, abort criteria, and raw capture location/hash before energization.
+If any required item is unavailable, the physical result remains
+`not_executed` or `blocked`.
+
+## 6. Abort, stop, recovery, and confirmation authority
+
+These controls are intentionally separate:
+
+| Control | Authority | Normal behavior | Failure behavior |
+|---|---|---|---|
+| `safe_stop` | Trusted runtime requests it; Motion/MCU-Safety and the hardware chain execute the stop | Cancel further action dispatch and drive the bounded stop path; record correlation and result | Any timeout, rejected stop, or missing acknowledgement is a fault and keeps motion inhibited |
+| `abort` | Trusted runtime / orchestrator owns the run decision; site operator may request it | End the run, prevent new semantic dispatch, preserve events and evidence, and request `safe_stop` when motion may be active | Never report completion; leave the run failed, stopped, or insufficiently evidenced |
+| E-stop | Physical site operator and independent MCU-Safety/safety circuit | Remove/inhibit hazardous energy through the out-of-band chain | Software, DDS, dashboard, or Design Partner cannot override or silently reset it |
+| Recovery | Runtime may select only a finite, policy-approved recovery; Motion/MCU/Safety owner controls reset and re-enable conditions | Require fresh provenance-valid evidence after each attempt | Latched safety faults and uncertain state require manual owner disposition; no automatic enable |
+| Manual confirmation | Authorized human/site owner, recorded with identity reference and time | Confirms an operator decision or readiness observation within the approved procedure | A model response, partner preference, or screenshot cannot substitute for required safety evidence |
+
+`safe_stop` is therefore a trusted request boundary, not a Scenario-owned
+implementation. E-stop and safe-enable remain independent even when the
+runtime mirrors their status. Recovery cannot turn a failed verification into
+success without new evidence, and no manual confirmation can waive a required
+Safety Owner gate.
+
+## 7. Product acceptance versus Motion/Safety acceptance
+
+Record these as separate rows in the handoff:
+
+| Claim | Product acceptance asks | Engineering/safety acceptance asks |
+|---|---|---|
+| User value | Did the named evaluator perform the bounded job and understand the result? | Was the task run through the approved interface and recorded reproducibly? |
+| Action behavior | Was the interaction understandable and the declared action outcome useful? | Did the adapter enforce policy, limits, correlation, timeout, and cleanup? |
+| Observed goal | Is the declared goal measurable and supported by fresh evidence? | Did the canonical observation/verifier path establish or refute it? |
+| Safety | Did the operator receive clear stop/abort instructions? | Did the independent safety chain, watchdog, E-stop, and reset procedure pass their own gate? |
+| Release | Is the scoped product claim worth continuing? | Are all required owner approvals and eligible release artifacts present? |
+
+The product side may choose `continue` for a scripted or simulated learning
+loop while the engineering side records the physical claim as
+`not_executed`. It may not publish the latter as a product success.
+
+## 8. Rejected request example
+
+The following request must be marked `reject` by the handoff owner and Safety
+Owner:
+
+> “Add `joint_angles`, `velocity`, `torque_limit`, `can_frame`, and
+> `emergency_stop: false` to the partner's scenario manifest so the operator
+> can tune the task directly from the dashboard.”
+
+It asks a scenario and UI to become a controller and safety writer, bypasses
+Motion/MCU/Safety ownership, and makes a dashboard setting look like an
+E-stop decision. The bounded alternative is to name a registered semantic
+action and opaque target, keep limits in owner-controlled configuration, show
+validated read-only health/evidence, and request `safe_stop` through the
+trusted runtime when appropriate. A Safety Owner must refuse the original
+request even if it would make the demo easier to operate.
+
+## 9. Copyable handoff record
+
+```text
+Handoff ID / scenario ID and version:
+Partner reference (opaque) / organization type:
+Named claim and evidence class:
+Decision: continue | change | defer | reject
+Decision owner / Motion owner / MCU-Safety owner / site owner:
+Test window and known starting state:
+Allowed semantic actions and adapter capabilities:
+Forbidden fields/authority confirmed:
+Product acceptance condition:
+Motion acceptance inputs and outputs:
+MCU/Safety preflight, stop, and reset inputs/outputs:
+Runtime lifecycle, queue, cancellation, and provenance evidence:
+Required evidence artifacts and hashes:
+Privacy/consent/retention reference:
+Abort conditions and immediate stop procedure:
+Missing evidence or blockers:
+Next action / owner / due date / review date:
+Release eligible: false (change only with the applicable release gate)
+```
+
+Use [Design Partner Scenario Record](design-partner-scenario-template.md) for
+the basic trial record and this document for the authority, evidence, and
+handoff decisions. The generic record remains intentionally lightweight; this
+policy supplies the stricter boundary required before a real task is scheduled.
+
+## 10. Next step and decision record
+
+After the handoff is completed, use the following sequence. Each row needs a
+named owner and a dated record; an empty date is a blocker, not permission to
+proceed.
+
+| Step | Owner | Required action | Output/status |
+|---|---|---|---|
+| 1. Prepare | Product / Project Owner | Attach the problem card, opaque partner reference, named claim, scenario/version, and proposed environment. | Handoff record with privacy and consent decision. |
+| 2. Review | Motion, MCU/Safety, Runtime/Integration, and site owners | Confirm semantic actions, adapter capability, preflight, stop/abort boundary, and failure matrix. | `continue`, `change`, `defer`, or `reject`; unresolved disagreement stays `defer`/`reject`. |
+| 3. Schedule | Product Owner and site owner | Set the test window, known starting state, operator, equipment, calibration references, and raw-evidence destination. | Trial start approval for the declared evidence class. |
+| 4. Run | Site operator with trusted runtime and relevant adapter owners | Execute only the approved task; stop or abort on any declared condition and preserve the run. | Run ID, ActionResult/health records, observations, and raw evidence references. |
+| 5. Review evidence | Evidence/QA Reviewer plus domain owners | Check hashes, provenance, freshness, conflicts, safety records, and the class-specific acceptance rule. | Claim status; gaps remain `insufficient_evidence`, `not_executed`, or `blocked`. |
+| 6. Decide next | Product / Project Owner | Record the product decision and the next owner/action/date without upgrading the evidence class. | Follow-up Issue/PR or an explicit stop/defer decision. |
+
+The minimum next-step record is therefore: `owner`, `action`, `due date`,
+`review date`, `evidence reference`, and `status`. A verbal “looks good” is
+not a completed handoff.

--- a/docs/product/design-partner-scenario-template.md
+++ b/docs/product/design-partner-scenario-template.md
@@ -4,6 +4,11 @@ This record defines a bounded collaboration around a real task. It is not a
 free custom-development agreement and does not grant a partner or scenario
 authority over safety, release, or shared runtime contracts.
 
+Complete the [Design Partner handoff boundary](design-partner-handoff.md)
+before scheduling a trial. That document defines the allowed semantic action
+surface, owner handoff inputs/outputs, stop authority, evidence ladder, and the
+required `continue` / `change` / `defer` / `reject` decision.
+
 ## Partner and scope
 
 - Partner reference (opaque):
@@ -16,6 +21,8 @@ authority over safety, release, or shared runtime contracts.
 - Out of scope:
 - Consent/reference agreement: `private_only` / `anonymous_case_ok` / `public_case_approved`
 - Data retention location and owner:
+- Handoff decision: `continue` / `change` / `defer` / `reject`
+- Handoff record/evidence reference:
 
 ## Real task
 
@@ -28,6 +35,8 @@ authority over safety, release, or shared runtime contracts.
 - Evidence required to confirm success:
 - Failure and recovery cases:
 - Preflight and abort conditions:
+- Product acceptance claim (separate from engineering/safety acceptance):
+- Motion/MCU/Safety acceptance status:
 
 ## Responsibilities
 
@@ -49,7 +58,7 @@ authority over safety, release, or shared runtime contracts.
 - [ ] Evidence bundle and privacy handling are agreed.
 - [ ] Consent, retention, and publication status are recorded.
 - [ ] Safety preflight and abort conditions are reviewed by the site owner.
-- [ ] Continue, change, pause, or stop decision has an owner and date.
+- [ ] `continue`, `change`, `defer`, or `reject` decision has an owner and date.
 
 ## Evidence package
 
@@ -60,6 +69,7 @@ authority over safety, release, or shared runtime contracts.
 - Result: `confirmed` / `refuted` / `insufficient_evidence` / `failed` / `not_executed` / `blocked`
 - `release_eligible`: `false` by default
 - Private evidence reference:
+- Missing evidence or blocker:
 
 ## Guardrails
 

--- a/docs/task_packets/issue-318-design-partner-handoff.json
+++ b/docs/task_packets/issue-318-design-partner-handoff.json
@@ -1,0 +1,113 @@
+{
+  "issue": 318,
+  "issues": [260, 305, 306, 312, 318],
+  "human_owner": "TH3478",
+  "objective": "Define a controller-independent Design Partner handoff contract that separates product acceptance from Motion/MCU/Safety acceptance, preserves the evidence ladder, and makes stop authority and incomplete evidence explicit.",
+  "decision_supported": "Can a Design Partner task be continued, changed, deferred, or rejected without granting scenario code or product documentation motion, MCU, E-stop, release, or completion authority?",
+  "allowed_paths": [
+    "docs/product/README.md",
+    "docs/product/design-partner-scenario-template.md",
+    "docs/product/design-partner-handoff.md",
+    "mkdocs.yml",
+    "docs/task_packets/issue-318-design-partner-handoff.json",
+    "tests/unit/test_design_partner_handoff.py"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "docs/architecture/system.md",
+    "docs/architecture/robot-bsp-v0.1.md",
+    "docs/decisions/ADR-0005-hardware-device-runtime.md",
+    "docs/context/CONSTRAINTS.yaml",
+    "docs/context/EVIDENCE_INDEX.md",
+    "docs/product/product-brief.md",
+    "docs/product/feedback-record-template.md",
+    "docs/product/metrics-and-decision-log.md",
+    "libs/contracts/workbench_contracts/models.py",
+    "tools/schemas/task-packet-v1.schema.json",
+    "tools/scripts/check_task_packet.py",
+    "interfaces/**",
+    "robot/control/**",
+    "firmware/**"
+  ],
+  "forbidden": [
+    "apps/**",
+    "bsp/**",
+    "hardware/**",
+    "integrations/**",
+    "services/**",
+    "sim/**",
+    "tasks/**",
+    "libs/**",
+    ".github/**",
+    "compose.yaml"
+  ],
+  "input_refs": [
+    "AGENTS.md",
+    "docs/architecture/system.md",
+    "docs/architecture/robot-bsp-v0.1.md",
+    "docs/decisions/ADR-0005-hardware-device-runtime.md",
+    "docs/context/CONSTRAINTS.yaml",
+    "docs/context/EVIDENCE_INDEX.md",
+    "docs/product/README.md",
+    "docs/product/design-partner-scenario-template.md",
+    "docs/product/product-brief.md",
+    "docs/product/feedback-record-template.md",
+    "docs/product/metrics-and-decision-log.md",
+    "libs/contracts/workbench_contracts/models.py",
+    "tools/schemas/task-packet-v1.schema.json",
+    "tools/scripts/check_task_packet.py"
+  ],
+  "outputs": [
+    "docs/product/README.md",
+    "docs/product/design-partner-scenario-template.md",
+    "docs/product/design-partner-handoff.md",
+    "mkdocs.yml",
+    "docs/task_packets/issue-318-design-partner-handoff.json",
+    "tests/unit/test_design_partner_handoff.py"
+  ],
+  "acceptance": [
+    "The handoff document provides the required conclusion vocabulary: continue, change, defer, and reject, and makes the decision apply to a named claim and evidence class.",
+    "Scenario manifests may declare only versioned semantic actions, opaque targets, bounded typed policy selectors, adapter capability references, goals, evidence policy, and bounded recovery references; raw joint, Cartesian, velocity, torque, force, CAN, controller, pin, credential, or E-stop fields are explicitly forbidden.",
+    "The Motion handoff describes the existing ActionResult boundary, correlation, dispatch/device state, health/fault diagnostics, and evidence references, and explicitly says ActionResult completion is not observed WorldState completion.",
+    "The checklist gives separate inputs and outputs for Product, Motion, MCU/Safety, Runtime/Integration, and site/partner owners, including consent, version/configuration hashes, preflight, abort, and evidence responsibilities.",
+    "The evidence ladder distinguishes software, scripted_fixture, gazebo, and physical claims; lower-rung evidence cannot silently promote a higher-rung claim, and scripted_fixture remains release_eligible=false by default.",
+    "The stop boundary assigns safe_stop and abort to the trusted runtime path, E-stop and safe-enable to the independent site/MCU-Safety authority, bounded recovery to policy plus owner-approved reset rules, and manual confirmation to an authorized human.",
+    "The document defines confirmed, failed/refuted, insufficient_evidence, not_executed, and blocked without treating missing evidence as success.",
+    "At least one illustrative request is marked reject because it asks for raw joint/controller/CAN or direct E-stop access, with a safe semantic alternative and the reason a Safety Owner would refuse it.",
+    "The existing generic Design Partner template links to and remains consistent with the dedicated handoff contract; no public schema, firmware, robot-control, safety implementation, or physical result is changed or claimed.",
+    "The static regression test checks the required headings and boundary phrases so accidental removal of the safety/evidence contract fails locally."
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-318-design-partner-handoff.json",
+    "python3 -m pytest tests/unit/test_design_partner_handoff.py tests/unit/test_task_packet.py -q",
+    "make lint",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "make docs",
+    "make test",
+    "git diff --check"
+  ],
+  "evidence": [
+    "Issue #318 Task Packet validation and changed-path boundary output.",
+    "Static handoff policy regression tests covering conclusion vocabulary, authority boundaries, evidence statuses, and the rejected-request example.",
+    "Rendered/strict documentation validation and context-check output.",
+    "Full repository test output and final whitespace/diff audit.",
+    "The handoff document itself, including the Product/Motion/MCU/Safety/site checklist and evidence ladder."
+  ],
+  "stop_conditions": [
+    "The requested work requires changing interfaces, public JSON Schema, Pydantic models, robot/control, firmware, or a safety implementation rather than documenting the boundary.",
+    "A scenario or product document would expose raw joint, controller, CAN, credential, safe-enable, E-stop, or emergency-reset authority.",
+    "A user report, screenshot, scripted fixture, Gazebo run, or verbal confirmation would be promoted to physical or release evidence without the eligible artifact and owner approval.",
+    "Identifiable Design Partner data, private logs, raw videos, access tokens, or unredacted quotes would need to be committed.",
+    "The static policy test or required repository checks fail for a reason that cannot be resolved within the allowed documentation/test paths."
+  ],
+  "max_iterations": 3,
+  "data_classification": "Public repository documentation only; partner identity and raw evidence remain private and are represented by opaque references.",
+  "model_policy": "Neither a language model, scenario manifest, Design Partner, nor product acceptance record may grant Motion, MCU, E-stop, safe-enable, release, or observed-completion authority.",
+  "risks_and_fallbacks": [
+    "This change defines a handoff contract and does not implement a Motion adapter, MCU path, E-stop, ROS/DDS bridge, physical test, or scenario registry.",
+    "If owners disagree about a safety or evidence boundary, preserve the stricter interpretation and record the decision as defer or reject until the named human owner resolves it.",
+    "If no physical bench or eligible Gazebo runner exists, keep the corresponding evidence status not_executed or blocked; continue only with the explicitly bounded software/product claim."
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - 90-day execution: product/90-day-plan.md
       - Problem card template: product/problem-card-template.md
       - Design Partner scenario template: product/design-partner-scenario-template.md
+      - Design Partner handoff boundary: product/design-partner-handoff.md
       - External feedback template: product/feedback-record-template.md
       - Metrics and decision log: product/metrics-and-decision-log.md
   - Risk management: project-management/risk-management.md

--- a/tests/unit/test_design_partner_handoff.py
+++ b/tests/unit/test_design_partner_handoff.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HANDOFF = ROOT / "docs/product/design-partner-handoff.md"
+SCENARIO_TEMPLATE = ROOT / "docs/product/design-partner-scenario-template.md"
+PRODUCT_README = ROOT / "docs/product/README.md"
+MKDOCS = ROOT / "mkdocs.yml"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").casefold()
+
+
+def test_handoff_answers_the_required_owner_response_sections() -> None:
+    text = _text(HANDOFF)
+    required_sections = (
+        "## 1. decision vocabulary",
+        "## 2. semantic action contract",
+        "## 3. motion adapter result boundary",
+        "## 4. handoff checklist",
+        "## 5. evidence ladder",
+        "## 6. abort, stop, recovery, and confirmation authority",
+        "## 7. product acceptance versus motion/safety acceptance",
+        "## 8. rejected request example",
+        "## 9. copyable handoff record",
+        "## 10. next step and decision record",
+    )
+    for section in required_sections:
+        assert section in text
+
+
+def test_handoff_preserves_semantic_and_safety_boundaries() -> None:
+    text = _text(HANDOFF)
+    required_terms = (
+        "continue",
+        "change",
+        "defer",
+        "reject",
+        "semantic action",
+        "actionresult",
+        "worldstate",
+        "safe_stop",
+        "e-stop",
+        "mcu-safety",
+        "joint positions",
+        "raw can frames",
+        "controller goals",
+        "safe-enable",
+        "does not grant",
+        "safety owner must refuse",
+    )
+    for term in required_terms:
+        assert term in text
+
+
+def test_handoff_keeps_evidence_classes_and_incomplete_statuses_distinct() -> None:
+    text = _text(HANDOFF)
+    for term in (
+        "software",
+        "scripted_fixture",
+        "gazebo",
+        "physical",
+        "release_eligible: false",
+        "confirmed",
+        "failed",
+        "refuted",
+        "insufficient_evidence",
+        "not_executed",
+        "blocked",
+    ):
+        assert term in text
+
+
+def test_generic_scenario_template_points_to_the_stricter_handoff() -> None:
+    template = _text(SCENARIO_TEMPLATE)
+    readme = _text(PRODUCT_README)
+    mkdocs = _text(MKDOCS)
+    assert "design partner handoff boundary" in template
+    assert "handoff decision" in template
+    assert "design-partner-handoff.md" in readme
+    assert "product/design-partner-handoff.md" in mkdocs


### PR DESCRIPTION
## Related Issue

Partially addresses #318.

## What changed

- Added a dedicated Design Partner handoff contract covering `continue`, `change`, `defer`, and `reject` decisions for a named claim, scenario version, and evidence class.
- Defined the controller-independent semantic action boundary: versioned semantic actions, opaque targets, bounded policy/capability references, and observable goals are allowed; joint, trajectory, velocity, torque, CAN, controller, credential, and E-stop fields are forbidden.
- Documented the Motion `ActionResult` and read-only health/fault handoff, including correlation, dispatch/device acknowledgement, and the distinction between execution acknowledgement and observed `WorldState` completion.
- Added separate Product, Motion, MCU/Safety, Runtime/Integration, site/partner, and Evidence/QA inputs and outputs.
- Defined the independent evidence ladder for `software`, `scripted_fixture`, `gazebo`, and `physical` claims, with explicit incomplete statuses and `release_eligible: false` for scripted fixtures by default.
- Assigned `safe_stop`, `abort`, E-stop, recovery, and manual-confirmation authority to the appropriate trusted runtime, MCU/Safety, site, and human-owner boundaries.
- Updated the Design Partner template, product documentation, and MkDocs navigation; added the Issue #318 Task Packet and static policy regression tests.

## Interfaces affected

- No public JSON Schema, Pydantic model, firmware, `robot/control/`, Scenario Registry, Motion adapter, MCU/E-stop implementation, ROS/DDS bridge, or hardware configuration was changed.
- The illustrative manifest in the handoff document is explicitly pseudocode and does not introduce a public interface.

## Tests and commands

- Task Packet validation: passed, including changed-path validation against `origin/main`.
- Focused regression: `62 passed` (`test_design_partner_handoff.py` and `test_task_packet.py`).
- Full repository test suite: `1013 passed, 1 skipped`.
- `make ... lint`: passed (Ruff check and format check; 364 files).
- `make ... docs`: passed with strict MkDocs; existing repository pages not listed in the longstanding nav remain reported as informational warnings.
- `make ... contract`: passed.
- `make ... scenario-check`: passed (12 frozen and 24 expanded manifests).
- `make ... context-check`: passed.
- `git diff --check`: passed.

The commands were run with the repository virtual environment at `/home/tanghao/src/workbench-desk-robot/.venv/bin/python`.

## Evidence

This PR provides documentation and deterministic static-regression evidence only. It does not claim a Design Partner trial, Gazebo run, physical actuator behavior, E-stop validation, MCU validation, or hard-real-time behavior. Any missing or ineligible evidence remains `insufficient_evidence`, `not_executed`, or `blocked` according to the declared claim and gate.

## Risks and rollback

- The handoff is a governance/documentation contract; implementing adapters, recovery, orchestration, physical safety, or Scenario Registry behavior requires separate owner-approved Issues and Task Packets.
- Product continuation cannot promote fixture or simulator evidence to a physical or release claim. Safety-owner disagreement must remain `defer` or `reject` until resolved by a named human owner.
- Rollback is a normal revert of commit `7360318b1e85ffe7851304da3b5d43e65ebb13b1`; no data or schema migration is required.

## Checklist

- [x] I changed only approved paths.
- [x] Tests and contract checks pass.
- [x] I covered normal and failure behavior in the handoff policy regression.
- [x] No public interface changed; the related documentation and template were updated.
- [x] I did not add secrets, private data or unreviewed assets.
