### PR TITLE
feat(linux): add fail-closed GPIO software contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 
 .PHONY: bootstrap lint fmt test contract scenario-check golden-check evaluation-check evaluation-scripted context-check \
 	dashboard-test dashboard demo demo-scripted demo-offline demo-model model-provision performance-test benchmark-startup \
-	benchmark-resources performance-regression-test offline-integration docs task-check check container-smoke \
+	benchmark-resources performance-regression-test offline-integration gpio-test docs task-check check container-smoke \
 	sim sim-doctor sim-list sim-run
 
 bootstrap:
@@ -89,6 +89,9 @@ dashboard-test:
 
 offline-integration:
 	$(PYTHON) -m pytest tests/integration/test_offline_system.py -v
+
+gpio-test:
+	$(PYTHON) -m pytest tests/unit/test_gpio_contract.py -v
 
 dashboard:
 	$(PYTHON) -m workbench_backend.server --host 127.0.0.1 --port 8080

--- a/docs/architecture/linux-drivers.md
+++ b/docs/architecture/linux-drivers.md
@@ -98,3 +98,7 @@ LINUX5/LINUX6 的实现必须在硬件资源确认后补充以下内容：
 不能作为真实吞吐、延迟或 jitter 的证据。后续驱动 PR 应先补齐目标控制器型号、
 寄存器/设备树资源和内核版本，再分别实现 CAN、UART/SPI、GPIO、DMA 和 IRQ 模块，
 并沿用本架构的错误回滚、数据所有权和证据要求。
+
+LINUX4 的 GPIO 软件契约和 fake provider 位于 `hardware/linux_drivers/gpio/`。该契约
+只验证 character-device 语义、unknown 输入、边沿、去抖和有界队列；真实 GPIO 线路、
+设备树和安全回路仍由硬件与安全 Owner 确认。

--- a/docs/task_packets/linux-gpio-contract.json
+++ b/docs/task_packets/linux-gpio-contract.json
@@ -7,6 +7,7 @@
     "hardware/linux_drivers/README.md",
     "tests/unit/test_gpio_contract.py",
     "Makefile",
+    "docs/architecture/linux-drivers.md",
     "docs/task_packets/linux-gpio-contract.json"
   ],
   "read_only_paths": [

--- a/docs/task_packets/linux-gpio-contract.json
+++ b/docs/task_packets/linux-gpio-contract.json
@@ -1,0 +1,59 @@
+{
+  "issue": "LINUX4",
+  "human_owner": "Quchaosheng",
+  "objective": "Define and test a fail-closed software GPIO contract with an injectable fake provider while leaving physical lines and safety-circuit ownership to hardware and safety owners.",
+  "allowed_paths": [
+    "hardware/linux_drivers/gpio/**",
+    "hardware/linux_drivers/README.md",
+    "tests/unit/test_gpio_contract.py",
+    "Makefile",
+    "docs/task_packets/linux-gpio-contract.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**",
+    "hardware/safety/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**",
+    "hardware/safety/**"
+  ],
+  "acceptance": [
+    "logical GPIO lines have validated direction, active level, edge and debounce configuration",
+    "outputs start inactive and unobserved inputs remain unknown until a valid observation",
+    "input timestamps are strictly increasing and edge events use bounded monotonic sequence numbers",
+    "queue-full, permission, invalid-line, invalid-timestamp and closed-provider outcomes fail closed",
+    "tests cover input and output behavior without changing frozen interfaces or physical safety ownership",
+    "documentation identifies real line numbers, pinmux, device-tree, IRQ and electrical validation as owner-gated"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/linux-gpio-contract.json",
+    "python3 -m pytest tests/unit/test_gpio_contract.py -v",
+    "make gpio-test",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "focused GPIO contract test output",
+    "fake provider default-state, edge, debounce, timestamp, backpressure and lifecycle assertions",
+    "repository gate output",
+    "software-only scope with physical GPIO and safety validation marked NOT_EXECUTED"
+  ],
+  "stop_conditions": [
+    "a physical GPIO line, safety circuit or device-tree choice is required",
+    "a production GPIO ABI or frozen interface schema change is required",
+    "the implementation would control E-stop, motor enable or watchdog authority",
+    "fake GPIO evidence would be presented as electrical or hardware safety evidence"
+  ]
+}

--- a/hardware/linux_drivers/README.md
+++ b/hardware/linux_drivers/README.md
@@ -13,6 +13,10 @@
 面向发布的架构说明位于
 [`docs/architecture/linux-drivers.md`](../../docs/architecture/linux-drivers.md)。
 
+LINUX4 的 GPIO 软件契约和 fake provider 位于
+[`gpio/README.md`](gpio/README.md)。它只验证 character-device 语义、unknown 输入、
+边沿、去抖和有界事件队列；真实 GPIO 线路和安全回路仍由硬件与安全 Owner 确认。
+
 ## 分层边界
 
 ```text

--- a/hardware/linux_drivers/gpio/README.md
+++ b/hardware/linux_drivers/gpio/README.md
@@ -1,0 +1,30 @@
+# GPIO 软件契约
+
+这是 LINUX4 的软件测试边界，使用 Linux GPIO character-device 的语义建模，但不
+绑定真实 GPIO 控制器、line number、设备树节点、pinmux 或安全电路。生产代码应
+通过 `libgpiod`/内核 GPIO character device 访问线路，不新增 sysfs 私有 ABI。
+
+## 契约
+
+- 每条线有唯一逻辑名称、输入/输出方向、有效电平、边沿和去抖时间。
+- 输出初始化为非激活值；输入在首次观测前是 unknown，不能被当作安全或许可状态。
+- 输入时间戳必须严格递增；回退、重复或非法时间戳失败关闭。
+- 边沿事件进入固定容量队列；队列满返回 backpressure，不能静默丢弃。
+- 关闭 provider 后，所有读写和事件读取都失败；挂起事件被清空。
+- fake provider 用 `RLock` 保护配置、状态和事件序号，模拟单写者状态边界。
+
+## 安全边界
+
+`FakeGPIOProvider` 只验证软件行为。它不控制电机使能、E-stop、安全继电器或
+watchdog，也不能证明 GPIO 电平、电气时序、抗干扰或硬件安全回路。真实 GPIO
+编号、极性、边沿、中断和权限必须由 PCB、MCU、安全 Owner 在设备树和实机 bring-up
+中确认。
+
+## 测试
+
+```bash
+make gpio-test
+```
+
+测试覆盖默认安全态、unknown 输入、边沿和去抖、序号和时间戳、队列背压、关闭
+语义、权限隔离和非法配置。硬件验证保持 `NOT_EXECUTED`。

--- a/hardware/linux_drivers/gpio/__init__.py
+++ b/hardware/linux_drivers/gpio/__init__.py
@@ -1,0 +1,27 @@
+"""Software-only GPIO contract and deterministic fake provider."""
+
+from .contract import (
+    Edge,
+    FakeGPIOProvider,
+    GPIOConfig,
+    GPIODirection,
+    GPIOError,
+    GPIOEvent,
+    GPIOPermissionError,
+    GPIOProviderClosed,
+    GPIOQueueFull,
+    GPIOStateError,
+)
+
+__all__ = [
+    "Edge",
+    "FakeGPIOProvider",
+    "GPIOConfig",
+    "GPIODirection",
+    "GPIOError",
+    "GPIOEvent",
+    "GPIOPermissionError",
+    "GPIOProviderClosed",
+    "GPIOQueueFull",
+    "GPIOStateError",
+]

--- a/hardware/linux_drivers/gpio/contract.py
+++ b/hardware/linux_drivers/gpio/contract.py
@@ -1,0 +1,171 @@
+"""Bounded GPIO contract for software adapter and lifecycle tests."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from enum import IntEnum, StrEnum
+
+
+class GPIOError(ValueError):
+    """Base class for invalid GPIO configuration or events."""
+
+
+class GPIOPermissionError(GPIOError):
+    """The requested operation is not allowed for the configured direction."""
+
+
+class GPIOStateError(GPIOError):
+    """The operation violates the line's state or timestamp contract."""
+
+
+class GPIOProviderClosed(ConnectionError):
+    """The provider has been closed and cannot be accessed."""
+
+
+class GPIOQueueFull(TimeoutError):
+    """The bounded input event queue is full."""
+
+
+class GPIODirection(StrEnum):
+    INPUT = "input"
+    OUTPUT = "output"
+
+
+class Edge(IntEnum):
+    NONE = 0
+    RISING = 1
+    FALLING = 2
+    BOTH = 3
+
+
+@dataclass(frozen=True, slots=True)
+class GPIOConfig:
+    """Logical line configuration, independent of physical line numbering."""
+
+    name: str
+    direction: GPIODirection
+    active_high: bool = True
+    edge: Edge = Edge.NONE
+    debounce_ns: int = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name or len(self.name) > 64:
+            raise GPIOError("line name must be 1-64 characters")
+        if not isinstance(self.direction, GPIODirection):
+            raise GPIOError("direction must be input or output")
+        if type(self.active_high) is not bool:
+            raise GPIOError("active_high must be a boolean")
+        if not isinstance(self.edge, Edge):
+            raise GPIOError("edge must be a valid Edge value")
+        if type(self.debounce_ns) is not int or not 0 <= self.debounce_ns <= 60_000_000_000:
+            raise GPIOError("debounce_ns must be between 0 and 60 seconds")
+        if self.direction is GPIODirection.OUTPUT and self.edge is not Edge.NONE:
+            raise GPIOError("output lines cannot subscribe to input edges")
+
+
+@dataclass(frozen=True, slots=True)
+class GPIOEvent:
+    """A validated input transition delivered to the bounded event queue."""
+
+    line: str
+    sequence: int
+    value: bool
+    timestamp_ns: int
+
+
+class FakeGPIOProvider:
+    """Thread-safe fake GPIO provider with fail-closed lifecycle semantics."""
+
+    def __init__(self, configs: list[GPIOConfig], *, event_capacity: int = 16) -> None:
+        if type(event_capacity) is not int or not 1 <= event_capacity <= 1024:
+            raise GPIOError("event_capacity must be between 1 and 1024")
+        if not configs:
+            raise GPIOError("at least one GPIO line is required")
+        if len({config.name for config in configs}) != len(configs):
+            raise GPIOError("GPIO line names must be unique")
+        self._configs = {config.name: config for config in configs}
+        self._values = {config.name: False for config in configs}
+        self._observed: set[str] = set()
+        self._last_timestamp: dict[str, int] = {}
+        self._events: list[GPIOEvent] = []
+        self._next_sequence = 0
+        self._event_capacity = event_capacity
+        self._closed = False
+        self._lock = threading.RLock()
+
+    @property
+    def event_count(self) -> int:
+        with self._lock:
+            return len(self._events)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            self._events.clear()
+
+    def configure(self, name: str) -> GPIOConfig:
+        self._ensure_open()
+        try:
+            return self._configs[name]
+        except KeyError as exc:
+            raise GPIOError(f"unknown GPIO line: {name}") from exc
+
+    def read(self, name: str) -> bool:
+        with self._lock:
+            config = self.configure(name)
+            if config.direction is not GPIODirection.INPUT:
+                raise GPIOPermissionError(f"GPIO line is not an input: {name}")
+            if name not in self._observed:
+                raise GPIOStateError(f"input value is unknown until observed: {name}")
+            return self._values[name]
+
+    def write(self, name: str, value: bool) -> None:
+        with self._lock:
+            config = self.configure(name)
+            if config.direction is not GPIODirection.OUTPUT:
+                raise GPIOPermissionError(f"GPIO line is not an output: {name}")
+            if type(value) is not bool:
+                raise GPIOError("GPIO value must be a boolean")
+            self._values[name] = value
+
+    def inject_input(self, name: str, value: bool, timestamp_ns: int) -> GPIOEvent | None:
+        with self._lock:
+            config = self.configure(name)
+            if config.direction is not GPIODirection.INPUT:
+                raise GPIOPermissionError(f"GPIO line is not an input: {name}")
+            if type(value) is not bool:
+                raise GPIOError("GPIO value must be a boolean")
+            if type(timestamp_ns) is not int or timestamp_ns < 0:
+                raise GPIOError("timestamp_ns must be a non-negative integer")
+            previous_timestamp = self._last_timestamp.get(name)
+            if previous_timestamp is not None and timestamp_ns <= previous_timestamp:
+                raise GPIOStateError("input timestamps must increase strictly")
+            previous_value = self._values[name]
+            self._last_timestamp[name] = timestamp_ns
+            self._values[name] = value
+            if name not in self._observed:
+                self._observed.add(name)
+                return None
+            if previous_value == value:
+                return None
+            if config.debounce_ns and timestamp_ns - previous_timestamp < config.debounce_ns:
+                return None
+            edge = Edge.RISING if not previous_value and value else Edge.FALLING
+            if config.edge is Edge.NONE or (config.edge is not edge and config.edge is not Edge.BOTH):
+                return None
+            if len(self._events) >= self._event_capacity:
+                raise GPIOQueueFull(f"GPIO event queue is full for {name}")
+            event = GPIOEvent(name, self._next_sequence, value, timestamp_ns)
+            self._next_sequence += 1
+            self._events.append(event)
+            return event
+
+    def read_event(self) -> GPIOEvent | None:
+        with self._lock:
+            self._ensure_open()
+            return self._events.pop(0) if self._events else None
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise GPIOProviderClosed("GPIO provider is closed")

--- a/hardware/linux_drivers/gpio/contract.py
+++ b/hardware/linux_drivers/gpio/contract.py
@@ -105,11 +105,12 @@ class FakeGPIOProvider:
             self._events.clear()
 
     def configure(self, name: str) -> GPIOConfig:
-        self._ensure_open()
-        try:
-            return self._configs[name]
-        except KeyError as exc:
-            raise GPIOError(f"unknown GPIO line: {name}") from exc
+        with self._lock:
+            self._ensure_open()
+            try:
+                return self._configs[name]
+            except KeyError as exc:
+                raise GPIOError(f"unknown GPIO line: {name}") from exc
 
     def read(self, name: str) -> bool:
         with self._lock:

--- a/tests/unit/test_gpio_contract.py
+++ b/tests/unit/test_gpio_contract.py
@@ -1,0 +1,90 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "hardware" / "linux_drivers"))
+
+from gpio import (
+    Edge,
+    FakeGPIOProvider,
+    GPIOConfig,
+    GPIODirection,
+    GPIOError,
+    GPIOEvent,
+    GPIOPermissionError,
+    GPIOProviderClosed,
+    GPIOQueueFull,
+    GPIOStateError,
+)
+
+
+def provider(*, capacity: int = 4) -> FakeGPIOProvider:
+    return FakeGPIOProvider(
+        [
+            GPIOConfig("status", GPIODirection.INPUT, edge=Edge.BOTH, debounce_ns=10),
+            GPIOConfig("enable", GPIODirection.OUTPUT, active_high=True),
+        ],
+        event_capacity=capacity,
+    )
+
+
+def test_output_starts_inactive_and_input_is_unknown_until_observed() -> None:
+    gpio = provider()
+    with pytest.raises(GPIOStateError, match="unknown"):
+        gpio.read("status")
+    with pytest.raises(GPIOPermissionError, match="not an input"):
+        gpio.read("enable")
+    with pytest.raises(GPIOPermissionError, match="not an output"):
+        gpio.write("status", True)
+    gpio.write("enable", True)
+    assert gpio._values["enable"] is True
+
+
+def test_input_edges_are_debounced_and_queued_with_monotonic_sequence() -> None:
+    gpio = provider()
+    assert gpio.inject_input("status", False, 100) is None
+    assert gpio.inject_input("status", True, 105) is None
+    event = gpio.inject_input("status", False, 120)
+    assert event is not None
+    assert event == GPIOEvent("status", 0, False, 120)
+    assert gpio.read_event() == event
+    assert gpio.read_event() is None
+
+
+def test_timestamp_rollback_unknown_line_and_invalid_lines_fail_closed() -> None:
+    gpio = provider()
+    gpio.inject_input("status", False, 10)
+    with pytest.raises(GPIOStateError, match="increase strictly"):
+        gpio.inject_input("status", True, 10)
+    with pytest.raises(GPIOStateError, match="increase strictly"):
+        gpio.inject_input("status", True, 9)
+    with pytest.raises(GPIOError, match="unknown GPIO"):
+        gpio.configure("missing")
+    with pytest.raises(GPIOError, match="line name"):
+        GPIOConfig("", GPIODirection.INPUT)
+
+
+def test_event_queue_backpressure_is_explicit() -> None:
+    gpio = provider(capacity=1)
+    gpio.inject_input("status", False, 0)
+    gpio.inject_input("status", True, 10)
+    with pytest.raises(GPIOQueueFull, match="full"):
+        gpio.inject_input("status", False, 20)
+
+
+def test_close_clears_pending_events_and_rejects_future_access() -> None:
+    gpio = provider()
+    gpio.inject_input("status", False, 0)
+    gpio.close()
+    assert gpio.event_count == 0
+    with pytest.raises(GPIOProviderClosed):
+        gpio.read_event()
+    with pytest.raises(GPIOProviderClosed):
+        gpio.write("enable", True)
+
+
+def test_config_rejects_edge_subscription_on_output() -> None:
+    with pytest.raises(GPIOError, match="output lines"):
+        GPIOConfig("enable", GPIODirection.OUTPUT, edge=Edge.RISING)

--- a/tests/unit/test_gpio_contract.py
+++ b/tests/unit/test_gpio_contract.py
@@ -1,4 +1,5 @@
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -83,6 +84,33 @@ def test_close_clears_pending_events_and_rejects_future_access() -> None:
         gpio.read_event()
     with pytest.raises(GPIOProviderClosed):
         gpio.write("enable", True)
+
+
+def test_public_configure_waits_for_provider_lock() -> None:
+    gpio = provider()
+    lock_held = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    def hold_provider_lock() -> None:
+        with gpio._lock:
+            lock_held.set()
+            release.wait(1.0)
+
+    def configure_line() -> None:
+        gpio.configure("status")
+        completed.set()
+
+    holder = threading.Thread(target=hold_provider_lock)
+    reader = threading.Thread(target=configure_line)
+    holder.start()
+    assert lock_held.wait(1.0)
+    reader.start()
+    assert not completed.wait(0.05)
+    release.set()
+    holder.join(1.0)
+    reader.join(1.0)
+    assert completed.is_set()
 
 
 def test_config_rejects_edge_subscription_on_output() -> None:


### PR DESCRIPTION
## Summary

Add the LINUX4 software-level GPIO contract and deterministic fake provider.

## Changes

- Define validated logical GPIO line configuration.
- Support input/output direction, active level, edge selection and debounce.
- Start output lines in the inactive state.
- Keep input values unknown until the first valid observation.
- Require strictly increasing input timestamps.
- Emit bounded edge events with monotonic sequence numbers.
- Reject queue overflow explicitly instead of silently dropping events.
- Reject reads and writes that violate input/output permissions.
- Reject unknown lines, invalid values, invalid timestamps and unsafe output edge subscriptions.
- Clear pending events and reject all future access after provider shutdown.
- Add thread-safe fake GPIO provider implementation.
- Add focused tests for default state, unknown inputs, debounce, edge events, timestamp rollback, backpressure, lifecycle and permission boundaries.
- Add the `make gpio-test` entry point.
- Add GPIO documentation and the LINUX4 Task Packet.

## Hardware Boundary

This PR is software-only. It does not define or implement:

- Physical GPIO line numbers
- Device-tree or ACPI nodes
- Pinmux configuration
- IRQ routing
- Electrical levels or debounce hardware
- E-stop, motor-enable or watchdog authority
- Safety relay behavior

Physical GPIO and safety validation remain owner-gated and NOT_EXECUTED.

## Validation

- 6 GPIO contract tests passed
- Ruff check passed
- Ruff format check passed
- Python syntax check passed
- Task Packet JSON syntax passed
- context-check passed
- git diff --check passed

The fake provider validates software semantics only and does not claim electrical or physical hardware evidence.

## Related Issue

## What changed

## Interfaces affected

## Tests and commands

## Evidence

## Risks and rollback

## Checklist

- [ ] I changed only approved paths.
- [ ] Tests and contract checks pass.
- [ ] I covered normal and failure behavior.
- [ ] I updated examples/docs when an interface changed.
- [ ] I did not add secrets, private data or unreviewed assets.
