### PR TITLE
feat(contract): add bounded navigate action

### DIFF
--- a/docs/product/design-partner-handoff.md
+++ b/docs/product/design-partner-handoff.md
@@ -26,9 +26,10 @@ physical or safety claim remains `insufficient_evidence`, `not_executed`, or
 ## 2. Semantic action contract
 
 The Scenario layer describes a user task. It does not describe how a
-controller should move. The current public semantic action set is:
+controller should move. Until a separately approved versioned contract adds
+more actions, the current public semantic action set is:
 
-`observe`, `grasp`, `place`, `ask_confirm`, `express`, `stop`, and `navigate`.
+`observe`, `grasp`, `place`, `ask_confirm`, `express`, and `stop`.
 
 A scenario may refer to an action only when that action is registered and
 version-compatible. It may provide:

--- a/docs/product/design-partner-handoff.md
+++ b/docs/product/design-partner-handoff.md
@@ -26,10 +26,9 @@ physical or safety claim remains `insufficient_evidence`, `not_executed`, or
 ## 2. Semantic action contract
 
 The Scenario layer describes a user task. It does not describe how a
-controller should move. Until a separately approved versioned contract adds
-more actions, the current public semantic action set is:
+controller should move. The current public semantic action set is:
 
-`observe`, `grasp`, `place`, `ask_confirm`, `express`, and `stop`.
+`observe`, `grasp`, `place`, `ask_confirm`, `express`, `stop`, and `navigate`.
 
 A scenario may refer to an action only when that action is registered and
 version-compatible. It may provide:

--- a/docs/task_packets/issue-162-navigate-contract.json
+++ b/docs/task_packets/issue-162-navigate-contract.json
@@ -1,0 +1,121 @@
+{
+  "issue": 162,
+  "human_owner": "TH3478",
+  "objective": "Add a bounded version-compatible NAVIGATE semantic action addressed only by a configured waypoint identifier, while preserving the independent STOP, execution, observation, and verification boundaries.",
+  "decision_supported": "Can Agent Runtime expose fixed-map waypoint navigation through the reviewed public semantic contract without accepting coordinates, raw motion controls, or unverified location claims?",
+  "allowed_paths": [
+    "docs/task_packets/issue-162-navigate-contract.json",
+    "interfaces/json_schema/semantic_action.schema.json",
+    "interfaces/examples/semantic-action-navigate.json",
+    "libs/kernel/workbench/kernel/schema_compiler.py",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_schemas.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_registry.py",
+    "tests/unit/test_contract_navigate.py",
+    "tests/unit/test_kernel_schema_compiler.py",
+    "tests/unit/test_tool_registry.py",
+    "tests/unit/test_policy_validator.py",
+    "tests/unit/test_execution_controller.py"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "interfaces/examples/semantic-action-place.json",
+    "interfaces/examples/task-graph-place.json",
+    "interfaces/json_schema/action_result.schema.json",
+    "interfaces/json_schema/task_graph.schema.json",
+    "services/agent_runtime/workbench_agent_runtime/execution_controller.py",
+    "services/agent_runtime/workbench_agent_runtime/policy_validator.py",
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "services/agent_runtime/workbench_agent_runtime/__init__.py",
+    "services/world_model/**",
+    "tests/integration/test_observe_plan_act.py",
+    "tests/unit/test_agent_runtime.py",
+    "tools/scripts/check_task_packet.py",
+    "tools/scripts/validate_contracts.py",
+    "Makefile",
+    "pyproject.toml"
+  ],
+  "forbidden": [
+    "robot/control/**",
+    "firmware/**",
+    "hardware/**",
+    "sim/**",
+    "services/backend/**",
+    "services/perception/**",
+    ".github/**"
+  ],
+  "input_refs": [
+    "AGENTS.md",
+    "interfaces/json_schema/semantic_action.schema.json",
+    "interfaces/json_schema/action_result.schema.json",
+    "interfaces/json_schema/task_graph.schema.json",
+    "interfaces/examples/semantic-action-place.json",
+    "interfaces/examples/task-graph-place.json",
+    "libs/kernel/workbench/kernel/schema_compiler.py",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_schemas.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_registry.py",
+    "services/agent_runtime/workbench_agent_runtime/policy_validator.py",
+    "services/agent_runtime/workbench_agent_runtime/execution_controller.py"
+  ],
+  "outputs": [
+    "interfaces/json_schema/semantic_action.schema.json",
+    "interfaces/examples/semantic-action-navigate.json",
+    "libs/kernel/workbench/kernel/schema_compiler.py",
+    "libs/contracts/workbench_contracts/models.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_schemas.py",
+    "services/agent_runtime/workbench_agent_runtime/tool_registry.py",
+    "tests/unit/test_contract_navigate.py",
+    "tests/unit/test_kernel_schema_compiler.py",
+    "tests/unit/test_tool_registry.py",
+    "tests/unit/test_policy_validator.py",
+    "tests/unit/test_execution_controller.py",
+    "docs/task_packets/issue-162-navigate-contract.json"
+  ],
+  "acceptance": [
+    "ActionType and the public SemanticAction JSON Schema both register navigate while the existing six action values and examples remain valid.",
+    "A navigate action requires a non-empty target_id that is treated as an opaque configured waypoint identifier; no coordinate, pose, TF, wheel, velocity, acceleration, joint, or free-form planner field is accepted.",
+    "The navigate parameter object is closed and currently empty, so no caller-supplied selector can loosen deployment safety limits; unknown waypoint resolution remains the injected executor adapter's explicit failure.",
+    "Pydantic construction and JSON ingress enforce the navigate-specific target and parameter boundary, and schema validation enforces the same conditional shape and rejects extra fields.",
+    "The repository Schema Compiler accepts the structural navigate conditional and generated models enforce its required target and closed parameter shape.",
+    "ToolRegistry and PolicyValidator accept a valid navigate action through the existing single allow-list, reject missing or blank targets and forbidden parameters, and allow STOP to remain independently registered.",
+    "Execution-controller regression evidence shows a valid navigate action is forwarded without inventing coordinates, an adapter-reported unknown waypoint fails explicitly, and a queued STOP is still dispatched at the next boundary.",
+    "A completed navigation ActionResult remains adapter evidence only and does not assert an observed or verified World Model location.",
+    "The Task Packet boundary, focused tests, contract, scenario, context, full test, lint, and whitespace checks pass; interface changes remain subject to Runtime, World Model, and Integration owner approval before merge."
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/issue-162-navigate-contract.json --base origin/main",
+    "python3 -m pytest tests/unit/test_contract_navigate.py tests/unit/test_tool_registry.py tests/unit/test_policy_validator.py tests/unit/test_execution_controller.py -v",
+    "python3 -m pytest tests/unit/test_kernel_schema_compiler.py -v",
+    "python3 -m pytest tests/integration/test_observe_plan_act.py tests/unit/test_agent_runtime.py -v",
+    "python3 -m ruff check libs/kernel/workbench/kernel/schema_compiler.py libs/contracts/workbench_contracts/models.py services/agent_runtime/workbench_agent_runtime/tool_schemas.py services/agent_runtime/workbench_agent_runtime/tool_registry.py tests/unit/test_contract_navigate.py tests/unit/test_kernel_schema_compiler.py tests/unit/test_tool_registry.py tests/unit/test_policy_validator.py tests/unit/test_execution_controller.py",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "Task Packet boundary output against the fixed branch base.",
+    "Focused contract, registry, policy, and execution-controller tests for valid navigation, closed parameters, unknown waypoint failure, STOP independence, and legacy action compatibility.",
+    "Schema/example and Pydantic round-trip output from make contract.",
+    "Full test, Ruff, scenario, context, and whitespace-check output.",
+    "Three-way Runtime, World Model, and Integration approval references on the eventual pull request."
+  ],
+  "stop_conditions": [
+    "Implementation requires Nav2, mapping, planners, appliance skills, firmware, robot/control, or physical navigation changes.",
+    "A public parameter cannot be kept closed and typed without adding a raw motion or arbitrary pose side channel.",
+    "Unknown waypoint handling would require guessing coordinates or claiming observed/verified location from ActionResult alone.",
+    "A required change falls outside allowed_paths or conflicts with the pre-existing .gitignore edit.",
+    "The interface change lacks Runtime, World Model, or Integration owner approval for merge.",
+    "A required validation command fails for a reason that cannot be fixed within this bounded contract and consumer scope."
+  ],
+  "max_iterations": 3,
+  "data_classification": "repository-contract",
+  "model_policy": "external_allowed",
+  "risks_and_fallbacks": [
+    "No waypoint catalog exists in this bounded contract change; the executor adapter owns deployment configuration and must return an explicit failure for an unknown identifier.",
+    "The zero-parameter NAVIGATE shape leaves future policy selectors for a separately reviewed contract change rather than accepting open-ended options.",
+    "Existing tabletop planners remain unchanged and continue emitting only their previously supported actions; navigation planning belongs to later issues."
+  ]
+}

--- a/interfaces/examples/semantic-action-navigate.json
+++ b/interfaces/examples/semantic-action-navigate.json
@@ -1,0 +1,6 @@
+{
+  "action_id": "act-navigate-home",
+  "action_type": "navigate",
+  "target_id": "workbench_home",
+  "parameters": {}
+}

--- a/interfaces/json_schema/semantic_action.schema.json
+++ b/interfaces/json_schema/semantic_action.schema.json
@@ -2,11 +2,24 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "SemanticAction",
   "type": "object",
+  "additionalProperties": false,
   "required": ["action_id", "action_type"],
   "properties": {
     "action_id": {"type": "string"},
-    "action_type": {"enum": ["observe", "grasp", "place", "ask_confirm", "express", "stop"]},
+    "action_type": {"enum": ["observe", "grasp", "place", "ask_confirm", "express", "stop", "navigate"]},
     "target_id": {"type": ["string", "null"]},
     "parameters": {"type": "object"}
-  }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"action_type": {"const": "navigate"}}},
+      "then": {
+        "required": ["target_id"],
+        "properties": {
+          "target_id": {"type": "string", "minLength": 1, "pattern": ".*\\S.*"},
+          "parameters": {"type": "object", "additionalProperties": false, "maxProperties": 0}
+        }
+      }
+    }
+  ]
 }

--- a/libs/contracts/workbench_contracts/models.py
+++ b/libs/contracts/workbench_contracts/models.py
@@ -21,6 +21,7 @@ class ActionType(StrEnum):
     ASK_CONFIRM = "ask_confirm"
     EXPRESS = "express"
     STOP = "stop"
+    NAVIGATE = "navigate"
 
 
 class ActionStatus(StrEnum):
@@ -275,10 +276,37 @@ class EmotionIntent(_CanonicalRuntimeModel):
 
 
 class SemanticAction(_CanonicalRuntimeModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "allOf": [
+                {
+                    "if": {"properties": {"action_type": {"const": "navigate"}}},
+                    "then": {
+                        "required": ["target_id"],
+                        "properties": {
+                            "target_id": {"type": "string", "minLength": 1, "pattern": r".*\S.*"},
+                            "parameters": {"type": "object", "additionalProperties": False, "maxProperties": 0},
+                        },
+                    },
+                }
+            ]
+        }
+    )
+
     action_id: str
     action_type: ActionType
     target_id: str | None = None
     parameters: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_navigate_boundary(self) -> "SemanticAction":
+        if self.action_type is not ActionType.NAVIGATE:
+            return self
+        if not isinstance(self.target_id, str) or not self.target_id.strip():
+            raise ValueError("navigate requires a non-empty configured waypoint target_id")
+        if self.parameters:
+            raise ValueError("navigate parameters must be empty; waypoint policy is executor-owned")
+        return self
 
 
 class ActionOutcome(StrEnum):

--- a/libs/kernel/workbench/kernel/schema_compiler.py
+++ b/libs/kernel/workbench/kernel/schema_compiler.py
@@ -23,7 +23,9 @@ PROPERTY_KEYWORDS = {
     "description",
     "enum",
     "items",
+    "maxProperties",
     "maximum",
+    "minLength",
     "minimum",
     "minItems",
     "pattern",
@@ -67,6 +69,13 @@ def _numeric_constraint(schema: dict[str, Any], keyword: str, location: str) -> 
     return bound
 
 
+def _non_negative_integer_constraint(schema: dict[str, Any], keyword: str, location: str) -> int:
+    bound = schema[keyword]
+    if type(bound) is not int or bound < 0:
+        raise _MalformedSchema(f"schema {keyword} at {location} must be a non-negative integer")
+    return bound
+
+
 def _validate_schema_structure(
     schema: Any,
     *,
@@ -105,6 +114,11 @@ def _validate_schema_structure(
     for constraint_name in ("minimum", "maximum"):
         if constraint_name in schema:
             _numeric_constraint(schema, constraint_name, location)
+    for constraint_name in ("maxProperties", "minItems", "minLength"):
+        if constraint_name in schema:
+            _non_negative_integer_constraint(schema, constraint_name, location)
+    if "additionalProperties" in schema and type(schema["additionalProperties"]) is not bool:
+        raise _MalformedSchema(f"schema additionalProperties at {location} must be boolean")
     if "pattern" in schema:
         pattern = schema["pattern"]
         if not isinstance(pattern, str):
@@ -113,9 +127,6 @@ def _validate_schema_structure(
             re.compile(pattern)
         except (re.error, OverflowError) as exc:
             raise _MalformedSchema(f"schema pattern at {location} is invalid") from exc
-    if "minItems" in schema and (type(schema["minItems"]) is not int or schema["minItems"] < 0):
-        raise _MalformedSchema(f"schema minItems at {location} must be a non-negative integer")
-
     items = schema.get("items")
     if items is not None:
         _validate_schema_structure(
@@ -296,11 +307,13 @@ def validate_schema_instance(
         if not isinstance(value, str) or matcher.search(value) is None:
             raise _SchemaMismatch(f"value at {location} does not match pattern {pattern!r}")
     if "minItems" in schema:
-        min_items = schema["minItems"]
-        if type(min_items) is not int or min_items < 0:
-            raise _MalformedSchema(f"schema minItems at {location} must be a non-negative integer")
+        min_items = _non_negative_integer_constraint(schema, "minItems", location)
         if not isinstance(value, list) or len(value) < min_items:
             raise _SchemaMismatch(f"array at {location} has fewer than {min_items} items")
+    if "minLength" in schema:
+        min_length = _non_negative_integer_constraint(schema, "minLength", location)
+        if not isinstance(value, str) or len(value) < min_length:
+            raise _SchemaMismatch(f"value at {location} violates minLength {min_length}")
 
     if isinstance(value, list) and "items" in schema:
         for index, item in enumerate(value):
@@ -331,6 +344,10 @@ def validate_schema_instance(
                     references=references,
                     location=f"{location}.{field_name}",
                 )
+        if "maxProperties" in schema:
+            max_properties = _non_negative_integer_constraint(schema, "maxProperties", location)
+            if len(value) > max_properties:
+                raise _SchemaMismatch(f"value at {location} violates maxProperties {max_properties}")
 
     any_of = schema.get("anyOf")
     if any_of is not None:
@@ -472,6 +489,10 @@ def _python_annotation(definition: dict[str, Any], base_annotation: str | None =
         constraints.append(f"le={definition['maximum']!r}")
     if "minItems" in definition:
         constraints.append(f"min_length={definition['minItems']!r}")
+    if "minLength" in definition:
+        constraints.append(f"min_length={definition['minLength']!r}")
+    if "maxProperties" in definition:
+        constraints.append(f"max_length={definition['maxProperties']!r}")
     if "pattern" in definition:
         constraints.append(f"pattern={definition['pattern']!r}")
     if constraints:
@@ -484,6 +505,8 @@ def _typescript_constraint_comment(definition: dict[str, Any]) -> str | None:
         f"minimum: {definition['minimum']}" if "minimum" in definition else None,
         f"maximum: {definition['maximum']}" if "maximum" in definition else None,
         f"minItems: {definition['minItems']}" if "minItems" in definition else None,
+        f"minLength: {definition['minLength']}" if "minLength" in definition else None,
+        f"maxProperties: {definition['maxProperties']}" if "maxProperties" in definition else None,
         f"pattern: {definition['pattern']}" if "pattern" in definition else None,
     ]
     present = [constraint for constraint in constraints if constraint]
@@ -500,6 +523,11 @@ def _validate_definition(definition: dict[str, Any], location: str) -> None:
         raise ValueError(f"maximum must be numeric at {location}")
     if "minItems" in definition and (type(definition["minItems"]) is not int or definition["minItems"] < 0):
         raise ValueError(f"minItems must be a non-negative integer at {location}")
+    for constraint_name in ("maxProperties", "minLength"):
+        if constraint_name in definition and (
+            type(definition[constraint_name]) is not int or definition[constraint_name] < 0
+        ):
+            raise ValueError(f"{constraint_name} must be a non-negative integer at {location}")
     if "pattern" in definition and not isinstance(definition["pattern"], str):
         raise ValueError(f"pattern must be a string at {location}")
     items = definition.get("items")
@@ -521,6 +549,22 @@ def _validate_runtime_schema(schema: dict[str, Any], location: str) -> None:
     unsupported = set(schema) - RUNTIME_SCHEMA_KEYWORDS
     if unsupported:
         raise ValueError(f"unsupported runtime schema keyword(s) at {location}: {sorted(unsupported)}")
+    for constraint_name in ("minimum", "maximum"):
+        if constraint_name in schema:
+            _numeric_constraint(schema, constraint_name, location)
+    for constraint_name in ("maxProperties", "minItems", "minLength"):
+        if constraint_name in schema:
+            _non_negative_integer_constraint(schema, constraint_name, location)
+    if "additionalProperties" in schema and type(schema["additionalProperties"]) is not bool:
+        raise ValueError(f"additionalProperties must be boolean at {location}")
+    if "pattern" in schema:
+        pattern = schema["pattern"]
+        if not isinstance(pattern, str):
+            raise ValueError(f"pattern must be a string at {location}")
+        try:
+            re.compile(pattern)
+        except (re.error, OverflowError) as exc:
+            raise ValueError(f"pattern is invalid at {location}") from exc
     required = schema.get("required")
     if required is not None and (
         not isinstance(required, list) or any(not isinstance(field_name, str) for field_name in required)
@@ -574,9 +618,46 @@ def _conditional_validators(schema: dict[str, Any], name: str) -> tuple[list[str
             ],
             schema.get("allOf", []),
         )
+    conditionals = schema.get("allOf", [])
     lines: list[str] = []
     metadata: list[dict[str, Any]] = []
-    for index, conditional in enumerate(schema.get("allOf", []), start=1):
+
+    def is_numeric_conditional(conditional: object) -> bool:
+        if not isinstance(conditional, dict):
+            return False
+        try:
+            condition_properties = conditional["if"]["properties"]
+            then_properties = conditional["then"]["properties"]
+        except (KeyError, TypeError):
+            return False
+        if len(condition_properties) != 1 or len(then_properties) != 1:
+            return False
+        condition = next(iter(condition_properties.values()))
+        constraint = next(iter(then_properties.values()))
+        return (
+            isinstance(condition, dict)
+            and set(condition) == {"const"}
+            and isinstance(constraint, dict)
+            and bool(constraint)
+            and not set(constraint) - {"minimum", "maximum"}
+        )
+
+    if conditionals and not all(is_numeric_conditional(conditional) for conditional in conditionals):
+        _validate_runtime_schema(schema, name)
+        return (
+            [
+                "",
+                '    @model_validator(mode="before")',
+                "    @classmethod",
+                "    def _validate_schema_conditionals(cls, value):",
+                "        if isinstance(value, cls):",
+                "            return value",
+                f"        validate_schema_instance(value, {schema!r})",
+                "        return value",
+            ],
+            list(conditionals),
+        )
+    for index, conditional in enumerate(conditionals, start=1):
         try:
             condition_properties = conditional["if"]["properties"]
             then_properties = conditional["then"]["properties"]
@@ -772,10 +853,12 @@ class SchemaCompiler:
             if name == "mcu_protocol":
                 pydantic_imports = "BaseModel, ConfigDict, Field, model_serializer, model_validator"
             python_code = f"from typing import Annotated, Any, Literal\n\nfrom pydantic import {pydantic_imports}\n"
-            if name == "mcu_protocol":
+            generated_body = "\n\n".join(class_blocks)
+            if "validate_schema_instance(" in generated_body:
                 python_code += "from workbench.kernel.schema_compiler import validate_schema_instance\n"
+            if name == "mcu_protocol":
                 python_code += f"\n\nMCU_PROTOCOL_SCHEMA = {schema!r}\n"
-            python_code += "\n\n" + "\n\n".join(class_blocks)
+            python_code += "\n\n" + generated_body
             typescript_body = "\n".join(typescript_fields)
             metadata = {
                 "fields": constraint_metadata,

--- a/services/agent_runtime/workbench_agent_runtime/tool_registry.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_registry.py
@@ -21,7 +21,7 @@ from . import tool_schemas as _schemas
 # public types
 # ---------------------------------------------------------------------------
 
-_TARGET_REQUIRED_ACTIONS: frozenset[ActionType] = frozenset({ActionType.GRASP, ActionType.PLACE})
+_TARGET_REQUIRED_ACTIONS: frozenset[ActionType] = frozenset({ActionType.GRASP, ActionType.PLACE, ActionType.NAVIGATE})
 _SCHEMA_KEYS: frozenset[str] = frozenset(
     {
         "description",
@@ -75,7 +75,7 @@ class ValidationResult:
 
 
 class ToolRegistry:
-    """Register and validate the six bounded semantic-action tools.
+    """Register and validate the seven bounded semantic-action tools.
 
     Validation layers, applied in order:
 

--- a/services/agent_runtime/workbench_agent_runtime/tool_schemas.py
+++ b/services/agent_runtime/workbench_agent_runtime/tool_schemas.py
@@ -1,4 +1,4 @@
-"""Parameter schemas for the six semantic-action tools.
+"""Parameter schemas for the seven semantic-action tools.
 
 Each tool is defined by its ActionType, a set of required and optional parameter
 keys, and the expected Python type for each parameter value.  The schemas here
@@ -110,6 +110,15 @@ TOOL_SCHEMAS: dict[ActionType, dict[str, object]] = {
             "emotion_state": {"non_blank": True},
             "duration_ms": {"minimum": 1, "maximum": 600000},
         },
+        "relational_constraints": frozenset[str](),
+    },
+    ActionType.NAVIGATE: {
+        "description": "Navigate to a configured waypoint; the executor resolves target_id.",
+        "target_id_required": True,
+        "required_params": frozenset[str](),
+        "optional_params": frozenset[str](),
+        "param_types": {},
+        "param_constraints": {},
         "relational_constraints": frozenset[str](),
     },
     ActionType.STOP: {

--- a/tests/unit/test_contract_navigate.py
+++ b/tests/unit/test_contract_navigate.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [
+    str(ROOT / "libs/contracts"),
+    str(ROOT / "services/agent_runtime"),
+]
+
+from workbench_agent_runtime.policy_validator import PolicyValidator
+from workbench_agent_runtime.tool_registry import ToolRegistry
+from workbench_contracts import (
+    ActionOutcome,
+    ActionResult,
+    ActionType,
+    DeviceState,
+    DispatchState,
+    SemanticAction,
+    TaskGraph,
+    TaskStep,
+)
+
+SCHEMA = json.loads((ROOT / "interfaces/json_schema/semantic_action.schema.json").read_text(encoding="utf-8"))
+
+
+def navigate_payload(**updates: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "action_id": "act-navigate-home",
+        "action_type": "navigate",
+        "target_id": "workbench_home",
+        "parameters": {},
+    }
+    payload.update(updates)
+    return payload
+
+
+def navigate_action(**updates: object) -> SemanticAction:
+    payload = navigate_payload(**updates)
+    return SemanticAction(
+        action_id=payload["action_id"],
+        action_type=ActionType.NAVIGATE,
+        target_id=payload.get("target_id"),
+        parameters=payload.get("parameters", {}),
+    )
+
+
+def action_graph(action: SemanticAction) -> TaskGraph:
+    return TaskGraph(
+        task_id="task-navigate",
+        goal="navigate to the configured waypoint",
+        steps=[TaskStep(step_id="navigate", action=action)],
+        planner="test",
+        model_route="template",
+    )
+
+
+def test_navigate_example_is_valid_against_schema_and_model() -> None:
+    example_path = ROOT / "interfaces/examples/semantic-action-navigate.json"
+    raw = example_path.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+
+    assert list(Draft202012Validator(SCHEMA).iter_errors(payload)) == []
+
+    action = SemanticAction.model_validate_json(raw)
+
+    assert action.action_type is ActionType.NAVIGATE
+    assert action.target_id == "workbench_home"
+    assert action.parameters == {}
+    assert SemanticAction.model_validate_json(action.model_dump_json()) == action
+
+
+def test_generated_model_schema_exposes_the_same_navigate_boundary() -> None:
+    generated_schema = SemanticAction.model_json_schema()
+
+    assert list(Draft202012Validator(generated_schema).iter_errors(navigate_payload())) == []
+    assert list(
+        Draft202012Validator(generated_schema).iter_errors(
+            navigate_payload(parameters={"pose": {"x": 1.0, "y": 2.0, "z": 0.0}})
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"target_id": None},
+        {"target_id": ""},
+        {"target_id": "   "},
+        {"parameters": {"waypoint": "other"}},
+        {"parameters": {"x": 1.0, "y": 2.0}},
+        {"parameters": {"velocity": 0.1}},
+    ],
+    ids=["missing-target", "empty-target", "blank-target", "selector", "coordinates", "velocity"],
+)
+def test_pydantic_rejects_invalid_navigate_boundary(updates: dict[str, object]) -> None:
+    payload = navigate_payload(**updates)
+
+    with pytest.raises(ValidationError):
+        SemanticAction.model_validate(payload)
+
+    with pytest.raises(ValidationError):
+        SemanticAction.model_validate_json(json.dumps(payload))
+
+
+def test_pydantic_rejects_unknown_top_level_navigate_fields() -> None:
+    payload = navigate_payload(unexpected="value")
+
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        SemanticAction.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        navigate_payload(target_id=None),
+        navigate_payload(target_id=""),
+        navigate_payload(target_id="   "),
+        navigate_payload(parameters={"pose": {"frame_id": "map"}}),
+        navigate_payload(parameters={"speed_profile": "slow"}),
+        navigate_payload(unexpected="value"),
+    ],
+    ids=["missing-target", "empty-target", "blank-target", "pose", "free-selector", "extra-field"],
+)
+def test_json_schema_rejects_invalid_navigate_boundary(payload: dict[str, object]) -> None:
+    assert list(Draft202012Validator(SCHEMA).iter_errors(payload))
+
+
+def test_legacy_place_example_remains_compatible() -> None:
+    example_path = ROOT / "interfaces/examples/semantic-action-place.json"
+    raw = example_path.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+
+    assert list(Draft202012Validator(SCHEMA).iter_errors(payload)) == []
+    assert SemanticAction.model_validate_json(raw).action_type is ActionType.PLACE
+
+
+def test_registry_and_policy_consume_navigate_from_the_single_allow_list() -> None:
+    action = navigate_action()
+    registry = ToolRegistry()
+
+    result = registry.validate(action)
+    report = PolicyValidator(
+        registry=registry,
+        policy_config={"policy_version": "navigate-policy-v1", "high_impact_actions": frozenset()},
+    ).check(action_graph(action))
+
+    assert result.is_valid, result.errors
+    assert ActionType.NAVIGATE in registry.list_all()
+    assert report.is_valid
+    assert report.decisions[0].reason_code.value == "policy_allowed"
+
+
+def test_policy_can_require_confirmation_for_navigate_without_affecting_stop() -> None:
+    action = navigate_action(action_id="act-navigate-confirmed")
+    validator = PolicyValidator(
+        policy_config={
+            "policy_version": "navigate-policy-v1",
+            "high_impact_actions": frozenset({ActionType.NAVIGATE}),
+        }
+    )
+
+    required = validator.check(action_graph(action))
+    confirmed = validator.check(
+        action_graph(action),
+        confirmed_action_ids=frozenset({action.action_id}),
+    )
+
+    assert not required.is_valid
+    assert required.decisions[0].reason_code.value == "action_confirmation_required"
+    assert confirmed.is_valid
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"target_id": None},
+        {"target_id": "   "},
+    ],
+    ids=["missing-target", "blank-target"],
+)
+def test_registry_rejects_malformed_navigate_constructed_at_a_lower_boundary(updates: dict[str, object]) -> None:
+    payload = navigate_payload(**updates)
+    malformed = SemanticAction.model_construct(
+        action_id=payload["action_id"],
+        action_type=ActionType.NAVIGATE,
+        target_id=payload["target_id"],
+        parameters={},
+    )
+
+    result = ToolRegistry().validate(malformed)
+
+    assert not result.is_valid
+    assert any(error.field == "target_id" for error in result.errors)
+
+
+def test_registry_rejects_raw_navigation_payload_even_if_model_validation_was_bypassed() -> None:
+    malformed = SemanticAction.model_construct(
+        action_id="act-navigate-raw",
+        action_type=ActionType.NAVIGATE,
+        target_id="workbench_home",
+        parameters={"map": "map.yaml", "x": 1.0, "y": 2.0},
+    )
+
+    result = ToolRegistry().validate(malformed)
+
+    assert not result.is_valid
+    assert any("forbidden keys" in error.message for error in result.errors)
+
+
+def test_stop_remains_a_separate_registered_action() -> None:
+    registry = ToolRegistry()
+
+    stop = SemanticAction(action_id="act-stop", action_type=ActionType.STOP)
+
+    assert ActionType.STOP in registry.list_all()
+    assert registry.validate(stop).is_valid
+
+
+def test_completed_navigation_result_has_no_observation_or_verification_claim() -> None:
+    result = ActionResult(
+        result_id="result-navigate-home",
+        action_id="act-navigate-home",
+        run_id="run-navigate",
+        outcome=ActionOutcome.COMPLETED,
+        dispatch_state=DispatchState.SENT,
+        device_state=DeviceState.CONFIRMED,
+        started_at="2026-09-03T00:00:00Z",
+        ended_at="2026-09-03T00:00:01Z",
+    )
+
+    assert result.entity_id is None
+    assert result.resulting_location is None
+    assert result.outcome is ActionOutcome.COMPLETED

--- a/tests/unit/test_execution_controller.py
+++ b/tests/unit/test_execution_controller.py
@@ -454,6 +454,71 @@ def test_adapter_exceptions_become_typed_terminal_records(
     assert report.records[1].transitions == (ExecutionState.PENDING,)
 
 
+def test_unknown_navigate_waypoint_is_an_explicit_adapter_failure() -> None:
+    graph = _graph(
+        _action(
+            "act-navigate-unknown",
+            ActionType.NAVIGATE,
+            target_id="not-configured",
+        )
+    )
+    unknown_waypoint = ActionResult(
+        result_id="result-navigate-unknown",
+        action_id="act-navigate-unknown",
+        run_id="run-controller-test",
+        outcome=ActionOutcome.FAILED,
+        dispatch_state=DispatchState.SENT,
+        device_state=DeviceState.REJECTED,
+        error_reason="unknown_waypoint",
+        started_at="2026-09-03T00:00:00Z",
+        ended_at="2026-09-03T00:00:01Z",
+    )
+    adapter = FakeAdapter({"act-navigate-unknown": unknown_waypoint})
+
+    report = _controller(adapter).execute(graph)
+
+    assert report.terminal_state is ExecutionState.FAILED
+    assert report.reason_code is ExecutionReasonCode.ACTION_FAILED
+    assert adapter.calls == ["act-navigate-unknown"]
+    assert adapter.action_payloads == [
+        {
+            "action_id": "act-navigate-unknown",
+            "action_type": "navigate",
+            "target_id": "not-configured",
+            "parameters": {},
+        }
+    ]
+    assert report.records[0].result is not None
+    assert report.records[0].result.error_reason == "unknown_waypoint"
+
+
+def test_navigate_does_not_change_independent_stop_preemption() -> None:
+    graph = _graph(
+        _action("act-navigate", ActionType.NAVIGATE, target_id="workbench_home"),
+        _action("act-after-navigate"),
+    )
+    stop_action = _action("act-stop", ActionType.STOP)
+    controller: ExecutionController
+
+    def request_stop_after_navigate(action: SemanticAction) -> None:
+        if action.action_id == "act-navigate":
+            assert controller.request_stop(stop_action) is StopRequestStatus.ACCEPTED
+
+    adapter = FakeAdapter(
+        {stop_action.action_id: _result(stop_action.action_id)},
+        before_return=request_stop_after_navigate,
+    )
+    controller = _controller(adapter)
+
+    report = controller.execute(graph)
+
+    assert adapter.calls == ["act-navigate", "act-stop"]
+    assert report.terminal_state is ExecutionState.STOPPED
+    assert report.reason_code is ExecutionReasonCode.STOP_DISPATCHED
+    assert report.records[1].transitions == (ExecutionState.PENDING,)
+    assert report.records[-1].action_id == "act-stop"
+
+
 @pytest.mark.parametrize(
     "invalid_result",
     [object(), _result("wrong-action-id")],

--- a/tests/unit/test_kernel_schema_compiler.py
+++ b/tests/unit/test_kernel_schema_compiler.py
@@ -31,6 +31,8 @@ def test_runtime_number_validation_handles_large_integers_and_non_finite_floats(
         {"type": "string", "pattern": "["},
         {"type": "string", "pattern": 123},
         {"type": "array", "minItems": "not-an-integer"},
+        {"type": "string", "minLength": "not-an-integer"},
+        {"type": "object", "maxProperties": -1},
     ],
 )
 def test_runtime_validation_normalizes_malformed_constraints(schema: dict) -> None:
@@ -54,6 +56,16 @@ def test_runtime_validation_supports_finite_recursive_instances() -> None:
     }
 
     validate_schema_instance({"next": {"next": {}}}, {"$ref": "node"}, references=references)
+
+
+def test_runtime_validation_supports_string_and_object_size_constraints() -> None:
+    validate_schema_instance("home", {"type": "string", "minLength": 1})
+    validate_schema_instance({}, {"type": "object", "maxProperties": 0})
+
+    with pytest.raises(SchemaValidationError, match="minLength"):
+        validate_schema_instance("", {"type": "string", "minLength": 1})
+    with pytest.raises(SchemaValidationError, match="maxProperties"):
+        validate_schema_instance({"extra": True}, {"type": "object", "maxProperties": 0})
 
 
 def test_runtime_validation_rejects_reference_cycles_that_do_not_advance_the_instance() -> None:
@@ -162,6 +174,46 @@ def test_generated_models_enforce_repository_constraints(tmp_path: Path) -> None
             entities=[{"entity_id": "x", "entity_type": "block", "belief": "observed", "confidence": 2.0}],
             reduced_at="t",
         )
+
+
+def test_generated_semantic_action_enforces_structural_navigate_constraints(tmp_path: Path) -> None:
+    semantic_action = generated_model(tmp_path, "semantic_action", "SemanticAction")
+
+    assert semantic_action(
+        action_id="act-navigate",
+        action_type="navigate",
+        target_id="workbench_home",
+        parameters={},
+    )
+    assert semantic_action(
+        action_id="act-place",
+        action_type="place",
+        target_id="red_block",
+        parameters={"destination_id": "tray"},
+    )
+
+    invalid_payloads = (
+        {
+            "action_id": "act-navigate",
+            "action_type": "navigate",
+            "target_id": "",
+            "parameters": {},
+        },
+        {
+            "action_id": "act-navigate",
+            "action_type": "navigate",
+            "target_id": "workbench_home",
+            "parameters": {"x": 1.0},
+        },
+        {
+            "action_id": "act-navigate",
+            "action_type": "navigate",
+            "parameters": {},
+        },
+    )
+    for payload in invalid_payloads:
+        with pytest.raises(ValueError):
+            semantic_action(**payload)
 
 
 def test_generated_models_validate_local_references(tmp_path: Path) -> None:

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -72,21 +72,22 @@ class _ChangingSchema(Mapping):
 
 
 class ToolRegistryRegistrationTests(unittest.TestCase):
-    """ToolRegistry knows all six ActionTypes on construction,
+    """ToolRegistry knows all seven ActionTypes on construction,
     supports register()/get(), and rejects invalid or duplicate registrations."""
 
     def setUp(self) -> None:
         self.registry = ToolRegistry()
 
-    def test_all_six_action_types_are_registered(self) -> None:
+    def test_all_seven_action_types_are_registered(self) -> None:
         registered = self.registry.list_all()
-        self.assertEqual(len(registered), 6)
+        self.assertEqual(len(registered), 7)
         self.assertIn(ActionType.OBSERVE, registered)
         self.assertIn(ActionType.GRASP, registered)
         self.assertIn(ActionType.PLACE, registered)
         self.assertIn(ActionType.ASK_CONFIRM, registered)
         self.assertIn(ActionType.EXPRESS, registered)
         self.assertIn(ActionType.STOP, registered)
+        self.assertIn(ActionType.NAVIGATE, registered)
 
     def test_register_rejects_non_action_type(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Related Issue

Partially addresses #162.

## What changed

- Add `navigate` to the versioned `ActionType` vocabulary and public `SemanticAction` JSON Schema.
- Require a non-empty opaque configured waypoint `target_id`; keep the `navigate` parameter object closed and empty.
- Reject coordinates, poses, TF data, wheel or velocity controls, acceleration, joints, and free-form planner fields at the contract boundary.
- Register `navigate` in the Agent Runtime Tool Registry and preserve independent STOP registration and preemption behavior.
- Extend the repository Schema Compiler with `minLength`, `maxProperties`, and structural conditional validation so generated models enforce the same boundary.
- Add a versioned example, Issue #162 Task Packet, and focused contract, registry, policy, compiler, and execution-controller regressions.

## Interfaces affected

- `interfaces/json_schema/semantic_action.schema.json`
- `interfaces/examples/semantic-action-navigate.json`
- `libs/contracts/workbench_contracts/models.py`
- `services/agent_runtime/workbench_agent_runtime/tool_schemas.py`
- `services/agent_runtime/workbench_agent_runtime/tool_registry.py`
- No changes to `services/world_model/`, `robot/control/`, `firmware/`, Nav2, mapping, planners, or MCU Wire V1 behavior.
- This public interface change requires independent Runtime, World Model, and Integration owner approval before merge.

## Tests and commands

- Task Packet validation against `origin/main` (`a4cd4ac`) and head `30598ee`: passed.
- Focused contract, registry, policy, and execution-controller tests: `205 passed`.
- Schema Compiler tests: `24 passed`.
- Integration and Agent Runtime tests: `19 passed`.
- `make contract`: passed.
- `make scenario-check`: passed (`12` frozen and `24` expanded manifests).
- `make context-check`: passed.
- `make golden-check`: passed (`50` tasks across `5` families and `26` dangerous requests).
- Ruff check and format check: passed (`372` files).
- `git diff --check`: passed.
- Full `make test`: `1073 passed, 1 skipped, 6 failed`; the six failures are local environment errors caused by read-only writes to existing hardware report paths under `hardware/procurement`, `hardware/qa`, `hardware/validation`, `hardware/release`, and `hardware/power`. No Issue #162 test failed.

## Evidence

- The contract and consumer tests prove valid waypoint navigation is forwarded without inventing coordinates, unknown waypoint resolution remains an explicit adapter failure, and STOP remains independently dispatchable.
- A completed navigation `ActionResult` represents adapter execution evidence only; it does not assert an observed or verified World Model location.
- Evidence is limited to Python/software and contract validation. No Nav2 run, map validation, physical navigation, actuator, or hard-real-time claim is made.

## Risks and rollback

- This change does not provide a waypoint catalog or navigation adapter; deployment configuration and unknown-waypoint failure remain executor-owned.
- The zero-parameter shape intentionally leaves future policy selectors for a separately reviewed contract change.
- Revert commit `30598ee7147474d7ee1c766f48eee86d881a6373` to roll back the change; no data migration is required.

## Checklist

- [x] I changed only approved paths; the pre-existing `.gitignore` edit is not included.
- [x] Changed-path tests and contract checks pass, with the local hardware report limitation documented above.
- [x] I covered normal and failure behavior.
- [x] I updated the example and Task Packet for the interface change.
- [x] I did not add secrets, private data or unreviewed assets.
