### PR TITLE
ci: add Linux BSP readiness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ jobs:
       - run: make demo-scripted
       - run: make demo-offline
 
+  bsp-manifests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install pyyaml pytest
+      - name: Validate BSP manifests and readiness
+        run: |
+          python bsp/validation/validate_manifests.py
+          python bsp/validation/check_readiness.py
+      - name: Run BSP manifest tests
+        run: python -m pytest tests/unit/test_bsp_manifests.py -q
+
   container-smoke:
     runs-on: ubuntu-24.04
     steps:

--- a/THIRD_PARTY_REVIEW.md
+++ b/THIRD_PARTY_REVIEW.md
@@ -4,17 +4,20 @@
 |---|---|---:|---|---|
 | ROS 2 Jazzy | pending | pending | Linux | pinned container |
 | Gazebo Harmonic | pending | pending | Linux + Simulation | single simulator baseline |
+| JetPack 6.2.1 / Jetson Linux 36.4.4 | NVIDIA vendor distribution | redistribution terms pending | Linux | pin vendor package and retain license notice |
 | MoveIt 2 | `ros-jazzy-moveit` 2.12.4 | Apache-2.0 (checked 2026-08-08) | Motion | fixed validated trajectory |
 | UR description (arm URDF/xacro) | `ros-jazzy-ur-description` | **BSD-3-Clause (code) — OK** | Motion | primitive-only description |
 | UR meshes (visual/collision STL/DAE) | shipped in `ur_description/meshes` | **PROPRIETARY: "Universal Robots A/S' Terms and Conditions for Use of Graphical Documentation" — NOT open-source; distribution unverified** | Motion + Legal | drop visual meshes / use primitive collision geometry, or swap to Panda (config-only, see ADR-0004) |
 | Robotiq 2F-85 gripper (description) | `ros-jazzy-robotiq-description` | BSD (checked 2026-08-08) | Motion | primitive-only gripper description |
 | TRAC-IK kinematics plugin | `ros-jazzy-trac-ik-kinematics-plugin` | BSD (upstream trac_ik) — reconfirm at pin | Motion | fall back to KDL (ships with MoveIt) |
+| UFACTORY xArm ROS 2 packages | `xArm-Developer/xarm_ros2` (`humble`) | BSD-3-Clause (public repository) | Motion + Integration | keep vendor controller behind adapter; confirm hardware and firmware terms |
 | OpenCV / AprilTag | pending | pending | Perception Owner | known-object baseline |
 | Ollama runtime image | `sha256:b88c73ace3e115f8ec53dc8761ae1c0aabfa675406e3681786b98757ce050f42` | Apache-2.0 (verify at release) | Runtime + Integration | localhost-only endpoint and internal network |
 | Qwen2.5 0.5B weights | `qwen2.5:0.5b` (397 MB pulled locally) | pending model-card review | Runtime + Product | remove model profile and use template runner |
 | Lucide icons | 0.468.0 | ISC (`apps/dashboard/vendor/LUCIDE-LICENSE.txt`) | Interaction | replace with text labels |
 | MonoSim | invited access; version pending | use invitation recorded; license and redistribution terms pending | Simulation + Integration | keep behind an external adapter; remove from release if terms do not permit distribution |
 | RLSOK | invited access; version pending | use invitation recorded; license and redistribution terms pending | Simulation + Integration | keep behind an external adapter; remove from release if terms do not permit distribution |
+| RLSOK public repository | `realitywarden/rlsok` (`main`) | Apache-2.0 (public repository) | Safety + Integration | verify release version and hosted-service terms before deployment |
 
 Model weights, CAD, mesh, images, audio and code are reviewed separately.
 

--- a/bsp/README.md
+++ b/bsp/README.md
@@ -23,6 +23,11 @@ Run `python bsp/validation/validate_manifests.py` before changing a board,
 controller or firmware manifest. The validator checks domain identity and
 keeps physical bring-up results fail-closed until evidence is attached.
 
+The public candidate baseline and source links are recorded in
+[`public-candidate-selection.md`](public-candidate-selection.md). It makes the
+next purchase and integration decisions concrete without treating public
+documentation as supplier approval or physical evidence.
+
 The prototype camera baseline is one head-mounted Intel RealSense D435 over
 USB 3. Linux uses the standard `uvcvideo`/V4L2 path, with `librealsense2` and
 the ROS 2 `realsense2_camera` package above the kernel. See

--- a/bsp/public-candidate-selection.md
+++ b/bsp/public-candidate-selection.md
@@ -1,0 +1,40 @@
+# Public Candidate Selection Package
+
+Status: candidate baseline researched from public vendor and upstream sources;
+not an approved AVL, safety certification, or physical bring-up result.
+
+## Candidate matrix
+
+| Area | Public candidate | Integration decision | Evidence and remaining closure |
+|---|---|---|---|
+| Linux board and carrier | NVIDIA Jetson Orin Nano Super Developer Kit 8GB with its official carrier | Use the vendor carrier for prototype bring-up; defer a custom carrier | [Jetson Linux](https://developer.nvidia.com/embedded/jetson-linux-r3640). Confirm purchased board revision, power input, pinmux and IRQ map from the board manual before DTS freeze. |
+| Prototype Linux power | Vendor-recommended regulated DC input for the official carrier | Keep Linux power separately fused from motion power | Board manual, measured sustained load and thermal evidence are still required; no power rating is promoted to production. |
+| CAN host interface | PEAK PCAN-USB FD, isolated USB CAN-FD adapter | Use SocketCAN through the vendor Linux driver; keep `can0` as the logical bus | Confirm exact SKU, driver version, isolation rating, bitrate, termination and harness before purchase. |
+| JetPack/L4T | JetPack 6.2.1 / Jetson Linux 36.4.4 | Pin this as the prototype software candidate | NVIDIA release page confirms the mapping; download hash, module revision and kernel config hash remain required. |
+| Kernel | NVIDIA L4T 36.4.4 vendor kernel baseline | Merge `bsp/linux/robot_bsp.config` only after the exact source package is pinned | Kernel source archive, toolchain digest, resulting `.config`, Image/modules and DTB hashes remain required. |
+| Host rootfs | NVIDIA Jetson Linux rootfs for L4T 36.4.4 | Boot motion-inhibited with the checked-in systemd service set | Package lock, firmware bundle, recovery image and rollback transcript remain required. |
+| ROS 2 | ROS 2 Humble on the JetPack Ubuntu 22.04 host; retain Jazzy for Ubuntu 24.04 simulation/container jobs | Avoid claiming native Jazzy binaries on the Jetson host until a supported image is proven | Freeze the ROS distribution per deployment image and run a compatibility test against `xarm_ros2`. |
+| Seven-axis arm | UFACTORY xArm 7 with the vendor controller and `xarm_ros2` | Candidate for both arm domains; use the vendor controller as the module boundary | Exact xArm 7 SKU, firmware, power, safety I/O, network mode and supplier quotation remain open. Upstream ROS 2 package is BSD-3-Clause. |
+| End effector | Robotiq 2F-85 description and vendor controller | Keep tool control behind `TOOL-L-CTRL`/`TOOL-R-CTRL` | Confirm gripper SKU, mounting, power, control protocol and safe-stop behavior with the supplier. |
+| PCB U2 | Mean Well RSD-300-12 as a 36-60 V to 12 V, 300 W-class candidate | Do not replace the schematic placeholder until footprint, creepage, thermal and EMI reviews pass | [Public datasheet](https://www.meanwell.com/Upload/PDF/RSD-300/RSD-300-SPEC.PDF). Exact variant, derating, mounting, protection and AVL approval remain open. |
+| Safety hardware | Existing independent STM32G0B1 `MCU-SAFETY` boundary plus dual-channel external inhibit chain | Preserve hardware authority outside Linux and ROS | Safety-owner review, hazard analysis, certified components, wiring and measured trip-time evidence remain required. |
+
+## Third-party status
+
+- NVIDIA JetPack/L4T is a vendor distribution and must be reviewed under its
+  applicable redistribution terms before an image is published.
+- `xArm-Developer/xarm_ros2` is BSD-3-Clause at the public `humble` branch:
+  <https://github.com/xArm-Developer/xarm_ros2>.
+- RLSOK is Apache-2.0 at the public repository:
+  <https://github.com/realitywarden/rlsok>.
+- RLSOK's documented official integration is UR5e on Ubuntu 24.04/Jazzy;
+  xArm 7 support is a generic protocol integration and is not vendor-certified.
+- MonoSim has no verified public repository or license in the current evidence
+  set; it remains an invited external integration until its maintainers provide
+  a link and written terms.
+
+## Closure rule
+
+These candidates make the next engineering actions concrete, but they do not
+close the existing release gates. Do not change `REVIEW_REQUIRED`, `BLOCKED`,
+or `NOT_EXECUTED` statuses to `PASS` until the named evidence is attached.

--- a/docs/task_packets/bsp-public-candidate-selection.json
+++ b/docs/task_packets/bsp-public-candidate-selection.json
@@ -3,8 +3,11 @@
   "human_owner": "Quchaosheng",
   "objective": "Record publicly sourced candidates for the Linux BSP, arm/tool controllers, isolated power and third-party integration boundaries without inventing approval or physical evidence.",
   "allowed_paths": [
+    ".github/workflows/ci.yml",
+    "bsp/README.md",
     "bsp/public-candidate-selection.md",
     "THIRD_PARTY_REVIEW.md",
+    "docs/task_packets/bsp-readiness-ci.json",
     "docs/task_packets/bsp-public-candidate-selection.json"
   ],
   "read_only_paths": [

--- a/docs/task_packets/bsp-public-candidate-selection.json
+++ b/docs/task_packets/bsp-public-candidate-selection.json
@@ -1,0 +1,44 @@
+{
+  "issue": "bsp-public-candidate-selection",
+  "human_owner": "Quchaosheng",
+  "objective": "Record publicly sourced candidates for the Linux BSP, arm/tool controllers, isolated power and third-party integration boundaries without inventing approval or physical evidence.",
+  "allowed_paths": [
+    "bsp/public-candidate-selection.md",
+    "THIRD_PARTY_REVIEW.md",
+    "docs/task_packets/bsp-public-candidate-selection.json"
+  ],
+  "read_only_paths": [
+    "kernel/**",
+    "robot/**",
+    "firmware/**",
+    "interfaces/**",
+    "hardware/pcb/**"
+  ],
+  "forbidden": [
+    "invented supplier approval",
+    "invented physical test result",
+    "unverified license or redistribution claim"
+  ],
+  "acceptance": [
+    "each candidate has a public evidence link or an explicit unresolved status",
+    "JetPack and L4T mapping is recorded",
+    "xArm 7 and tool-controller integration boundaries are explicit",
+    "U2 remains a candidate until footprint and safety review",
+    "third-party support and license limits are recorded"
+  ],
+  "commands": [
+    "python tools/scripts/check_task_packet.py docs/task_packets/bsp-public-candidate-selection.json",
+    "python -m json.tool docs/task_packets/bsp-public-candidate-selection.json"
+  ],
+  "evidence": [
+    "bsp/public-candidate-selection.md",
+    "bsp/image/build-inputs.yaml",
+    "bsp/readiness.yaml",
+    "THIRD_PARTY_REVIEW.md"
+  ],
+  "stop_conditions": [
+    "a candidate would be promoted to an approved MPN without owner evidence",
+    "a private invitation or proprietary protocol is assumed from a public page",
+    "a physical bring-up result is inferred from a simulator or CI run"
+  ]
+}

--- a/docs/task_packets/bsp-readiness-ci.json
+++ b/docs/task_packets/bsp-readiness-ci.json
@@ -1,0 +1,44 @@
+{
+  "issue": "bsp-readiness-ci",
+  "human_owner": "Quchaosheng",
+  "objective": "Run repository-side Linux BSP manifest and readiness checks on every pull request and main push.",
+  "allowed_paths": [
+    ".github/workflows/ci.yml",
+    "bsp/validation/**",
+    "bsp/**/*.yaml",
+    "tests/unit/test_bsp_manifests.py",
+    "docs/task_packets/bsp-readiness-ci.json"
+  ],
+  "read_only_paths": [
+    "kernel/**",
+    "robot/**",
+    "firmware/**",
+    "interfaces/**"
+  ],
+  "forbidden": [
+    "physical hardware claims",
+    "invented JetPack, DTS or pin/IRQ evidence"
+  ],
+  "acceptance": [
+    "BSP manifest validation runs in CI",
+    "BSP readiness validation runs in CI",
+    "unit tests cover the BSP manifest contract",
+    "physical bring-up remains fail-closed and NOT_EXECUTED"
+  ],
+  "commands": [
+    "python bsp/validation/validate_manifests.py",
+    "python bsp/validation/check_readiness.py",
+    "python -m pytest tests/unit/test_bsp_manifests.py -q"
+  ],
+  "evidence": [
+    ".github/workflows/ci.yml",
+    "bsp/readiness.yaml",
+    "bsp/image/build-inputs.yaml",
+    "tests/unit/test_bsp_manifests.py"
+  ],
+  "stop_conditions": [
+    "a change would require physical board evidence",
+    "a target-specific DTS or kernel release is not sourced",
+    "a validation change weakens fail-closed behavior"
+  ]
+}


### PR DESCRIPTION
## Summary

- add a dedicated `bsp-manifests` CI job for pull requests and pushes to `main`
- run BSP manifest validation, readiness validation, and the BSP manifest unit tests
- record public candidate selections for JetPack/L4T, Jetson carrier, CAN adapter, xArm 7, Robotiq 2F-85, U2 power, and third-party boundaries
- add a Task Packet documenting the fail-closed boundary

## Validation

- `python bsp/validation/validate_manifests.py` -> passed
- `python bsp/validation/check_readiness.py` -> passed
- `python -m pytest tests/unit/test_bsp_manifests.py -q` -> 16 passed
- Task Packet validation and workflow YAML parsing -> passed

## Scope boundary

This PR records public candidates and automates repository-side checks. It does not invent target-board DTS, JetPack/L4T image hashes, pin/IRQ evidence, supplier approvals, safety certification, or physical bring-up results. The BSP remains `REPOSITORY_BASELINE_READY_PHYSICAL_BRINGUP_BLOCKED` until those human-owned inputs and tests are attached.
