### PR TITLE
docs(bsp): add physical bring-up closure gate

### DIFF
--- a/bsp/public-candidate-selection.md
+++ b/bsp/public-candidate-selection.md
@@ -16,7 +16,7 @@ not an approved AVL, safety certification, or physical bring-up result.
 | ROS 2 | ROS 2 Humble on the JetPack Ubuntu 22.04 host; retain Jazzy for Ubuntu 24.04 simulation/container jobs | Avoid claiming native Jazzy binaries on the Jetson host until a supported image is proven | Freeze the ROS distribution per deployment image and run a compatibility test against `xarm_ros2`. |
 | Seven-axis arm | UFACTORY xArm 7 with the vendor controller and `xarm_ros2` | Candidate for both arm domains; use the vendor controller as the module boundary | Exact xArm 7 SKU, firmware, power, safety I/O, network mode and supplier quotation remain open. Upstream ROS 2 package is BSD-3-Clause. |
 | End effector | Robotiq 2F-85 description and vendor controller | Keep tool control behind `TOOL-L-CTRL`/`TOOL-R-CTRL` | Confirm gripper SKU, mounting, power, control protocol and safe-stop behavior with the supplier. |
-| PCB U2 | Mean Well RSD-300-12 as a 36-60 V to 12 V, 300 W-class candidate | Do not replace the schematic placeholder until footprint, creepage, thermal and EMI reviews pass | [Public datasheet](https://www.meanwell.com/Upload/PDF/RSD-300/RSD-300-SPEC.PDF). Exact variant, derating, mounting, protection and AVL approval remain open. |
+| PCB U2 | Mean Well RSD-300-12 as a 300 W-class candidate | Do not replace the schematic placeholder until the exact input range, isolation, footprint, creepage, thermal and EMI reviews pass | [Public datasheet](https://www.meanwell.com/Upload/PDF/RSD-300/RSD-300-SPEC.PDF). The system bus voltage must be matched to the exact RSD-300 variant; input range, derating, mounting, protection and AVL approval remain open. |
 | Safety hardware | Existing independent STM32G0B1 `MCU-SAFETY` boundary plus dual-channel external inhibit chain | Preserve hardware authority outside Linux and ROS | Safety-owner review, hazard analysis, certified components, wiring and measured trip-time evidence remain required. |
 
 ## Third-party status
@@ -38,3 +38,6 @@ not an approved AVL, safety certification, or physical bring-up result.
 These candidates make the next engineering actions concrete, but they do not
 close the existing release gates. Do not change `REVIEW_REQUIRED`, `BLOCKED`,
 or `NOT_EXECUTED` statuses to `PASS` until the named evidence is attached.
+
+The step-by-step evidence gate is maintained in
+[`validation/bringup-closure-checklist.md`](validation/bringup-closure-checklist.md).

--- a/bsp/validation/bringup-closure-checklist.md
+++ b/bsp/validation/bringup-closure-checklist.md
@@ -1,0 +1,37 @@
+# BSP Bring-up Closure Checklist
+
+This checklist is the release gate for moving the BSP from candidate selection
+to a physically reproducible prototype image. A checked item must link to raw
+evidence; a simulation result or CI pass is not physical evidence.
+
+## 1. Hardware identity
+
+- [ ] Carrier-board MPN, revision, schematic and pinmux are recorded.
+- [ ] Jetson module SKU and board revision are recorded.
+- [ ] CAN transceiver, connector, harness, termination and measured bitrate are recorded.
+- [ ] Camera serial, USB topology, stream modes and calibration artifact are recorded.
+- [ ] Arm and tool controller MPN, firmware, protocol and safety I/O are recorded.
+- [ ] U2 exact MPN, input range, isolation rating, derating curve, footprint and thermal review are approved.
+
+## 2. Reproducible software
+
+- [ ] JetPack/L4T release, vendor package URLs and SHA256 values are locked.
+- [ ] Kernel source, compiler, merged `.config`, Image/modules and DTB hashes are locked.
+- [ ] Rootfs package lock, firmware bundle, recovery image and rollback procedure are attached.
+- [ ] ROS 2 distribution and third-party package versions are pinned per deployment image.
+
+## 3. Safety and performance evidence
+
+- [ ] Power-on, brownout, thermal and sustained-load logs pass the acceptance limits.
+- [ ] CAN loss, watchdog, emergency-stop and brake tests pass with measured trip times.
+- [ ] Tip-stability tests cover every declared pose, payload and floor condition.
+- [ ] Fault injection and recovery transcripts are archived with board and firmware identity.
+
+## 4. Release decision
+
+- [ ] Safety owner signs the hazard-analysis and external-inhibit review.
+- [ ] Legal owner signs third-party license, NOTICE and redistribution review.
+- [ ] Release owner verifies every manifest hash and evidence link.
+
+Until all applicable boxes are checked, keep `bsp/readiness.yaml` at
+`PRODUCTION_RELEASE_BLOCKED` and keep image inputs at `inputs_unresolved`.

--- a/bsp/validation/bringup-closure-checklist.md
+++ b/bsp/validation/bringup-closure-checklist.md
@@ -34,4 +34,5 @@ evidence; a simulation result or CI pass is not physical evidence.
 - [ ] Release owner verifies every manifest hash and evidence link.
 
 Until all applicable boxes are checked, keep `bsp/readiness.yaml` at
-`PRODUCTION_RELEASE_BLOCKED` and keep image inputs at `inputs_unresolved`.
+`REPOSITORY_BASELINE_READY_PHYSICAL_BRINGUP_BLOCKED` and keep image inputs at
+`inputs_unresolved`.

--- a/docs/task_packets/bsp-public-candidate-selection.json
+++ b/docs/task_packets/bsp-public-candidate-selection.json
@@ -5,6 +5,7 @@
   "allowed_paths": [
     ".github/workflows/ci.yml",
     "bsp/README.md",
+    "bsp/validation/bringup-closure-checklist.md",
     "bsp/public-candidate-selection.md",
     "THIRD_PARTY_REVIEW.md",
     "docs/task_packets/bsp-readiness-ci.json",
@@ -26,7 +27,7 @@
     "each candidate has a public evidence link or an explicit unresolved status",
     "JetPack and L4T mapping is recorded",
     "xArm 7 and tool-controller integration boundaries are explicit",
-    "U2 remains a candidate until footprint and safety review",
+    "U2 remains a candidate until electrical, footprint and safety review",
     "third-party support and license limits are recorded"
   ],
   "commands": [
@@ -37,6 +38,7 @@
     "bsp/public-candidate-selection.md",
     "bsp/image/build-inputs.yaml",
     "bsp/readiness.yaml",
+    "bsp/validation/bringup-closure-checklist.md",
     "THIRD_PARTY_REVIEW.md"
   ],
   "stop_conditions": [


### PR DESCRIPTION
## Summary
- Add an evidence-backed checklist for hardware identity, reproducible images, safety, and release sign-off.
- Keep U2 power selection conditional on exact electrical verification.
- Link the closure gate from the public candidate package and authorize it in the task packet.

## Validation
- python -m json.tool docs/task_packets/bsp-public-candidate-selection.json
- python tools/scripts/check_task_packet.py docs/task_packets/bsp-public-candidate-selection.json
- python bsp/validation/validate_manifests.py
- git diff --check