### PR TITLE
docs(contract): include navigate in partner handoff

### DIFF
--- a/docs/product/design-partner-handoff.md
+++ b/docs/product/design-partner-handoff.md
@@ -26,10 +26,9 @@ physical or safety claim remains `insufficient_evidence`, `not_executed`, or
 ## 2. Semantic action contract
 
 The Scenario layer describes a user task. It does not describe how a
-controller should move. Until a separately approved versioned contract adds
-more actions, the current public semantic action set is:
+controller should move. The current public semantic action set is:
 
-`observe`, `grasp`, `place`, `ask_confirm`, `express`, and `stop`.
+`observe`, `grasp`, `place`, `ask_confirm`, `express`, `stop`, and `navigate`.
 
 A scenario may refer to an action only when that action is registered and
 version-compatible. It may provide:

--- a/docs/task_packets/issue-318-design-partner-handoff.json
+++ b/docs/task_packets/issue-318-design-partner-handoff.json
@@ -67,6 +67,7 @@
   ],
   "acceptance": [
     "The handoff document provides the required conclusion vocabulary: continue, change, defer, and reject, and makes the decision apply to a named claim and evidence class.",
+    "The documented public semantic action vocabulary includes navigate when the versioned contract registers it, alongside the existing bounded actions.",
     "Scenario manifests may declare only versioned semantic actions, opaque targets, bounded typed policy selectors, adapter capability references, goals, evidence policy, and bounded recovery references; raw joint, Cartesian, velocity, torque, force, CAN, controller, pin, credential, or E-stop fields are explicitly forbidden.",
     "The Motion handoff describes the existing ActionResult boundary, correlation, dispatch/device state, health/fault diagnostics, and evidence references, and explicitly says ActionResult completion is not observed WorldState completion.",
     "The checklist gives separate inputs and outputs for Product, Motion, MCU/Safety, Runtime/Integration, and site/partner owners, including consent, version/configuration hashes, preflight, abort, and evidence responsibilities.",


### PR DESCRIPTION
Synchronize the Design Partner handoff vocabulary with the public semantic action schema introduced by PR #334. Add navigate to the documented action set so downstream scenario authors do not reject a valid contract action.