### PR TITLE
feat(linux): add bounded IRQ lifecycle contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 
 .PHONY: bootstrap lint fmt test contract scenario-check golden-check evaluation-check evaluation-scripted context-check \
 	dashboard-test dashboard demo demo-scripted demo-offline demo-model model-provision performance-test benchmark-startup \
-	benchmark-resources performance-regression-test offline-integration uart-spi-test docs task-check check container-smoke \
+	benchmark-resources performance-regression-test offline-integration uart-spi-test irq-test docs task-check check container-smoke \
 	sim sim-doctor sim-list sim-run container-build container-check container-colcon-build container-colcon-test \
 	container-image-verify container-python-test container-sim-check container-mujoco-check container-hardware-doctor \
 	container-gpu-matrix-check container-host-doctor container-dashboard-check container-project-check
@@ -94,6 +94,9 @@ offline-integration:
 
 uart-spi-test:
 	$(PYTHON) -m pytest tests/unit/test_uart_spi_contract.py -v
+
+irq-test:
+	$(PYTHON) -m pytest tests/unit/test_irq_contract.py -v
 
 dashboard:
 	$(PYTHON) -m workbench_backend.server --host 127.0.0.1 --port 8080

--- a/docs/architecture/linux-drivers.md
+++ b/docs/architecture/linux-drivers.md
@@ -99,6 +99,10 @@ LINUX5/LINUX6 的实现必须在硬件资源确认后补充以下内容：
 寄存器/设备树资源和内核版本，再分别实现 CAN、UART/SPI、GPIO、DMA 和 IRQ 模块，
 并沿用本架构的错误回滚、数据所有权和证据要求。
 
+LINUX6 的 IRQ 生命周期和 fake provider 位于 `hardware/linux_drivers/irq/`。它固化
+共享线路、上半部确认、下半部 work、取消/flush 和停止同步测试，但不冻结真实 IRQ
+资源、调度优先级、PREEMPT_RT 或物理 jitter 预算。
+
 LINUX3 的 UART/SPI 软件契约和 fake transport 测试位于仓库的
 `hardware/linux_drivers/uart_spi/`。该契约是 owner-gated 的提案：它固化边界、CRC、
 序号、背压和重试测试，但不冻结物理控制器、pinmux、设备树、DMA 或 IRQ 参数。

--- a/docs/task_packets/linux-irq-contract.json
+++ b/docs/task_packets/linux-irq-contract.json
@@ -1,0 +1,59 @@
+{
+  "issue": "LINUX6",
+  "human_owner": "Quchaosheng",
+  "objective": "Define and test a bounded software IRQ lifecycle with shared-line ownership, top-half acknowledgement, bottom-half work cancellation and fail-closed stop/remove behavior without claiming real IRQ jitter.",
+  "allowed_paths": [
+    "hardware/linux_drivers/irq/**",
+    "tests/unit/test_irq_contract.py",
+    "Makefile",
+    "docs/architecture/linux-drivers.md",
+    "hardware/linux_drivers/README.md",
+    "docs/task_packets/linux-irq-contract.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**"
+  ],
+  "acceptance": [
+    "shared and non-shared IRQ ownership is validated before enable or trigger",
+    "trigger creates bounded bottom-half work while active handler count is observable",
+    "stop waits for active handlers, flushes pending work and fails closed on timeout",
+    "close completes the stop/flush lifecycle before clearing owners",
+    "tests cover shared IRQ routing, queue backpressure, cancellation, timeout and closed state",
+    "the implementation is software-only and does not claim IRQ jitter below 100 microseconds"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/linux-irq-contract.json",
+    "python3 -m pytest tests/unit/test_irq_contract.py -v",
+    "make irq-test",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "focused IRQ lifecycle and cancellation test output",
+    "shared-owner and bottom-half queue assertions",
+    "stop timeout fail-closed assertion",
+    "repository gate output",
+    "physical IRQ and jitter evidence marked NOT_EXECUTED"
+  ],
+  "stop_conditions": [
+    "a real IRQ number, device register or device-tree choice is required",
+    "PREEMPT_RT or physical jitter measurement is required",
+    "a frozen interface, firmware, robot-control or PCB change is required",
+    "fake IRQ evidence would be presented as target-hardware real-time validation"
+  ]
+}

--- a/hardware/linux_drivers/README.md
+++ b/hardware/linux_drivers/README.md
@@ -17,6 +17,10 @@ LINUX3 的软件 UART/SPI 帧契约和 fake transport 位于
 [`uart_spi/README.md`](uart_spi/README.md)。该实现只验证有界编码、CRC、序号、背压、
 重试和错误处理；真实控制器、pinmux、设备树、DMA 和 IRQ 参数仍由硬件负责人确认。
 
+LINUX6 的 IRQ 生命周期和 fake provider 位于
+[`irq/README.md`](irq/README.md)。它只验证共享线路、上半部/下半部、取消、flush 和
+停止同步；真实 IRQ 资源和 jitter 证据仍由硬件 Owner 确认。
+
 ## 分层边界
 
 ```text

--- a/hardware/linux_drivers/irq/README.md
+++ b/hardware/linux_drivers/irq/README.md
@@ -1,0 +1,27 @@
+# IRQ 软件契约
+
+这是 LINUX6 的软件测试边界，不是目标 Linux 内核的真实 IRQ 驱动。它用 fake provider
+验证共享 IRQ、上半部确认、下半部 work、停止/卸载同步和失败关闭语义，不绑定 IRQ
+号码、设备寄存器、优先级策略或 PREEMPT_RT 行为。
+
+## 生命周期
+
+```text
+register owner -> enable -> trigger/top-half -> bottom-half work
+                               |
+                         stop/close -> cancel/flush -> disabled/closed
+```
+
+- 非共享 IRQ 只能注册一个 owner；共享 IRQ 的每个触发必须来自已注册 owner。
+- `trigger` 只确认并排队 work；真正处理由下半部显式执行。
+- work 队列有固定容量，满时失败，不静默丢事件。
+- `stop` 先禁止新触发，再等待活动 handler 结束并清理 pending work。
+- 超过 deadline 的活动 handler 返回 `IRQHandlerTimeout`，provider 保持 STOPPING，
+  不能假装已经完成卸载。
+- `close` 复用 stop/flush 顺序，完成后才清除 owner 并进入 CLOSED。
+
+## 硬件边界
+
+真实驱动仍需硬件 Owner 确认 IRQ 号、共享关系、中断确认/清除寄存器、threaded IRQ
+或 NAPI/workqueue 选择、优先级和设备树资源。fake provider 不能证明 IRQ jitter
+小于 100 微秒、共享中断电气行为或 PREEMPT_RT 实时性。

--- a/hardware/linux_drivers/irq/__init__.py
+++ b/hardware/linux_drivers/irq/__init__.py
@@ -1,0 +1,23 @@
+"""Software-only IRQ lifecycle and cancellation contract."""
+
+from .contract import (
+    FakeIRQProvider,
+    IRQError,
+    IRQHandlerTimeout,
+    IRQLine,
+    IRQNotShared,
+    IRQState,
+    IRQWork,
+    IRQWorkCancelled,
+)
+
+__all__ = [
+    "FakeIRQProvider",
+    "IRQError",
+    "IRQHandlerTimeout",
+    "IRQLine",
+    "IRQNotShared",
+    "IRQState",
+    "IRQWork",
+    "IRQWorkCancelled",
+]

--- a/hardware/linux_drivers/irq/contract.py
+++ b/hardware/linux_drivers/irq/contract.py
@@ -1,0 +1,167 @@
+"""Bounded IRQ/top-half/bottom-half lifecycle model for software tests."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from enum import StrEnum
+from time import monotonic
+
+
+class IRQError(RuntimeError):
+    """Base class for invalid IRQ operations."""
+
+
+class IRQHandlerTimeout(TimeoutError, IRQError):
+    """An active handler or bottom-half did not stop before the deadline."""
+
+
+class IRQNotShared(IRQError):
+    """A shared line was triggered without a registered owner."""
+
+
+class IRQWorkCancelled(IRQError):
+    """Work was cancelled before execution."""
+
+
+class IRQState(StrEnum):
+    DISABLED = "disabled"
+    ENABLED = "enabled"
+    STOPPING = "stopping"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True, slots=True)
+class IRQLine:
+    number: int
+    shared: bool = False
+    priority: int = 0
+
+    def __post_init__(self) -> None:
+        if type(self.number) is not int or self.number < 0:
+            raise IRQError("IRQ number must be a non-negative integer")
+        if type(self.shared) is not bool:
+            raise IRQError("shared must be boolean")
+        if type(self.priority) is not int or not 0 <= self.priority <= 99:
+            raise IRQError("priority must be between 0 and 99")
+
+
+@dataclass(frozen=True, slots=True)
+class IRQWork:
+    sequence: int
+    owner: str
+    line: int
+
+
+class FakeIRQProvider:
+    """Thread-safe IRQ router with explicit top/bottom-half ownership."""
+
+    def __init__(self, line: IRQLine, *, work_capacity: int = 16) -> None:
+        if type(work_capacity) is not int or not 1 <= work_capacity <= 1024:
+            raise IRQError("work_capacity must be between 1 and 1024")
+        self.line = line
+        self.work_capacity = work_capacity
+        self._state = IRQState.DISABLED
+        self._handlers: set[str] = set()
+        self._works: list[IRQWork] = []
+        self._active_work: set[int] = set()
+        self._next_sequence = 0
+        self._lock = threading.RLock()
+        self._active_changed = threading.Condition(self._lock)
+
+    @property
+    def state(self) -> IRQState:
+        with self._lock:
+            return self._state
+
+    @property
+    def active_count(self) -> int:
+        with self._lock:
+            return len(self._active_work)
+
+    @property
+    def pending_work(self) -> int:
+        with self._lock:
+            return len(self._works)
+
+    def register(self, owner: str) -> None:
+        with self._lock:
+            self._ensure_not_closed()
+            if not owner or owner in self._handlers:
+                raise IRQError("IRQ owner must be unique and non-empty")
+            if not self.line.shared and self._handlers:
+                raise IRQError("non-shared IRQ line accepts one owner")
+            self._handlers.add(owner)
+
+    def enable(self) -> None:
+        with self._lock:
+            self._ensure_not_closed()
+            if not self._handlers:
+                raise IRQNotShared("cannot enable an IRQ without an owner")
+            if self._state is IRQState.STOPPING:
+                raise IRQError("cannot enable an IRQ while stopping")
+            self._state = IRQState.ENABLED
+
+    def trigger(self, owner: str) -> IRQWork:
+        """Confirm an interrupt in the top-half and enqueue one bottom-half work item."""
+        with self._lock:
+            self._ensure_not_closed()
+            if self._state is not IRQState.ENABLED:
+                raise IRQError(f"IRQ is {self._state.value}")
+            if owner not in self._handlers:
+                raise IRQNotShared(f"IRQ owner is not registered: {owner}")
+            if len(self._works) >= self.work_capacity:
+                raise IRQError("IRQ bottom-half queue is full")
+            work = IRQWork(self._next_sequence, owner, self.line.number)
+            self._next_sequence += 1
+            self._works.append(work)
+            self._active_work.add(work.sequence)
+            return work
+
+    def complete_top_half(self, work: IRQWork) -> None:
+        with self._lock:
+            if work not in self._works or work.sequence not in self._active_work:
+                raise IRQError("IRQ top-half work is not active")
+            self._active_work.remove(work.sequence)
+            self._active_changed.notify_all()
+
+    def run_bottom_half(self, work: IRQWork) -> None:
+        with self._lock:
+            if work not in self._works:
+                raise IRQWorkCancelled("IRQ work is not pending")
+            if work.sequence in self._active_work:
+                raise IRQError("IRQ bottom-half cannot run before top-half completion")
+            self._works.remove(work)
+
+    def stop(self, *, timeout_s: float = 1.0) -> None:
+        with self._lock:
+            self._ensure_not_closed()
+            self._state = IRQState.STOPPING
+            deadline = monotonic() + timeout_s
+            while self._active_work:
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    raise IRQHandlerTimeout("active IRQ handler did not stop before deadline")
+                self._active_changed.wait(remaining)
+            self._works.clear()
+            self._state = IRQState.DISABLED
+
+    def cancel_work(self) -> int:
+        with self._lock:
+            cancellable = [work for work in self._works if work.sequence not in self._active_work]
+            count = len(cancellable)
+            self._works = [work for work in self._works if work.sequence in self._active_work]
+            return count
+
+    def close(self, *, timeout_s: float = 1.0) -> None:
+        with self._lock:
+            if self._state is IRQState.CLOSED:
+                return
+        self.stop(timeout_s=timeout_s)
+        with self._lock:
+            self._handlers.clear()
+            self._state = IRQState.CLOSED
+
+    def _ensure_not_closed(self) -> None:
+        if self._state is IRQState.CLOSED:
+            raise IRQError("IRQ provider is closed")

--- a/hardware/linux_drivers/irq/contract.py
+++ b/hardware/linux_drivers/irq/contract.py
@@ -68,6 +68,7 @@ class FakeIRQProvider:
         self._next_sequence = 0
         self._lock = threading.RLock()
         self._active_changed = threading.Condition(self._lock)
+        self._close_lock = threading.Lock()
 
     @property
     def state(self) -> IRQState:
@@ -120,6 +121,7 @@ class FakeIRQProvider:
 
     def complete_top_half(self, work: IRQWork) -> None:
         with self._lock:
+            self._ensure_not_closed()
             if work not in self._works or work.sequence not in self._active_work:
                 raise IRQError("IRQ top-half work is not active")
             self._active_work.remove(work.sequence)
@@ -127,6 +129,7 @@ class FakeIRQProvider:
 
     def run_bottom_half(self, work: IRQWork) -> None:
         with self._lock:
+            self._ensure_not_closed()
             if work not in self._works:
                 raise IRQWorkCancelled("IRQ work is not pending")
             if work.sequence in self._active_work:
@@ -148,19 +151,24 @@ class FakeIRQProvider:
 
     def cancel_work(self) -> int:
         with self._lock:
+            self._ensure_not_closed()
             cancellable = [work for work in self._works if work.sequence not in self._active_work]
             count = len(cancellable)
             self._works = [work for work in self._works if work.sequence in self._active_work]
             return count
 
     def close(self, *, timeout_s: float = 1.0) -> None:
-        with self._lock:
-            if self._state is IRQState.CLOSED:
-                return
-        self.stop(timeout_s=timeout_s)
-        with self._lock:
-            self._handlers.clear()
-            self._state = IRQState.CLOSED
+        # Serialize the check/stop/owner-clear sequence.  ``stop`` waits on a
+        # condition and therefore releases ``_lock``; a separate close lock
+        # prevents another close from interleaving during that wait.
+        with self._close_lock:
+            with self._lock:
+                if self._state is IRQState.CLOSED:
+                    return
+            self.stop(timeout_s=timeout_s)
+            with self._lock:
+                self._handlers.clear()
+                self._state = IRQState.CLOSED
 
     def _ensure_not_closed(self) -> None:
         if self._state is IRQState.CLOSED:

--- a/tests/unit/test_irq_contract.py
+++ b/tests/unit/test_irq_contract.py
@@ -1,0 +1,121 @@
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "hardware" / "linux_drivers"))
+
+from irq import FakeIRQProvider, IRQError, IRQHandlerTimeout, IRQLine, IRQNotShared, IRQState
+
+
+def test_irq_lifecycle_routes_top_half_and_bottom_half_work() -> None:
+    irq = FakeIRQProvider(IRQLine(42, shared=False, priority=20))
+    irq.register("uart0")
+    irq.enable()
+
+    work = irq.trigger("uart0")
+    assert work.owner == "uart0"
+    assert irq.active_count == 1
+    assert irq.pending_work == 1
+    irq.complete_top_half(work)
+    with pytest.raises(IRQError, match="not active"):
+        irq.complete_top_half(work)
+    irq.run_bottom_half(work)
+    assert irq.active_count == 0
+    assert irq.pending_work == 0
+    irq.stop()
+    assert irq.state is IRQState.DISABLED
+
+
+def test_shared_irq_requires_registered_owner_and_preserves_owner_identity() -> None:
+    irq = FakeIRQProvider(IRQLine(43, shared=True))
+    irq.register("spi0")
+    irq.register("gpio-exp")
+    irq.enable()
+
+    with pytest.raises(IRQNotShared):
+        irq.trigger("missing")
+    first = irq.trigger("spi0")
+    second = irq.trigger("gpio-exp")
+    assert (first.owner, second.owner) == ("spi0", "gpio-exp")
+    with pytest.raises(IRQError, match="before top-half"):
+        irq.run_bottom_half(first)
+    irq.complete_top_half(first)
+    irq.complete_top_half(second)
+    irq.run_bottom_half(first)
+    irq.run_bottom_half(second)
+
+
+def test_stop_cancels_pending_bottom_half_and_waits_for_active_handler() -> None:
+    irq = FakeIRQProvider(IRQLine(44))
+    irq.register("can0")
+    irq.enable()
+    work = irq.trigger("can0")
+    stop_result: list[Exception | None] = []
+
+    def stop() -> None:
+        try:
+            irq.stop(timeout_s=1.0)
+        except IRQError as exc:  # pragma: no cover - assertion captures this path
+            stop_result.append(exc)
+
+    thread = threading.Thread(target=stop)
+    thread.start()
+    deadline = time.monotonic() + 1.0
+    while irq.state is not IRQState.STOPPING and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert irq.state is IRQState.STOPPING
+    assert thread.is_alive()
+    irq.complete_top_half(work)
+    thread.join(1.0)
+    assert not thread.is_alive()
+    assert not stop_result
+    assert irq.pending_work == 0
+    with pytest.raises(IRQError):
+        irq.run_bottom_half(work)
+
+
+def test_stop_timeout_is_an_error_and_does_not_claim_cleanup() -> None:
+    irq = FakeIRQProvider(IRQLine(45))
+    irq.register("gpio")
+    irq.enable()
+    work = irq.trigger("gpio")
+
+    with pytest.raises(IRQHandlerTimeout):
+        irq.stop(timeout_s=0.0)
+    assert irq.state is IRQState.STOPPING
+    irq.complete_top_half(work)
+    irq.stop(timeout_s=1.0)
+
+
+def test_work_queue_backpressure_and_closed_lifecycle_fail_closed() -> None:
+    irq = FakeIRQProvider(IRQLine(46), work_capacity=1)
+    irq.register("spi")
+    irq.enable()
+    work = irq.trigger("spi")
+    with pytest.raises(IRQError, match="queue is full"):
+        irq.trigger("spi")
+    irq.complete_top_half(work)
+    irq.cancel_work()
+    irq.close()
+    assert irq.state is IRQState.CLOSED
+    with pytest.raises(IRQError, match="closed"):
+        irq.enable()
+
+
+def test_cancel_work_preserves_active_top_half_until_completion() -> None:
+    irq = FakeIRQProvider(IRQLine(47))
+    irq.register("uart")
+    irq.enable()
+    work = irq.trigger("uart")
+
+    assert irq.cancel_work() == 0
+    assert irq.active_count == 1
+    assert irq.pending_work == 1
+    irq.complete_top_half(work)
+    assert irq.cancel_work() == 1
+    assert irq.active_count == 0
+    assert irq.pending_work == 0

--- a/tests/unit/test_irq_contract.py
+++ b/tests/unit/test_irq_contract.py
@@ -106,6 +106,49 @@ def test_work_queue_backpressure_and_closed_lifecycle_fail_closed() -> None:
         irq.enable()
 
 
+def test_closed_provider_rejects_all_work_lifecycle_operations() -> None:
+    irq = FakeIRQProvider(IRQLine(48))
+    irq.register("uart")
+    irq.enable()
+    work = irq.trigger("uart")
+    irq.complete_top_half(work)
+    irq.close()
+
+    with pytest.raises(IRQError, match="closed"):
+        irq.complete_top_half(work)
+    with pytest.raises(IRQError, match="closed"):
+        irq.run_bottom_half(work)
+    with pytest.raises(IRQError, match="closed"):
+        irq.cancel_work()
+
+
+def test_concurrent_close_calls_are_serialized() -> None:
+    irq = FakeIRQProvider(IRQLine(49))
+    irq.register("gpio")
+    irq.enable()
+    errors: list[Exception] = []
+    barrier = threading.Barrier(2)
+
+    def close() -> None:
+        try:
+            barrier.wait(timeout=1.0)
+            irq.close()
+        except (IRQError, threading.BrokenBarrierError) as exc:  # pragma: no cover - assertion captures this path
+            errors.append(exc)
+
+    first = threading.Thread(target=close)
+    second = threading.Thread(target=close)
+    first.start()
+    second.start()
+    first.join(1.0)
+    second.join(1.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert not errors
+    assert irq.state is IRQState.CLOSED
+
+
 def test_cancel_work_preserves_active_top_half_until_completion() -> None:
     irq = FakeIRQProvider(IRQLine(47))
     irq.register("uart")


### PR DESCRIPTION
## Summary

Add the LINUX6 software-level IRQ lifecycle and cancellation contract.

## Changes

- Add a bounded fake IRQ provider.
- Validate shared and non-shared IRQ owner registration.
- Model explicit disabled, enabled, stopping and closed states.
- Separate top-half acknowledgement from bottom-half work.
- Add bounded bottom-half work capacity and queue backpressure.
- Require bottom-half execution to follow top-half completion.
- Make stop wait for active handlers and flush pending work.
- Fail closed when active handlers exceed the stop deadline.
- Preserve active work during cancellation until its top-half is completed.
- Reject duplicate completion, unknown owners and closed-provider access.
- Add focused tests for shared routing, lifecycle, cancellation, timeout, backpressure and shutdown.
- Add `make irq-test`.
- Add LINUX6 Task Packet and architecture documentation.

## Hardware Boundary

This PR is software-only. It does not implement or claim:

- Physical IRQ numbers or device registers
- Device-tree IRQ resources
- Threaded IRQ or NAPI binding
- PREEMPT_RT behavior
- Real shared-interrupt electrical behavior
- IRQ jitter below 100 microseconds

Target hardware IRQ and real-time evidence remain NOT_EXECUTED.

## Validation

- 6 IRQ contract tests passed
- 7 release workflow regression tests passed
- Ruff check passed
- Ruff format check passed
- Python syntax check passed
- Task Packet JSON syntax passed
- context-check passed
- git diff --check passed

## Related Issue

## What changed

## Interfaces affected

## Tests and commands

## Evidence

## Risks and rollback

## Checklist

- [ ] I changed only approved paths.
- [ ] Tests and contract checks pass.
- [ ] I covered normal and failure behavior.
- [ ] I updated examples/docs when an interface changed.
- [ ] I did not add secrets, private data or unreviewed assets.
