### PR TITLE
fix(ci): run dashboard health probes inside container

### DIFF
--- a/.github/workflows/container-full-stack.yml
+++ b/.github/workflows/container-full-stack.yml
@@ -74,8 +74,8 @@ jobs:
           docker compose up -d --no-build dashboard
           trap 'docker compose down' EXIT
           for attempt in $(seq 1 30); do
-            if curl --fail --silent http://127.0.0.1:8080/healthz \
-              && curl --fail --silent http://127.0.0.1:8080/readyz; then
+            if docker compose exec -T dashboard curl --fail --silent http://127.0.0.1:8080/healthz \
+              && docker compose exec -T dashboard curl --fail --silent http://127.0.0.1:8080/readyz; then
               exit 0
             fi
             sleep 1

--- a/docs/task_packets/ci-dashboard-health-check.json
+++ b/docs/task_packets/ci-dashboard-health-check.json
@@ -1,0 +1,55 @@
+{
+  "issue": "ci-dashboard-health-check",
+  "human_owner": "TH3478",
+  "objective": "Make the full-stack container workflow validate dashboard health and readiness without crossing the dashboard local-trust boundary through Docker port forwarding.",
+  "allowed_paths": [
+    ".github/workflows/container-full-stack.yml",
+    "tests/unit/test_container_profiles.py",
+    "docs/task_packets/ci-dashboard-health-check.json"
+  ],
+  "read_only_paths": [
+    "AGENTS.md",
+    "compose.yaml",
+    "services/backend/**",
+    "tools/scripts/check_task_packet.py",
+    "tools/schemas/task-packet-v1.schema.json"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "firmware/**",
+    "robot/control/**",
+    "services/backend/**",
+    "docker/**"
+  ],
+  "acceptance": [
+    "The dashboard health and readiness probes execute through docker compose exec inside the dashboard container.",
+    "The dashboard remains in local trust mode and no Docker bridge range is added to the trusted proxy allow-list.",
+    "The regression test fails if the workflow falls back to a host-side health probe.",
+    "The workflow YAML remains parseable and the existing container static checks continue to pass.",
+    "The changed paths are authorized by this Task Packet and no runtime, Compose security, interface, firmware, or robot-control code changes are introduced."
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py --all --base origin/main --head HEAD",
+    "python3 -m pytest tests/unit/test_container_baseline.py tests/unit/test_container_profiles.py -v",
+    "python3 -m ruff check tests/unit/test_container_baseline.py tests/unit/test_container_profiles.py docker/*.py",
+    "docker compose config --quiet",
+    "git diff --check"
+  ],
+  "evidence": [
+    "Task Packet changed-path validation output",
+    "Container baseline and workflow regression test output",
+    "Ruff and Compose configuration output",
+    "Diff whitespace validation output"
+  ],
+  "stop_conditions": [
+    "The fix requires changing the backend inbound trust policy or Compose security settings.",
+    "A workflow other than container-full-stack.yml or a runtime source file must change.",
+    "The Docker bridge address can only be handled by broadening the trusted proxy allow-list.",
+    "A required check cannot be reproduced or remains attributable to an unrelated main-branch failure."
+  ],
+  "max_iterations": 3,
+  "risks_and_fallbacks": [
+    "The container-side probe validates the service health and readiness endpoints from their intended local trust context; host port publication remains represented by the unchanged Compose configuration.",
+    "Native Docker daemon behavior is ultimately validated by the hosted static-and-cpu-image job."
+  ]
+}

--- a/tests/unit/test_container_profiles.py
+++ b/tests/unit/test_container_profiles.py
@@ -395,8 +395,9 @@ def test_ci_bare_image_smoke_uses_copied_source_workdir() -> None:
     assert "--read-only --tmpfs /tmp:size=512m,mode=1777" in workflow
     assert "--workdir /opt/workbench_source workbench-1:container-ci" in workflow
     assert "docker compose up -d --no-build dashboard" in workflow
-    assert "http://127.0.0.1:8080/healthz" in workflow
-    assert "http://127.0.0.1:8080/readyz" in workflow
+    assert "docker compose exec -T dashboard curl --fail --silent http://127.0.0.1:8080/healthz" in workflow
+    assert "docker compose exec -T dashboard curl --fail --silent http://127.0.0.1:8080/readyz" in workflow
+    assert "\n            if curl --fail --silent http://127.0.0.1:8080/healthz" not in workflow
 
 
 def test_ci_and_release_bare_image_smokes_use_copied_source_workdir() -> None:


### PR DESCRIPTION
## Summary

- Run the dashboard health and readiness probes from inside the dashboard container.
- Keep the dashboard in `local` trust mode instead of trusting the Docker bridge network.
- Add a regression assertion that prevents the workflow from falling back to host-side probes.
- Add a focused Task Packet so the repository boundary check authorizes this standalone CI fix.

## Root cause

The `container-full-stack` workflow published the dashboard on `127.0.0.1:8080` and then probed it from the GitHub Actions host. Docker port forwarding presents that request to the backend as the bridge gateway (for example, `172.18.0.1`), so the backend correctly rejected it with `403 untrusted_client` under the default `local` trust policy.

The workflow now probes `127.0.0.1:8080` through `docker compose exec`, matching the dashboard's existing container health-check path without weakening the inbound HTTP trust boundary.

## Validation

- `python3 -m pytest tests/unit/test_container_baseline.py tests/unit/test_container_profiles.py -q` — 34 passed
- `docker compose config --quiet` — passed
- Workflow YAML parsing — passed
- `git diff --check` — passed

The local environment does not provide Ruff or actionlint; the corresponding GitHub checks will validate them remotely.

Hosted validation on commit `56e6f58` passed all 10 reported checks. The `static-and-cpu-image` job completed the image build, CPU smoke, in-container dashboard health/readiness probes, container contract checks, SBOM generation, and vulnerability scan successfully.

## Scope

This PR changes only the container CI workflow, its regression test, and the focused Task Packet authorizing those paths. It does not change the backend trust policy, Compose security settings, application behavior, or the Issue #168 implementation.

Related to #340.
