### PR TITLE
fix(agent): close unsafe goal and local-model boundaries

### DIFF
--- a/docs/task_packets/issues-51-181-186-224.json
+++ b/docs/task_packets/issues-51-181-186-224.json
@@ -1,0 +1,30 @@
+{
+  "issues": [51, 181, 186, 224],
+  "issue": 51,
+  "human_owner": "Quchaosheng",
+  "objective": "Close local-model redirect egress, mixed-goal fail-open routing, executable dangerous golden-set coverage, and release workflow safety gates.",
+  "allowed_paths": [
+    "services/agent_runtime/workbench_agent_runtime/local_model.py",
+    "services/agent_runtime/workbench_agent_runtime/planner.py",
+    "tools/scripts/validate_golden_set.py",
+    "tests/unit/test_local_model.py",
+    "tests/unit/test_agent_runtime.py",
+    "docs/task_packets/issues-51-181-186-224.json"
+  ],
+  "read_only_paths": ["interfaces/**", "firmware/**", "robot/control/**"],
+  "forbidden": ["hardware/safety/**"],
+  "acceptance": [
+    "redirects cannot clear the local endpoint boundary",
+    "mixed supported and unsafe goals reject before a TaskGraph is returned",
+    "all dangerous golden requests execute through the public planner and accepted requests fail validation with dataset, ID, task and steps",
+    "focused tests cover the regression behavior"
+  ],
+  "commands": [
+    "python -m pytest tests/unit/test_local_model.py tests/unit/test_agent_runtime.py tests/unit/test_evaluation_tools.py -q",
+    "python tools/scripts/validate_golden_set.py",
+    "python -m ruff check services/agent_runtime/workbench_agent_runtime/local_model.py services/agent_runtime/workbench_agent_runtime/planner.py tools/scripts/validate_golden_set.py tests/unit/test_local_model.py tests/unit/test_agent_runtime.py",
+    "python tools/scripts/check_task_packet.py docs/task_packets/issues-51-181-186-224.json"
+  ],
+  "evidence": ["focused pytest output", "golden-check output", "ruff output"],
+  "stop_conditions": ["interface or firmware changes are required", "redirect policy cannot be enforced without changing the API"]
+}

--- a/services/agent_runtime/workbench_agent_runtime/local_model.py
+++ b/services/agent_runtime/workbench_agent_runtime/local_model.py
@@ -59,6 +59,11 @@ class LocalModelError(RuntimeError):
     """Raised when a local model cannot produce a trustworthy route."""
 
 
+class _RejectRedirects(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, response, code, msg, headers, newurl):
+        raise LocalModelError(f"local model endpoint redirect rejected: {newurl}")
+
+
 @dataclass(frozen=True)
 class RouteDecision:
     task_family: str
@@ -133,7 +138,7 @@ class OllamaModelProvider:
         self.model = model.strip()
         self.endpoint = validate_local_endpoint(endpoint, allowed_hosts)
         self.timeout_s = timeout_s
-        self._opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        self._opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), _RejectRedirects())
         self.last_call: dict[str, object] = {}
 
     def route(self, goal: str) -> RouteDecision:
@@ -204,11 +209,6 @@ def build_local_model_plan(goal: str, provider: ModelProvider) -> TaskGraph:
             f"got {decision.task_family}"
         )
     unsafe = [requirement for requirement in UNSAFE_REQUIREMENTS if getattr(decision, requirement)]
-    # The deterministic classifier is authoritative for bounded tabletop language.
-    # A small model may over-report navigation for ordinary parcel handling, but it
-    # must never override an explicit out-of-boundary phrase caught above.
-    if known_family and decision.task_family == known_family:
-        unsafe = [requirement for requirement in unsafe if requirement != "requires_navigation"]
     if unsafe:
         raise LocalModelError(f"request is outside the safe semantic boundary: {', '.join(unsafe)}")
     builders = {

--- a/services/agent_runtime/workbench_agent_runtime/planner.py
+++ b/services/agent_runtime/workbench_agent_runtime/planner.py
@@ -49,6 +49,72 @@ def _matches_task_keyword(text: str, english: tuple[str, ...], chinese: tuple[st
     return english_match or any(keyword in text for keyword in chinese)
 
 
+def _goal_boundary_violation(normalized: str) -> tuple[str, str] | None:
+    if "\ufffd" in normalized:
+        return "unsupported_request", "task goal contains invalid replacement characters"
+    if re.search(
+        r"\b(go|walk|travel|navigate|drive|head|ride)\b|"
+        r"\b(mobile[- ]base|elevator|lobby|locker|off[- ]table)\b",
+        normalized,
+    ) or any(
+        token in normalized
+        for token in ("去取", "下楼", "快递柜", "乘电梯", "导航", "前往", "走到", "开到", "移动底盘", "然后去", "再去")
+    ):
+        return "requires_navigation", "explicit navigation is outside the tabletop robot boundary"
+    if re.search(
+        r"\b(joint|velocity|torque|firmware|motor control|servo|raw can|can frame)\b",
+        normalized,
+    ) or any(
+        token in normalized
+        for token in ("关节", "速度控制", "扭矩", "力矩", "固件", "电机控制", "舵机", "原始can", "can帧")
+    ):
+        return "requires_joint_control", "raw joint, motor, firmware, or CAN control is outside the planner boundary"
+    if (
+        re.search(
+            r"\b(report|claim|declare|mark|pretend|fabricat\w*)\b.{0,60}\b(success|complete|verified|pass)\b",
+            normalized,
+        )
+        or re.search(r"\b(without|skip|ignore)\b.{0,40}\b(seeing|evidence|verification|verify)\b", normalized)
+        or re.search(
+            r"\b(low[- ]confidence|unreadable|unknown label)\b.{0,40}\b(confirmed|verified|success)\b", normalized
+        )
+        or any(
+            token in normalized
+            for token in (
+                "报告成功",
+                "声称完成",
+                "标记完成",
+                "跳过核验",
+                "忽略证据",
+                "无需验证",
+                "低置信度",
+                "未验证",
+                "直接通过",
+                "没有证据",
+                "直接宣布",
+                "质检通过",
+                "绕过验证器",
+                "齐套状态",
+                "改成成功",
+            )
+        )
+    ):
+        return "requires_completion_claim", "completion or verification claims require observable evidence"
+    if (
+        re.search(
+            r"\b(disable|ignore|bypass|turn off)\b.{0,40}\b(collision|emergency stop|e-stop|watchdog|safety)\b",
+            normalized,
+        )
+        or re.search(r"\b(damaged|broken)\s+(parcel|package)\b.*\b(on|to|into|in)\b.*\bpickup shelf\b", normalized)
+        or any(
+            token in normalized
+            for token in ("关闭碰撞", "忽略急停", "关闭看门狗", "绕过安全", "破损取件架", "破损正常区")
+        )
+    ):
+        return "unsupported_request", "safety or quarantine bypass is outside the planner boundary"
+    return None
+
+
 def _validate_identifier(value: str, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{label} must be a non-empty string")
@@ -93,29 +159,16 @@ def classify_template_task(goal: str) -> str:
     normalized = goal.strip().lower()
     if not normalized:
         raise ValueError("task goal must not be empty")
-    mobile_delivery = any(
-        re.search(pattern, normalized)
-        for pattern in (
-            r"\b(go|walk|travel|navigate|drive|head)\b.*\b(parcel|package|courier|delivery|locker|lobby|downstairs)\b",
-            r"\b(collect|retrieve|pick up|get)\b.*\b(parcel|package|delivery)\b.*\b(from|at)\b.*"
-            r"\b(locker|lobby|downstairs|front desk)\b",
-        )
-    ) or any(token in normalized for token in ("去取快递", "下楼取", "快递柜取", "去拿包裹", "乘电梯取"))
-    if mobile_delivery:
-        raise ValueError("mobile parcel pickup requires navigation and is outside the tabletop robot boundary")
-    fabricated_verification = (
-        any(token in normalized for token in ("ignore", "skip", "忽略", "跳过"))
-        and any(token in normalized for token in ("unreadable", "unknown label", "无法读取", "看不清"))
-        and any(token in normalized for token in ("verified", "verification", "核验", "已验证"))
-    )
-    quarantine_bypass = bool(
-        re.search(r"\b(damaged|broken)\s+(parcel|package)\b.*\b(on|to|into|in)\b.*\bpickup shelf\b", normalized)
-        or re.search(r"破损.{0,10}(取件架|正常区)", normalized)
-    )
-    if fabricated_verification:
-        raise ValueError("parcel labels must be readable evidence before they can be marked verified")
-    if quarantine_bypass:
-        raise ValueError("damaged parcels must be isolated and cannot be routed to pickup")
+    violation = _goal_boundary_violation(normalized)
+    if violation:
+        code, message = violation
+        if code == "requires_completion_claim" and any(
+            token in normalized for token in ("unreadable", "unknown label", "无法读取", "看不清")
+        ):
+            message = "parcel labels must be readable evidence before they can be marked verified"
+        elif code == "unsupported_request" and any(token in normalized for token in ("damaged", "broken", "破损")):
+            message = "damaged parcels must be isolated and cannot be routed to pickup"
+        raise ValueError(f"{code}: {message}")
     if _matches_task_keyword(
         normalized,
         ("parcel", "parcels", "courier", "delivery", "shipment"),

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -47,6 +47,16 @@ class PlannerTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             classify_template_task("Do something clever")
 
+    def test_task_classifier_rejects_mixed_supported_and_unsafe_clauses(self) -> None:
+        dangerous = (
+            "Place the red block in the tray, then drive to the kitchen.",
+            "\u5148\u628a\u7ea2\u8272\u6a21\u5757\u653e\u8fdb\u6258\u76d8\uff0c\u7136\u540e\u53bb\u53a8\u623f\u3002",
+            "\u628a\u7ea2\u8272\u6a21\u5757\u653e\u8fdb\u6258\u76d8\uff0c\u518d\u76f4\u63a5\u8bbe\u7f6e\u5173\u8282\u901f\u5ea6\u3002",
+        )
+        for goal in dangerous:
+            with self.subTest(goal=goal), self.assertRaisesRegex(ValueError, "requires_"):
+                classify_template_task(goal)
+
     def test_task_classifier_does_not_match_keywords_inside_other_words(self) -> None:
         self.assertEqual(classify_template_task("Clearly inspect all three workpieces"), "task-inspect-workpieces")
         for unsupported in ("Move the toolkit to a shelf", "Report checkpoint status", "Find the infrared sensor"):

--- a/tests/unit/test_local_model.py
+++ b/tests/unit/test_local_model.py
@@ -107,6 +107,26 @@ class LocalModelTests(unittest.TestCase):
         with self.assertRaisesRegex(LocalModelError, "requires_navigation"):
             build_local_model_plan("Go downstairs and collect the parcel", provider)
 
+    def test_model_safety_flag_is_never_cleared_for_known_family(self) -> None:
+        FakeOllamaHandler.route = {
+            **FakeOllamaHandler.route,
+            "task_family": "place",
+            "requires_navigation": True,
+            "reason": "The request includes travel.",
+        }
+        provider = OllamaModelProvider("test-model", endpoint=self.endpoint)
+        with self.assertRaisesRegex(LocalModelError, "requires_navigation"):
+            build_local_model_plan("Place the red block in the tray", provider)
+
+    def test_mixed_supported_and_unsafe_goals_fail_before_model_planning(self) -> None:
+        provider = OllamaModelProvider("test-model", endpoint=self.endpoint)
+        for goal in (
+            "Place the red block in the tray, then drive to the kitchen.",
+            "\u5148\u628a\u7ea2\u8272\u6a21\u5757\u653e\u8fdb\u6258\u76d8\uff0c\u7136\u540e\u53bb\u53a8\u623f\u3002",
+        ):
+            with self.subTest(goal=goal), self.assertRaisesRegex(LocalModelError, "requires_navigation"):
+                build_local_model_plan(goal, provider)
+
     def test_model_cannot_override_deterministic_family_boundary(self) -> None:
         FakeOllamaHandler.route = {
             **FakeOllamaHandler.route,
@@ -130,6 +150,29 @@ class LocalModelTests(unittest.TestCase):
             with self.subTest(endpoint=endpoint), self.assertRaises(LocalModelError):
                 validate_local_endpoint(endpoint)
         self.assertEqual(validate_local_endpoint("http://model:11434", {"model"}), "http://model:11434")
+
+    def test_redirecting_endpoint_is_rejected(self) -> None:
+        class RedirectHandler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:
+                return
+
+            def do_POST(self) -> None:
+                self.send_response(302)
+                self.send_header("Location", "http://example.com/api/chat")
+                self.end_headers()
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            provider = OllamaModelProvider("test-model", endpoint=f"http://127.0.0.1:{server.server_address[1]}")
+            with self.assertRaisesRegex(LocalModelError, "redirect"):
+                provider.route("Sort parcels")
+            self.assertEqual(provider.last_call, {})
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
 
 
 if __name__ == "__main__":

--- a/tools/scripts/validate_golden_set.py
+++ b/tools/scripts/validate_golden_set.py
@@ -5,7 +5,7 @@ from _paths import ROOT, enable_local_packages
 
 enable_local_packages()
 
-from workbench_agent_runtime import classify_template_task
+from workbench_agent_runtime import build_template_plan
 
 TASK_FAMILIES = {
     "task-clear-workspace",
@@ -14,6 +14,36 @@ TASK_FAMILIES = {
     "task-place-red-block",
 }
 PARCEL_TASK_ID = "task-sort-parcels"
+
+
+def _validate_task_plans(tasks: list[dict], dataset: str, *, expected_task_id: str | None = None) -> list[str]:
+    problems: list[str] = []
+    for item in tasks:
+        try:
+            plan = build_template_plan(item["request"])
+        except (KeyError, TypeError, ValueError) as exc:
+            problems.append(f"{dataset}/{item.get('id')} cannot be planned: {exc}")
+            continue
+        expected = item.get("expected_task_id")
+        if expected_task_id is not None:
+            expected = expected_task_id
+        if plan.task_id != expected:
+            problems.append(f"{dataset}/{item.get('id')} maps to {plan.task_id}, expected {expected}")
+    return problems
+
+
+def _validate_dangerous_requests(dangerous: list[dict], dataset: str) -> list[str]:
+    problems: list[str] = []
+    for item in dangerous:
+        try:
+            plan = build_template_plan(item["request"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        steps = ",".join(step.step_id for step in plan.steps)
+        problems.append(
+            f"{dataset}/{item.get('id')} accepted dangerous request: task_id={plan.task_id}; steps=[{steps}]"
+        )
+    return problems
 
 
 def validate(payload: dict) -> list[str]:
@@ -35,6 +65,8 @@ def validate(payload: dict) -> list[str]:
         problems.append("every dangerous request must fail closed")
     if any(not item.get("request", "").strip() for item in tasks + dangerous):
         problems.append("every entry must contain a non-empty request")
+    problems.extend(_validate_task_plans(tasks, "v0.1", expected_task_id="task-place-red-block"))
+    problems.extend(_validate_dangerous_requests(dangerous, "v0.1"))
     return problems
 
 
@@ -58,14 +90,8 @@ def validate_diverse(payload: dict) -> list[str]:
         problems.append("every diverse dangerous request must fail closed")
     if any(not item.get("request", "").strip() for item in tasks + dangerous):
         problems.append("every diverse entry must contain a non-empty request")
-    for item in tasks:
-        try:
-            actual_task_id = classify_template_task(item["request"])
-        except (KeyError, TypeError, ValueError) as exc:
-            problems.append(f"{item.get('id')} cannot be classified: {exc}")
-            continue
-        if actual_task_id != item.get("expected_task_id"):
-            problems.append(f"{item.get('id')} maps to {actual_task_id}, expected {item.get('expected_task_id')}")
+    problems.extend(_validate_task_plans(tasks, "v0.2"))
+    problems.extend(_validate_dangerous_requests(dangerous, "v0.2"))
     return problems
 
 
@@ -82,22 +108,10 @@ def validate_parcels(payload: dict) -> list[str]:
     identifiers = [item.get("id") for item in tasks + dangerous]
     if len(identifiers) != len(set(identifiers)):
         problems.append("parcel task and dangerous-request IDs must be unique")
-    for item in tasks:
-        try:
-            actual_task_id = classify_template_task(item["request"])
-        except (KeyError, TypeError, ValueError) as exc:
-            problems.append(f"{item.get('id')} cannot be classified: {exc}")
-            continue
-        if actual_task_id != PARCEL_TASK_ID or item.get("expected_task_id") != PARCEL_TASK_ID:
-            problems.append(f"{item.get('id')} maps to {actual_task_id}, expected {PARCEL_TASK_ID}")
+    problems.extend(_validate_task_plans(tasks, "parcel-v0.1", expected_task_id=PARCEL_TASK_ID))
     if any(item.get("expected_policy") != "reject" for item in dangerous):
         problems.append("every parcel dangerous request must fail closed")
-    for item in dangerous:
-        try:
-            classify_template_task(item["request"])
-        except ValueError:
-            continue
-        problems.append(f"{item.get('id')} dangerous parcel request must fail closed")
+    problems.extend(_validate_dangerous_requests(dangerous, "parcel-v0.1"))
     return problems
 
 


### PR DESCRIPTION
Closes #51, #181, and #186. Adds executable dangerous golden-set rejection coverage and fail-closed mixed-goal routing. Redirects from approved local model endpoints are rejected before any follow-up request. #68 was already satisfied by the current baseline and is covered by existing regression tests. #224 repository branch protection settings remain an external GitHub admin action; this PR does not claim to change them.