### PR TITLE
fix(linux): harden DMA buffer reuse and close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 
 .PHONY: bootstrap lint fmt test contract scenario-check golden-check evaluation-check evaluation-scripted context-check \
 	dashboard-test dashboard demo demo-scripted demo-offline demo-model model-provision performance-test benchmark-startup \
-	benchmark-resources performance-regression-test offline-integration uart-spi-test docs task-check check container-smoke \
+	benchmark-resources performance-regression-test offline-integration uart-spi-test dma-test docs task-check check container-smoke \
 	sim sim-doctor sim-list sim-run container-build container-check container-colcon-build container-colcon-test \
 	container-image-verify container-python-test container-sim-check container-mujoco-check container-hardware-doctor \
 	container-gpu-matrix-check container-host-doctor container-dashboard-check container-project-check
@@ -94,6 +94,9 @@ offline-integration:
 
 uart-spi-test:
 	$(PYTHON) -m pytest tests/unit/test_uart_spi_contract.py -v
+
+dma-test:
+	$(PYTHON) -m pytest tests/unit/test_dma_contract.py -v
 
 dashboard:
 	$(PYTHON) -m workbench_backend.server --host 127.0.0.1 --port 8080

--- a/docs/architecture/linux-drivers.md
+++ b/docs/architecture/linux-drivers.md
@@ -102,3 +102,7 @@ LINUX5/LINUX6 的实现必须在硬件资源确认后补充以下内容：
 LINUX3 的 UART/SPI 软件契约和 fake transport 测试位于仓库的
 `hardware/linux_drivers/uart_spi/`。该契约是 owner-gated 的提案：它固化边界、CRC、
 序号、背压和重试测试，但不冻结物理控制器、pinmux、设备树、DMA 或 IRQ 参数。
+
+LINUX5 的 DMA 软件契约和 fake provider 位于 `hardware/linux_drivers/dma/`。它固化
+预分配 buffer、CPU/DMA 所有权、固定描述符容量、取消和错误恢复测试，但不冻结真实
+DMA 控制器、cache 一致性、IRQ 资源或物理吞吐预算。

--- a/docs/task_packets/linux-dma-contract.json
+++ b/docs/task_packets/linux-dma-contract.json
@@ -1,0 +1,59 @@
+{
+  "issue": "LINUX5",
+  "human_owner": "Quchaosheng",
+  "objective": "Define and test a bounded software DMA ownership model with preallocated buffers, zero-copy descriptor submission, cancellation and fail-closed recovery without claiming physical throughput.",
+  "allowed_paths": [
+    "hardware/linux_drivers/dma/**",
+    "hardware/linux_drivers/README.md",
+    "tests/unit/test_dma_contract.py",
+    "Makefile",
+    "docs/architecture/linux-drivers.md",
+    "docs/task_packets/linux-dma-contract.json"
+  ],
+  "read_only_paths": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**",
+    "AGENTS.md"
+  ],
+  "forbidden": [
+    "interfaces/**",
+    "libs/contracts/**",
+    "firmware/**",
+    "robot/control/**",
+    "hardware/pcb/**"
+  ],
+  "acceptance": [
+    "preallocated buffers and descriptors have bounded capacities",
+    "CPU/DMA/FREE ownership transitions reject reads, writes and submissions in the wrong state",
+    "descriptor completion and cancellation return buffers to CPU ownership exactly once",
+    "DMA errors halt the engine and recovery is fail-closed until active work is cleared",
+    "queue saturation, foreign buffers, invalid lengths and closed-provider access are observable",
+    "the implementation is software-only and does not claim chained DMA, physical zero-copy or >50 MB/s evidence"
+  ],
+  "commands": [
+    "python3 tools/scripts/check_task_packet.py docs/task_packets/linux-dma-contract.json",
+    "python3 -m pytest tests/unit/test_dma_contract.py -v",
+    "make dma-test",
+    "make test",
+    "make contract",
+    "make scenario-check",
+    "make context-check",
+    "git diff --check"
+  ],
+  "evidence": [
+    "focused DMA ownership and lifecycle test output",
+    "descriptor saturation and backpressure assertions",
+    "error, cancellation, recovery and close assertions",
+    "repository gate output",
+    "physical DMA throughput and target-controller evidence marked NOT_EXECUTED"
+  ],
+  "stop_conditions": [
+    "a real DMA controller, channel, descriptor layout or cache policy is required",
+    "a physical throughput or latency threshold is requested without raw hardware samples",
+    "a frozen interface, firmware, robot-control or PCB change is required",
+    "software fake evidence would be presented as target-hardware DMA validation"
+  ]
+}

--- a/hardware/linux_drivers/README.md
+++ b/hardware/linux_drivers/README.md
@@ -4,6 +4,10 @@
 应用之间，向上只暴露 Linux 标准子系统接口，向下才绑定具体控制器、总线和
 板级资源。
 
+LINUX5 的 DMA 软件契约和 fake provider 位于
+[`dma/README.md`](dma/README.md)。它只验证 buffer/descriptor 所有权、背压、取消和
+错误恢复；真实 DMA 控制器、cache 策略和吞吐证据仍由硬件 Owner 确认。
+
 当前仓库已经有一个用于软件验证的 SocketCAN 内核模块：
 [`kernel/wbcan`](../../kernel/wbcan/)。它是带故障注入面的虚拟 CAN 设备，服务
 于固件和恢复路径测试，不代表已经完成某一款物理 CAN 控制器的量产驱动。

--- a/hardware/linux_drivers/dma/README.md
+++ b/hardware/linux_drivers/dma/README.md
@@ -1,0 +1,33 @@
+# DMA 软件契约
+
+这是 LINUX5 的软件验证边界。`FakeDMAProvider` 模拟 Linux DMA 驱动必须遵守的
+缓冲区所有权和描述符生命周期，但不绑定真实 DMA 控制器、通道、寄存器、cache
+属性或设备树资源。
+
+## 所有权和生命周期
+
+```text
+allocate -> CPU-owned -> submit -> DMA-owned -> complete/cancel -> CPU-owned -> recycle -> FREE
+```
+
+- 缓冲区预分配且容量有界；写入只能发生在 CPU-owned 状态。
+- `submit` 不复制 payload，描述符直接引用预分配 buffer，模拟零拷贝提交。
+- DMA-owned buffer 不允许 CPU 读写；完成或取消后才归还 CPU。
+- 描述符环固定容量；满时显式返回 backpressure，不静默覆盖在途工作。
+- `DMAStatus.ERROR` 会停止引擎；必须清理在途描述符后才能 `recover`。
+- 关闭会取消在途描述符、清空可见队列并拒绝后续访问。
+
+## 硬件接入前置条件
+
+真实驱动还需要硬件负责人确认 DMA 控制器、通道、descriptor layout、cache 一致性、
+中断完成信号、最大批量、错误恢复和设备树资源。当前模型不能证明链式 DMA、物理
+零拷贝、`>50 MB/s` 吞吐或目标板稳定性；这些证据保持 `NOT_EXECUTED`。
+
+## 测试
+
+```bash
+make dma-test
+```
+
+测试覆盖所有权转移、固定描述符容量、完成/取消、错误停机、恢复、关闭和外部 buffer
+拒绝。

--- a/hardware/linux_drivers/dma/README.md
+++ b/hardware/linux_drivers/dma/README.md
@@ -11,11 +11,13 @@ allocate -> CPU-owned -> submit -> DMA-owned -> complete/cancel -> CPU-owned -> 
 ```
 
 - 缓冲区预分配且容量有界；写入只能发生在 CPU-owned 状态。
+- `recycle` 后的 `FREE` buffer 会优先被 `allocate` 复用，不因历史分配数量达到上限而错误背压。
+- `DMABuffer.owner` 仅提供只读观察；所有权转换只能由 provider 在完成、取消和回收路径中执行。
 - `submit` 不复制 payload，描述符直接引用预分配 buffer，模拟零拷贝提交。
 - DMA-owned buffer 不允许 CPU 读写；完成或取消后才归还 CPU。
 - 描述符环固定容量；满时显式返回 backpressure，不静默覆盖在途工作。
 - `DMAStatus.ERROR` 会停止引擎；必须清理在途描述符后才能 `recover`。
-- 关闭会取消在途描述符、清空可见队列并拒绝后续访问。
+- 关闭会取消在途描述符、清空 completion 队列并拒绝后续访问。
 
 ## 硬件接入前置条件
 

--- a/hardware/linux_drivers/dma/__init__.py
+++ b/hardware/linux_drivers/dma/__init__.py
@@ -1,0 +1,31 @@
+"""Software-only DMA ownership contract and deterministic fake engine."""
+
+from .contract import (
+    BufferOwner,
+    DMABackpressure,
+    DMABuffer,
+    DMACompletion,
+    DMADescriptor,
+    DMAError,
+    DMAOwnershipError,
+    DMAProviderClosed,
+    DMAState,
+    DMAStateError,
+    DMAStatus,
+    FakeDMAProvider,
+)
+
+__all__ = [
+    "BufferOwner",
+    "DMABackpressure",
+    "DMABuffer",
+    "DMACompletion",
+    "DMADescriptor",
+    "DMAError",
+    "DMAOwnershipError",
+    "DMAProviderClosed",
+    "DMAState",
+    "DMAStateError",
+    "DMAStatus",
+    "FakeDMAProvider",
+]

--- a/hardware/linux_drivers/dma/contract.py
+++ b/hardware/linux_drivers/dma/contract.py
@@ -1,0 +1,262 @@
+"""Bounded DMA model for software ownership and recovery tests.
+
+The fake engine models the invariants a physical Linux DMA driver must keep:
+preallocated buffers, zero-copy descriptor submission, explicit CPU/DMA
+ownership, bounded descriptor capacity, and fail-closed recovery. It does not
+model a controller register layout or claim physical throughput.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from enum import StrEnum
+
+MAX_BUFFER_BYTES = 1024 * 1024
+MAX_DESCRIPTORS = 1024
+
+
+class DMAError(ValueError):
+    """Base class for invalid DMA configuration or operations."""
+
+
+class DMAOwnershipError(DMAError):
+    """A buffer or descriptor is used by the wrong owner or lifecycle state."""
+
+
+class DMAStateError(DMAError):
+    """The engine state does not permit the requested operation."""
+
+
+class DMABackpressure(TimeoutError):
+    """The fixed descriptor pool is full."""
+
+
+class DMAProviderClosed(ConnectionError):
+    """The DMA engine has been closed."""
+
+
+class BufferOwner(StrEnum):
+    CPU = "cpu"
+    DMA = "dma"
+    FREE = "free"
+
+
+class DMAState(StrEnum):
+    READY = "ready"
+    HALTED = "halted"
+    CLOSED = "closed"
+
+
+class DMAStatus(StrEnum):
+    COMPLETE = "complete"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+@dataclass(slots=True)
+class DMABuffer:
+    """Preallocated storage whose access is constrained by ``owner``."""
+
+    buffer_id: int
+    capacity: int
+    _data: bytearray
+    owner: BufferOwner = BufferOwner.FREE
+
+
+@dataclass(frozen=True, slots=True)
+class DMADescriptor:
+    descriptor_id: int
+    buffer_id: int
+    length: int
+    status: DMAStatus | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DMACompletion:
+    descriptor_id: int
+    buffer_id: int
+    status: DMAStatus
+    bytes_transferred: int
+    error: str | None = None
+
+
+class FakeDMAProvider:
+    """Thread-safe bounded DMA engine with explicit ownership transitions."""
+
+    def __init__(self, *, buffer_capacity: int = 8, descriptor_capacity: int = 8) -> None:
+        if type(buffer_capacity) is not int or not 1 <= buffer_capacity <= MAX_DESCRIPTORS:
+            raise DMAError("buffer_capacity must be between 1 and 1024")
+        if type(descriptor_capacity) is not int or not 1 <= descriptor_capacity <= MAX_DESCRIPTORS:
+            raise DMAError("descriptor_capacity must be between 1 and 1024")
+        self._buffer_capacity = buffer_capacity
+        self._descriptor_capacity = descriptor_capacity
+        self._buffers: dict[int, DMABuffer] = {}
+        self._descriptors: dict[int, DMADescriptor] = {}
+        self._active: list[int] = []
+        self._completions: list[DMACompletion] = []
+        self._next_buffer_id = 1
+        self._next_descriptor_id = 1
+        self._state = DMAState.READY
+        self._lock = threading.RLock()
+
+    @property
+    def state(self) -> DMAState:
+        with self._lock:
+            return self._state
+
+    @property
+    def active_count(self) -> int:
+        with self._lock:
+            return len(self._active)
+
+    @property
+    def completion_count(self) -> int:
+        with self._lock:
+            return len(self._completions)
+
+    def allocate(self, capacity: int) -> DMABuffer:
+        with self._lock:
+            self._ensure_ready()
+            if type(capacity) is not int or not 1 <= capacity <= MAX_BUFFER_BYTES:
+                raise DMAError(f"buffer capacity must be between 1 and {MAX_BUFFER_BYTES}")
+            if len(self._buffers) >= self._buffer_capacity:
+                raise DMABackpressure("preallocated DMA buffer pool is full")
+            buffer = DMABuffer(self._next_buffer_id, capacity, bytearray(capacity), BufferOwner.CPU)
+            self._next_buffer_id += 1
+            self._buffers[buffer.buffer_id] = buffer
+            return buffer
+
+    def write(self, buffer: DMABuffer, data: bytes) -> None:
+        with self._lock:
+            self._ensure_ready()
+            owned = self._owned_buffer(buffer)
+            if owned.owner is not BufferOwner.CPU:
+                raise DMAOwnershipError("CPU may write only buffers owned by CPU")
+            if not isinstance(data, bytes) or len(data) > owned.capacity:
+                raise DMAError("data must be bytes no larger than the buffer capacity")
+            owned._data[: len(data)] = data
+
+    def read(self, buffer: DMABuffer, length: int | None = None) -> bytes:
+        with self._lock:
+            self._ensure_open()
+            owned = self._owned_buffer(buffer)
+            if owned.owner is not BufferOwner.CPU:
+                raise DMAOwnershipError("CPU may read only buffers owned by CPU")
+            size = owned.capacity if length is None else length
+            if type(size) is not int or not 0 <= size <= owned.capacity:
+                raise DMAError("read length is outside the buffer capacity")
+            return bytes(owned._data[:size])
+
+    def submit(self, buffer: DMABuffer, length: int) -> DMADescriptor:
+        with self._lock:
+            self._ensure_ready()
+            owned = self._owned_buffer(buffer)
+            if owned.owner is not BufferOwner.CPU:
+                raise DMAOwnershipError("buffer must be CPU-owned before submission")
+            if type(length) is not int or not 1 <= length <= owned.capacity:
+                raise DMAError("descriptor length must be within the buffer capacity")
+            if len(self._descriptors) >= self._descriptor_capacity:
+                raise DMABackpressure("DMA descriptor ring is full")
+            descriptor = DMADescriptor(self._next_descriptor_id, owned.buffer_id, length)
+            self._next_descriptor_id += 1
+            owned.owner = BufferOwner.DMA
+            self._descriptors[descriptor.descriptor_id] = descriptor
+            self._active.append(descriptor.descriptor_id)
+            return descriptor
+
+    def complete_next(self, *, status: DMAStatus = DMAStatus.COMPLETE, error: str | None = None) -> DMACompletion:
+        with self._lock:
+            self._ensure_open()
+            if not self._active:
+                raise DMAStateError("no active DMA descriptor")
+            if not isinstance(status, DMAStatus) or status is DMAStatus.CANCELLED:
+                raise DMAError("complete_next accepts COMPLETE or ERROR")
+            if status is DMAStatus.ERROR and (not isinstance(error, str) or not error):
+                raise DMAError("DMA error completion requires a non-empty error")
+            descriptor_id = self._active.pop(0)
+            descriptor = self._descriptors[descriptor_id]
+            buffer = self._buffers[descriptor.buffer_id]
+            buffer.owner = BufferOwner.CPU
+            completed = DMACompletion(
+                descriptor_id,
+                descriptor.buffer_id,
+                status,
+                descriptor.length if status is DMAStatus.COMPLETE else 0,
+                error,
+            )
+            self._descriptors[descriptor_id] = DMADescriptor(
+                descriptor.descriptor_id, descriptor.buffer_id, descriptor.length, status
+            )
+            self._completions.append(completed)
+            if status is DMAStatus.ERROR:
+                self._state = DMAState.HALTED
+            return completed
+
+    def cancel_pending(self) -> list[DMACompletion]:
+        with self._lock:
+            self._ensure_open()
+            cancelled: list[DMACompletion] = []
+            while self._active:
+                descriptor_id = self._active.pop(0)
+                descriptor = self._descriptors[descriptor_id]
+                self._buffers[descriptor.buffer_id].owner = BufferOwner.CPU
+                completion = DMACompletion(descriptor_id, descriptor.buffer_id, DMAStatus.CANCELLED, 0, "cancelled")
+                self._descriptors[descriptor_id] = DMADescriptor(
+                    descriptor.descriptor_id, descriptor.buffer_id, descriptor.length, DMAStatus.CANCELLED
+                )
+                self._completions.append(completion)
+                cancelled.append(completion)
+            return cancelled
+
+    def poll_completion(self) -> DMACompletion | None:
+        with self._lock:
+            self._ensure_open()
+            return self._completions.pop(0) if self._completions else None
+
+    def recycle(self, descriptor_id: int) -> DMABuffer:
+        with self._lock:
+            self._ensure_open()
+            try:
+                descriptor = self._descriptors[descriptor_id]
+            except KeyError as exc:
+                raise DMAError(f"unknown descriptor: {descriptor_id}") from exc
+            if descriptor.status is None:
+                raise DMAOwnershipError("descriptor is still owned by DMA")
+            buffer = self._buffers[descriptor.buffer_id]
+            if buffer.owner is not BufferOwner.CPU:
+                raise DMAOwnershipError("completed descriptor buffer is not CPU-owned")
+            buffer.owner = BufferOwner.FREE
+            del self._descriptors[descriptor_id]
+            return buffer
+
+    def recover(self) -> None:
+        with self._lock:
+            if self._state is DMAState.CLOSED:
+                raise DMAProviderClosed("DMA provider is closed")
+            if self._state is not DMAState.HALTED:
+                raise DMAStateError("DMA recovery is only valid after an error")
+            if self._active:
+                raise DMAStateError("cancel active descriptors before recovery")
+            self._state = DMAState.READY
+
+    def close(self) -> None:
+        with self._lock:
+            if self._state is DMAState.CLOSED:
+                return
+            self.cancel_pending()
+            self._state = DMAState.CLOSED
+
+    def _owned_buffer(self, buffer: DMABuffer) -> DMABuffer:
+        if not isinstance(buffer, DMABuffer) or self._buffers.get(buffer.buffer_id) is not buffer:
+            raise DMAOwnershipError("buffer does not belong to this DMA provider")
+        return buffer
+
+    def _ensure_open(self) -> None:
+        if self._state is DMAState.CLOSED:
+            raise DMAProviderClosed("DMA provider is closed")
+
+    def _ensure_ready(self) -> None:
+        self._ensure_open()
+        if self._state is not DMAState.READY:
+            raise DMAStateError(f"DMA provider is {self._state.value}")

--- a/hardware/linux_drivers/dma/contract.py
+++ b/hardware/linux_drivers/dma/contract.py
@@ -9,7 +9,7 @@ model a controller register layout or claim physical throughput.
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 
 MAX_BUFFER_BYTES = 1024 * 1024
@@ -61,7 +61,13 @@ class DMABuffer:
     buffer_id: int
     capacity: int
     _data: bytearray
-    owner: BufferOwner = BufferOwner.FREE
+    _owner: BufferOwner = field(default=BufferOwner.FREE, repr=False)
+
+    @property
+    def owner(self) -> BufferOwner:
+        """Read-only ownership view; transitions belong to the provider."""
+
+        return self._owner
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +126,19 @@ class FakeDMAProvider:
             self._ensure_ready()
             if type(capacity) is not int or not 1 <= capacity <= MAX_BUFFER_BYTES:
                 raise DMAError(f"buffer capacity must be between 1 and {MAX_BUFFER_BYTES}")
+            reusable = min(
+                (
+                    buffer
+                    for buffer in self._buffers.values()
+                    if buffer.owner is BufferOwner.FREE and buffer.capacity >= capacity
+                ),
+                key=lambda buffer: buffer.capacity,
+                default=None,
+            )
+            if reusable is not None:
+                reusable._owner = BufferOwner.CPU
+                reusable._data[:] = b"\x00" * reusable.capacity
+                return reusable
             if len(self._buffers) >= self._buffer_capacity:
                 raise DMABackpressure("preallocated DMA buffer pool is full")
             buffer = DMABuffer(self._next_buffer_id, capacity, bytearray(capacity), BufferOwner.CPU)
@@ -160,7 +179,7 @@ class FakeDMAProvider:
                 raise DMABackpressure("DMA descriptor ring is full")
             descriptor = DMADescriptor(self._next_descriptor_id, owned.buffer_id, length)
             self._next_descriptor_id += 1
-            owned.owner = BufferOwner.DMA
+            owned._owner = BufferOwner.DMA
             self._descriptors[descriptor.descriptor_id] = descriptor
             self._active.append(descriptor.descriptor_id)
             return descriptor
@@ -177,7 +196,7 @@ class FakeDMAProvider:
             descriptor_id = self._active.pop(0)
             descriptor = self._descriptors[descriptor_id]
             buffer = self._buffers[descriptor.buffer_id]
-            buffer.owner = BufferOwner.CPU
+            buffer._owner = BufferOwner.CPU
             completed = DMACompletion(
                 descriptor_id,
                 descriptor.buffer_id,
@@ -200,7 +219,7 @@ class FakeDMAProvider:
             while self._active:
                 descriptor_id = self._active.pop(0)
                 descriptor = self._descriptors[descriptor_id]
-                self._buffers[descriptor.buffer_id].owner = BufferOwner.CPU
+                self._buffers[descriptor.buffer_id]._owner = BufferOwner.CPU
                 completion = DMACompletion(descriptor_id, descriptor.buffer_id, DMAStatus.CANCELLED, 0, "cancelled")
                 self._descriptors[descriptor_id] = DMADescriptor(
                     descriptor.descriptor_id, descriptor.buffer_id, descriptor.length, DMAStatus.CANCELLED
@@ -226,7 +245,7 @@ class FakeDMAProvider:
             buffer = self._buffers[descriptor.buffer_id]
             if buffer.owner is not BufferOwner.CPU:
                 raise DMAOwnershipError("completed descriptor buffer is not CPU-owned")
-            buffer.owner = BufferOwner.FREE
+            buffer._owner = BufferOwner.FREE
             del self._descriptors[descriptor_id]
             return buffer
 
@@ -245,6 +264,7 @@ class FakeDMAProvider:
             if self._state is DMAState.CLOSED:
                 return
             self.cancel_pending()
+            self._completions.clear()
             self._state = DMAState.CLOSED
 
     def _owned_buffer(self, buffer: DMABuffer) -> DMABuffer:

--- a/tests/unit/test_dma_contract.py
+++ b/tests/unit/test_dma_contract.py
@@ -1,0 +1,134 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "hardware" / "linux_drivers"))
+
+from dma import (
+    BufferOwner,
+    DMABackpressure,
+    DMAError,
+    DMAOwnershipError,
+    DMAProviderClosed,
+    DMAState,
+    DMAStateError,
+    DMAStatus,
+    FakeDMAProvider,
+)
+
+
+def test_preallocated_buffer_is_cpu_owned_and_submit_transfers_ownership() -> None:
+    dma = FakeDMAProvider()
+    buffer = dma.allocate(64)
+    dma.write(buffer, b"hello")
+    descriptor = dma.submit(buffer, 5)
+
+    assert buffer.owner is BufferOwner.DMA
+    with pytest.raises(DMAOwnershipError, match="CPU may read"):
+        dma.read(buffer, 5)
+
+    completion = dma.complete_next()
+    assert completion.descriptor_id == descriptor.descriptor_id
+    assert completion.bytes_transferred == 5
+    assert buffer.owner is BufferOwner.CPU
+    assert dma.read(buffer, 5) == b"hello"
+    assert dma.recycle(descriptor.descriptor_id) is buffer
+    assert buffer.owner is BufferOwner.FREE
+
+
+def test_descriptor_ring_is_bounded_and_recycled() -> None:
+    dma = FakeDMAProvider(buffer_capacity=2, descriptor_capacity=1)
+    first = dma.allocate(8)
+    second = dma.allocate(8)
+    dma.write(first, b"one")
+    dma.write(second, b"two")
+    descriptor = dma.submit(first, 3)
+
+    with pytest.raises(DMABackpressure, match="descriptor ring"):
+        dma.submit(second, 3)
+    dma.complete_next()
+    dma.recycle(descriptor.descriptor_id)
+    dma.submit(second, 3)
+
+
+def test_cancel_returns_all_inflight_buffers_to_cpu_and_records_completions() -> None:
+    dma = FakeDMAProvider()
+    first = dma.allocate(8)
+    second = dma.allocate(8)
+    dma.write(first, b"one")
+    dma.write(second, b"two")
+    first_descriptor = dma.submit(first, 3)
+    second_descriptor = dma.submit(second, 3)
+
+    cancelled = dma.cancel_pending()
+
+    assert [item.descriptor_id for item in cancelled] == [
+        first_descriptor.descriptor_id,
+        second_descriptor.descriptor_id,
+    ]
+    assert all(item.status is DMAStatus.CANCELLED for item in cancelled)
+    assert first.owner is BufferOwner.CPU
+    assert second.owner is BufferOwner.CPU
+    assert dma.active_count == 0
+
+
+def test_error_halts_engine_and_recovery_requires_cancelled_active_work() -> None:
+    dma = FakeDMAProvider()
+    buffer = dma.allocate(8)
+    dma.write(buffer, b"fault")
+    descriptor = dma.submit(buffer, 5)
+
+    completion = dma.complete_next(status=DMAStatus.ERROR, error="bus fault")
+    assert completion.status is DMAStatus.ERROR
+    assert dma.state is DMAState.HALTED
+    with pytest.raises(DMAStateError, match="halted"):
+        dma.allocate(8)
+    dma.recover()
+    assert dma.state is DMAState.READY
+    dma.recycle(descriptor.descriptor_id)
+
+
+def test_recovery_rejects_remaining_active_descriptors() -> None:
+    dma = FakeDMAProvider()
+    first = dma.allocate(8)
+    second = dma.allocate(8)
+    dma.write(first, b"fault")
+    dma.write(second, b"active")
+    first_descriptor = dma.submit(first, 5)
+    dma.submit(second, 6)
+    dma.complete_next(status=DMAStatus.ERROR, error="bus fault")
+
+    with pytest.raises(DMAStateError, match="active descriptors"):
+        dma.recover()
+    dma.cancel_pending()
+    dma.recover()
+    dma.recycle(first_descriptor.descriptor_id)
+
+
+def test_recovery_rejects_active_descriptors_and_close_cancels_then_closes() -> None:
+    dma = FakeDMAProvider()
+    buffer = dma.allocate(8)
+    dma.write(buffer, b"active")
+    dma.submit(buffer, 6)
+    dma.complete_next(status=DMAStatus.ERROR, error="fault")
+    assert dma.state is DMAState.HALTED
+    dma.close()
+    assert dma.state is DMAState.CLOSED
+    with pytest.raises(DMAProviderClosed):
+        dma.read(buffer, 6)
+    with pytest.raises(DMAProviderClosed):
+        dma.recover()
+
+
+def test_invalid_buffers_lengths_and_external_ownership_fail_closed() -> None:
+    dma = FakeDMAProvider()
+    buffer = dma.allocate(8)
+    with pytest.raises(DMAError):
+        dma.write(buffer, b"too large" * 2)
+    with pytest.raises(DMAStateError, match="no active"):
+        dma.complete_next()
+    foreign = FakeDMAProvider().allocate(8)
+    with pytest.raises(DMAOwnershipError, match="does not belong"):
+        dma.submit(foreign, 1)

--- a/tests/unit/test_dma_contract.py
+++ b/tests/unit/test_dma_contract.py
@@ -36,6 +36,16 @@ def test_preallocated_buffer_is_cpu_owned_and_submit_transfers_ownership() -> No
     assert dma.read(buffer, 5) == b"hello"
     assert dma.recycle(descriptor.descriptor_id) is buffer
     assert buffer.owner is BufferOwner.FREE
+    reused = dma.allocate(32)
+    assert reused is buffer
+    assert reused.owner is BufferOwner.CPU
+
+
+def test_buffer_owner_is_read_only_to_callers() -> None:
+    dma = FakeDMAProvider()
+    buffer = dma.allocate(8)
+    with pytest.raises(AttributeError):
+        buffer.owner = BufferOwner.DMA  # type: ignore[misc]
 
 
 def test_descriptor_ring_is_bounded_and_recycled() -> None:
@@ -114,8 +124,10 @@ def test_recovery_rejects_active_descriptors_and_close_cancels_then_closes() -> 
     dma.submit(buffer, 6)
     dma.complete_next(status=DMAStatus.ERROR, error="fault")
     assert dma.state is DMAState.HALTED
+    assert dma.completion_count == 1
     dma.close()
     assert dma.state is DMAState.CLOSED
+    assert dma.completion_count == 0
     with pytest.raises(DMAProviderClosed):
         dma.read(buffer, 6)
     with pytest.raises(DMAProviderClosed):


### PR DESCRIPTION
## Summary
This PR hardens the DMA buffer management in three areas:

1. **Buffer reuse** – `recycle()` only marked `owner` as `FREE`, but `allocate()` still used `len(_buffers)` to decide capacity. As a result, recycled buffers were never reused, and once the buffer count hit the limit, further allocations would falsely return `DMABackpressure`.  
   *Fix:* `allocate()` now searches for a free buffer with sufficient capacity, resets its ownership to CPU, clears old data, and creates a new buffer only when no reusable buffer is available. A test for reuse after recycle is added.

2. **Ownership protection** – `buffer.owner` was directly writable by callers, bypassing the provider’s ownership checks and breaking the CPU/DMA ownership contract.  
   *Fix:* The internal field is renamed to `_owner` and exposed as a read‑only property. Ownership transitions are now strictly controlled by the provider. A test verifies that external writes raise `AttributeError`.

3. **Completion queue clearing on close** – `close()` cancelled in‑flight descriptors but left completed/cancelled records in `_completions`, so `completion_count` still returned stale values after close, contradicting the README.  
   *Fix:* `close()` now clears `_completions` after cancelling descriptors, ensuring `_completion_count == 0` after close while maintaining fail‑closed semantics.

## Motivation
These issues were discovered during integration testing. They caused unexpected backpressure, weakened ownership guarantees, and left stale completion data, which could mislead error recovery logic. The changes align the DMA driver with the contract specification and improve overall robustness.

## Testing
All modifications have been validated locally with the following checks (all passed):

- 8 DMA tests – **passed**
- Ruff linting – **passed**
- Formatting – **passed**
- Task Packet validation – **passed**
- `git diff --check` – **passed**

Commands executed:
```bash
make test
make contract
make scenario-check
# (DMA‑specific tests were also run)